### PR TITLE
fix: support Fish shell's space-separated PATH format

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -34,23 +34,8 @@ defmodule Expert.Port do
   def elixir_executable(%Project{} = project) do
     root_path = Project.root_path(project)
 
-    # We run a shell in interactive mode to populate the PATH with the right value
-    # at the project root. Otherwise, we either can't find an elixir executable,
-    # we use the wrong version if the user uses a version manager like asdf/mise,
-    # or we get an incomplete PATH not including erl or any other version manager
-    # managed programs.
     shell = System.get_env("SHELL")
-
-    # Ideally, it should contain the path to shell (e.g. `/usr/bin/fish`),
-    # but it might contain only the name of the shell (e.g. `fish`).
-    is_fish? = String.contains?(shell, "fish")
-
-    # Fish uses space-separated PATH, so we use the built-in `string join` command
-    # to join the entries with colons and have a standard colon-separated PATH output
-    # as in bash, which is expected by `:os.find_executable/2`.
-    path_command = if is_fish?, do: "string join ':' $PATH", else: "echo $PATH"
-
-    {path, 0} = System.cmd(shell, ["-i", "-l", "-c", "cd #{root_path} && #{path_command}"])
+    path = path_env_at_directory(root_path, shell)
 
     case :os.find_executable(~c"elixir", to_charlist(path)) do
       false ->
@@ -69,6 +54,31 @@ defmodule Expert.Port do
           end)
 
         {:ok, elixir, env}
+    end
+  end
+
+  defp path_env_at_directory(directory, shell) do
+    # We run a shell in interactive mode to populate the PATH with the right value
+    # at the project root. Otherwise, we either can't find an elixir executable,
+    # we use the wrong version if the user uses a version manager like asdf/mise,
+    # or we get an incomplete PATH not including erl or any other version manager
+    # managed programs.
+
+    case Path.basename(shell) do
+      # Ideally, it should contain the path to shell (e.g. `/usr/bin/fish`),
+      # but it might contain only the name of the shell (e.g. `fish`).
+      "fish" ->
+        # Fish uses space-separated PATH, so we use the built-in `string join` command
+        # to join the entries with colons and have a standard colon-separated PATH output
+        # as in bash, which is expected by `:os.find_executable/2`.
+        {path, 0} =
+          System.cmd(shell, ["-i", "-l", "-c", "cd #{directory} && string join ':' $PATH"])
+
+        path
+
+      _ ->
+        {path, 0} = System.cmd(shell, ["-i", "-l", "-c", "cd #{directory} && echo $PATH"])
+        path
     end
   end
 


### PR DESCRIPTION
Hey 👋 
I spontaneously decided to give it a try to #171 and see if i can fix Fish support. I hope this doesn't bother you, if so, feel free to close the PR. 

---

Fish shell uses space-separated PATH variables internally (as a proper list), while other shells like bash and zsh use colon-separated strings. When Expert tried to detect the Elixir executable by running `echo $PATH` in Fish, it received space-separated output like: `/opt/homebrew/bin /opt/homebrew/sbin /Users/username/.local/bin ...`

This caused `:os.find_executable/2` to fail since it expects colon-separated paths on Unix systems, preventing Fish users from using Expert properly.

## Proposed Solution

This PR adds Fish-specific handling to convert the `PATH` to the expected colon-separated format:

- Detects Fish shell using `String.contains?(shell, "fish")`
- For Fish: uses `string join ':' $PATH` to convert Fish's list format to colon-separated
  - `string join ...` is built-in in Fish and available since version [2.3.0](https://github.com/fish-shell/fish-shell/releases/tag/2.3.0) (2016)
- For other shells: continues using echo $PATH as before

💡 This approach correctly handles paths with spaces in them (e.g., `/Applications/Visual Studio Code.app/bin`) because it works with Fish's native list structure rather than trying to parse space-separated strings.

## Testing

Tested with Fish shell + Mise on macOS, where Elixir executable is now correctly found 🚀 

Let me know if the solution is good enough for you, or if is there anything missing.

Cheers ✌️ 
