### PR TITLE
ci: add nix build

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -1,0 +1,29 @@
+name: Nix CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Nix Build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@7be5dee1421f63d07e71ce6e0a9f8a4b07c2a487 # v31.6.1
+
+      - name: Setup Nix GHA Cache
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+
+      - name: Build
+        run: |
+          nix build .#expert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: Elixir CI
 on:
   pull_request:
   push:
-    branches: main
+    branches:
+      - main
 
 env:
   DEFAULT_ELIXIR: 1.15.8-otp-25


### PR DESCRIPTION
@mhanberg Here's a first pass. It'll cache nix paths in the GHA cache. If we want, we could stand up a cachix.org cache and use that instead. That would also have the benefit that users could leverage it to avoid rebuilding thing, though this package compilation isn't that large. If we want to use cachix, then someone will need to create that and then we can update this job.

I'm still seeing the occasional build failure trying to chmod `erl`, but I can't quite nail down what's causing this.