### PR TITLE
chore: add install task to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -87,4 +87,10 @@ release-plain: (deps "engine") (deps "expert")
 compile-ci-matrix:
   elixir matrix.exs
 
+[doc('Build and install binary locally')]
+[unix]
+install: release-local
+  #!/usr/bin/env bash
+  cp ./apps/expert/burrito_out/expert_{{ local_target }} ~/.local/bin/expert
+
 default: release-local

--- a/pages/installation.md
+++ b/pages/installation.md
@@ -58,6 +58,9 @@ If things complete successfully, you will then have a release in your
 `apps/expert/burrito_out` directory. If you see errors, please file a
 bug.
 
+In case you want to build and install it locally you can run `just install`,
+which will install the generated binary inside `~/.local/bin`.
+
 For the following examples, assume the absolute path to your Expert
 source code is `/my/home/projects/expert` and that you are running an amd64
 Linux system. For other systems, replace the `expert_linux_amd64` with the


### PR DESCRIPTION
A unify task to build and install the binary was missing, also add to
installation documentation how to call it