### PR TITLE
[fix] Fix `prefix_stream` crashing on interpolations with newlines

### DIFF
--- a/apps/common/lib/lexical/ast/tokens.ex
+++ b/apps/common/lib/lexical/ast/tokens.ex
@@ -163,6 +163,10 @@ defmodule Lexical.Ast.Tokens do
     Enum.reverse(ranges)
   end
 
+  defp get_start_pos([{:eol, {start_line, start_column, _}} | _]) do
+    {start_line, start_column}
+  end
+
   defp get_start_pos([{_, {start_line, start_column, _}, _} | _]) do
     {start_line, start_column}
   end


### PR DESCRIPTION
Fixes #11 

Interpolations with newlines contain an `:eol` token in the shape of
`{:eol, positions}`, which `get_start_pos` wasn't considering, causing a
crash.

The solution I went for here is to just consider that token shape when
dealing with interpolation tokens. As far as I can see the tokens inside
the interpolation aren't being normalized, so I kept that behavior.

The test I added uses the `~S` sigil instead of the helper `~q` sigil. This
is due to the `~q` sigil escaping the interpolation in a way that didn't
reproduce the issue I saw in an Expert release.

The code in the new test is the snippet that caused the crashes while editing
Sourceror, so to reproduce this locally it's enough to paste that into a
project and try to trigger a completion like `Enum|`.
