### PR TITLE
docs: update neovim setup

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -164,7 +164,7 @@ configuration below as a reference:
 require('lspconfig').lexical.setup {
   cmd = { "my/home/projects/expert/apps/expert/burrito_out/expert_linux_amd64" },
   root_dir = function(fname)
-    return util.root_pattern("mix.exs", ".git")(fname) or vim.loop.cwd()
+    return require('lspconfig').util.root_pattern("mix.exs", ".git")(fname) or vim.loop.cwd()
   end,
   filetypes = { "elixir", "eelixir", "heex" },
   -- optional settings


### PR DESCRIPTION
Fixed lua error `attempt to index global 'util' (a nil value)` when trying to setup lsp server