### PR TITLE
fix: `nix develop -c just release-local` is not working on clean build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
               xz
               just
               _7zz
+              git
             ];
           };
         };


### PR DESCRIPTION
The `nix develop -c just release-local` is not working when running on fresh clone. It raise that `git` command not found error during `mi deps.get` is processing:

```
$ nix develop -c just release-local
* Getting elixir_sense (https://github.com/elixir-lsp/elixir_sense.g
it - e3ddc403554050221a2fd19a10a896fa7525bc02)
error: tool 'git' not found
** (Mix) Command "git -c core.hooksPath='' init --quiet" failed
error: Recipe `deps` failed with exit code 1
```

Solve by add `git` to the `flake.nix` to make nix recognize `git` command.