### PR TITLE
docs: update nightly installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to try out the latest features, you can download a nightly build.
 Using the GH CLI, you can run the following command to download the latest nightly build:
 
 ```shell
-gh release download nightly --pattern 'expert_linux_amd64'
+gh release download nightly --pattern 'expert_linux_amd64' --repo elixir-lang/expert
 ```
 
 Then point your editor to the downloaded binary.


### PR DESCRIPTION
Unless the repo is specified, the user is required to download the repo for the specific gh command.