### PR TITLE
fix: use project directory when building engine

### DIFF
--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -207,7 +207,7 @@ defmodule Expert.EngineNode do
                 Expert.vsn()
               ],
               env: Expert.Port.ensure_charlists(env),
-              cd: engine_source
+              cd: Project.root_path(project)
             ]
 
           launcher = Expert.Port.path()


### PR DESCRIPTION
Use project root as working directory when building engine so asdf resolves to the correct Elixir/OTP version from .tool-versions.

The problem happened when the project/local Elixir/Erlang versions set by asdf were different from the global Elixir/Erlang versions set by asdf.

My project has this `.tool-versions` file:

```sh
cat .tool-versions

elixir 1.18.1-otp-27
erlang 27.2.4
```

But my global .tool-versions file had different Elixir/Erlang versions:

```sh
cat ~/.tool-versions

elixir 1.19.2-otp-28
erlang 28.1.1
```

When Expert was building the engine, it was being built with the global Elixir version instead of my project's Elixir version.

This caused an exception with a message like `corrupt atom table`.