### PR TITLE
fix: remove erts from extra_applications

### DIFF
--- a/apps/expert/mix.exs
+++ b/apps/expert/mix.exs
@@ -23,7 +23,7 @@ defmodule Expert.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :runtime_tools, :kernel, :erts, :observer],
+      extra_applications: [:logger, :runtime_tools, :kernel, :observer],
       mod: {Expert.Application, []}
     ]
   end


### PR DESCRIPTION
Before this fix, when running `just release-local`, I was getting this error:

> ** (Mix) Unknown application :erts
> error: Recipe `release-local` failed with exit code 1

I got this error while running with these Elixir and Erlang versions:

- Elixir 1.19.2-otp-28
- Erlang 28.1.1

I think this error started to happen with Elixir 1.19.2, after this change: https://github.com/elixir-lang/elixir/commit/bea1c6c58edff9c77a71ab1e94d096dd4496f3bb