### PR TITLE
ci: conventional commits

### DIFF
--- a/.github/workflows/lint-commit.yaml
+++ b/.github/workflows/lint-commit.yaml
@@ -1,0 +1,22 @@
+name: Lint Commit
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    name: commitlint
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: ^(?![A-Z]).+$
+


### PR DESCRIPTION
Since we are going to use release-please to manage our releases and
changelog, we need to start using conventional commits and the Squash
and Merge style of PR merging.

This workflow will lint the pull request title to ensure that it follows
conventional commits, since the title will be used as the commit subject
when squash and merging
