### PR TITLE
feat: epmdless deployments

### DIFF
--- a/apps/expert/lib/expert/epmd.ex
+++ b/apps/expert/lib/expert/epmd.ex
@@ -1,0 +1,26 @@
+defmodule Expert.EPMD do
+  def dist_port do
+    :persistent_term.get(:expert_dist_port, nil)
+  end
+
+  # EPMD callbacks
+
+  def register_node(name, port), do: register_node(name, port, :inet)
+
+  def register_node(name, port, family) do
+    :persistent_term.put(:expert_dist_port, port)
+
+    # We don't care if EPMD is not running
+    case :erl_epmd.register_node(name, port, family) do
+      {:error, _} -> {:ok, -1}
+      {:ok, _} = ok -> ok
+    end
+  end
+
+  defdelegate start_link(), to: :erl_epmd
+  defdelegate port_please(name, host), to: :erl_epmd
+  defdelegate port_please(name, host, timeout), to: :erl_epmd
+  defdelegate listen_port_please(name, host), to: :erl_epmd
+  defdelegate address_please(name, host, family), to: :erl_epmd
+  defdelegate names(host_name), to: :erl_epmd
+end

--- a/apps/expert/rel/remote.vm.args.eex
+++ b/apps/expert/rel/remote.vm.args.eex
@@ -1,0 +1,12 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+
+## Enable deployment without epmd
+## (requires changing both vm.args and remote.vm.args)
+-start_epmd false -dist_listen false

--- a/apps/expert/rel/vm.args.eex
+++ b/apps/expert/rel/vm.args.eex
@@ -1,0 +1,12 @@
+## Customize flags given to the VM: https://www.erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+
+## Enable deployment without epmd
+## (requires changing both vm.args and remote.vm.args)
+-start_epmd false -epmd_module Elixir.XPExpert.EPMD


### PR DESCRIPTION
Closes #108 
Should fix #59 

Removes the usage of EPMD, and instead uses a custom EPMD module that provides an epmd port that project nodes use to connect to the manager node directly, instead of relying on epmd to resolve the names to ports.

There is one caveat to this implementation: while it works fairly well, we're still using the ETS search store, which implements a WAL that only supports writes from a single node. We're currently relying on EPMD to let other project nodes discover who is the current wal leader so we can ensure there is always a single writer for the WAL. With this change, we can end up with multiple writers if you open the same project with multiple editors which can lead to issues. I didn't observe problems so far in my tests with multiple editors but it's still something that needs to be changed.

There are two ways to solve that problem: switch to sqlite(we've been wanting to do this for a while), or do something similar to what livebook does to discover the runtime nodes.