### PR TITLE
fix(nix): use eval release command

### DIFF
--- a/apps/engine/deps.nix
+++ b/apps/engine/deps.nix
@@ -165,7 +165,7 @@ let
 
       gen_lsp =
         let
-          version = "0.11.0";
+          version = "0.11.1";
           drv = buildMix {
             inherit version;
             name = "gen_lsp";
@@ -174,7 +174,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "gen_lsp";
-              sha256 = "d67c20650a5290a02f7bac53083ac4487d3c6b461f35a8b14c5d2d7638c20d26";
+              sha256 = "78cd7994c0e46399c71e727fe29cfb8ff41e32711c1a30ad4b92203ee0d7920d";
             };
 
             beamDeps = [

--- a/apps/expert/deps.nix
+++ b/apps/expert/deps.nix
@@ -147,7 +147,7 @@ let
 
       burrito =
         let
-          version = "1.4.0";
+          version = "1.5.0";
           drv = buildMix {
             inherit version;
             name = "burrito";
@@ -156,7 +156,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "burrito";
-              sha256 = "0fa052e6f446cd3e5ff7e00813452b09eeadeddb5ec5174c2976eb0e4ad88765";
+              sha256 = "3861abda7bffa733862b48da3e03df0b4cd41abf6fd24b91745f5c16d971e5fa";
             };
 
             beamDeps = [
@@ -195,7 +195,7 @@ let
 
       gen_lsp =
         let
-          version = "0.11.0";
+          version = "0.11.1";
           drv = buildMix {
             inherit version;
             name = "gen_lsp";
@@ -204,7 +204,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "gen_lsp";
-              sha256 = "d67c20650a5290a02f7bac53083ac4487d3c6b461f35a8b14c5d2d7638c20d26";
+              sha256 = "78cd7994c0e46399c71e727fe29cfb8ff41e32711c1a30ad4b92203ee0d7920d";
             };
 
             beamDeps = [

--- a/apps/forge/deps.nix
+++ b/apps/forge/deps.nix
@@ -147,7 +147,7 @@ let
 
       gen_lsp =
         let
-          version = "0.11.0";
+          version = "0.11.1";
           drv = buildMix {
             inherit version;
             name = "gen_lsp";
@@ -156,7 +156,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "gen_lsp";
-              sha256 = "d67c20650a5290a02f7bac53083ac4487d3c6b461f35a8b14c5d2d7638c20d26";
+              sha256 = "78cd7994c0e46399c71e727fe29cfb8ff41e32711c1a30ad4b92203ee0d7920d";
             };
 
             beamDeps = [

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -47,7 +47,7 @@ beamPackages.mixRelease rec {
 
   postInstall = ''
     mv $out/bin/plain $out/bin/expert
-    wrapProgram $out/bin/expert --add-flag start
+    wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
   '';
 
   removeCookie = false;


### PR DESCRIPTION
Using eval over start allows us to pass commandline arguments.

Closes #198 