### PR TITLE
fix: trim any quotes wrapping PATH when elixir is managed by mise

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -87,6 +87,10 @@ defmodule Expert.Port do
           key_and_value
           |> String.split("=", parts: 2)
           |> Enum.map(&String.trim/1)
+          |> then(fn
+            ["PATH", path] -> ["PATH", String.trim(path, "'")]
+            other -> other
+          end)
 
         {key, value}
 
@@ -108,6 +112,10 @@ defmodule Expert.Port do
           key_and_value
           |> String.split("=", parts: 2)
           |> Enum.map(&String.trim/1)
+          |> then(fn
+            ["PATH", path] -> ["PATH", String.trim(path, "'")]
+            other -> other
+          end)
 
         {key, value}
 


### PR DESCRIPTION
When Expert.Port detects the elixir executable, it extracts the current env from mise/rtx if present, by calling `mise env -s bash`. This returns

    ...
    export PATH='<path>'
    ...

If we don't strip the surrounding single quotes, later when we re-inject `PATH` into the environmetn, `sh` will fail to intepret it correctly, meaning future calls to any `mise` managed executables such as `erl` will fail as a command not found. This will then cause servers to fail to load and bubble an `{:erpc, :noconnection}` error up to the user.

https://github.com/elixir-lang/expert/issues/59#issuecomment-3236766517