### PR TITLE
docs(installation): update zed installation instructions to include setting the --stdio flag

### DIFF
--- a/pages/installation.md
+++ b/pages/installation.md
@@ -291,6 +291,13 @@ So, first install the extension and then update your `settings.json` to use Expe
 
 ```json
 {
+  "lsp": {
+    "expert": {
+      "binary": {
+        "arguments": ["--stdio"]
+      }
+    }
+  },
   "languages": {
     "Elixir": {
       "language_servers": [


### PR DESCRIPTION
Until the zed extension handles this natively, Zed users need to add an extra `arguments` setting within the `lsp` section of their config.