### PR TITLE
fix: fixup namespacing and packaging

### DIFF
--- a/apps/expert/lib/mix/tasks/package.ex
+++ b/apps/expert/lib/mix/tasks/package.ex
@@ -270,7 +270,7 @@ defmodule Mix.Tasks.Package do
     Namespace.Transform.Configs.apply_to_all(config_dest)
   end
 
-  @priv_apps [:engine]
+  @priv_apps [:expert]
 
   defp copy_priv_files(package_root) do
     priv_dest_dir = priv_path(package_root)

--- a/apps/forge/lib/forge/namespace/transform/configs.ex
+++ b/apps/forge/lib/forge/namespace/transform/configs.ex
@@ -1,7 +1,7 @@
 defmodule Forge.Namespace.Transform.Configs do
   def apply_to_all(base_directory) do
     base_directory
-    |> Path.join("**/releases/**/runtime.exs")
+    |> Path.join("**/runtime.exs")
     |> Path.wildcard()
     |> Enum.map(&Path.absname/1)
     |> tap(fn paths ->


### PR DESCRIPTION
When extracting the engine isolation changes from the burrito pr, I forgot to also extract a few changes to namespacing and packaging. I didn't purge the packaged code when testing it, so I never noticed that neither the configuration files nor the port wrapper file were actually being copied over. This PR fixes that.