### PR TITLE
docs: mention explicit need for zig 0.14.1 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then point your editor to the downloaded binary.
 
 ### Building from source
 
-To build Expert from source, you need Zig `0.14.1` installed on your system.
+To build Expert from source, you need Zig `0.14.1` installed on your system. Later versions will not work.
 
 Then you can run the following command or follow the instructions in the [Installation Instructions](pages/installation.md):
 


### PR DESCRIPTION
See https://github.com/elixir-lang/expert/issues/107

Normally a later version of a dependency is perfectly fine, so the fact that we need exactly 0.14.1 tripped me up.  I recommend adding a note to that effect to the readme.