### PR TITLE
fix: use dynamic registrations and start project node asynchronously

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -18,7 +18,6 @@ defmodule Expert do
     GenLSP.Notifications.TextDocumentDidOpen,
     GenLSP.Notifications.TextDocumentDidSave,
     GenLSP.Notifications.Exit,
-    GenLSP.Notifications.Initialized,
     GenLSP.Requests.Shutdown
   ]
 
@@ -47,13 +46,6 @@ defmodule Expert do
 
     case State.initialize(state, request) do
       {:ok, response, state} ->
-        # TODO: this should be gated behind the dynamic registration in the initialization params
-        registrations = registrations()
-
-        if nil != GenLSP.request(lsp, registrations) do
-          Logger.error("Failed to register capability")
-        end
-
         lsp = assign(lsp, state: state)
         {:ok, response} = Forge.Protocol.Convert.to_lsp(response)
 
@@ -117,6 +109,16 @@ defmodule Expert do
            message: message
          }, lsp}
     end
+  end
+
+  def handle_notification(%GenLSP.Notifications.Initialized{}, lsp) do
+    registrations = registrations()
+
+    if nil != GenLSP.request(lsp, registrations) do
+      Logger.error("Failed to register capability")
+    end
+
+    {:noreply, lsp}
   end
 
   def handle_notification(%mod{} = notification, lsp) when mod in @server_specific_messages do

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -54,7 +54,8 @@ defmodule Expert.State do
 
     response = initialize_result()
 
-    Project.Supervisor.start(config.project)
+    Task.start_link(fn -> Project.Supervisor.start(config.project) end)
+
     {:ok, response, new_state}
   end
 


### PR DESCRIPTION
After we transitioned to GenLSP, I was no longer able to make Expert work with the Lexical vscode extension, so I would only be able to test it with neovim.

Apparently this is caused by two issues:
- Because we weren't doing the dynamic registrations when receiving the `Initialized` notification but rather in the initialization request, vscode stopped sending requests to the server
- I don't fully understand why, but if we start the project node synchronously on initialization, genlsp will apparently stop handling requests/notifictations from the vscode client, causing the client to cancel every request.

Fixing those two things I got Expert fully working on vscode again. I accidentally found those fixes while working on workpsace folders support, where the project nodes are started when files are opened instead of on initialization.