### PR TITLE
test: add defguard macro coverage to jump-to-definition

### DIFF
--- a/apps/forge/test/fixtures/navigations/lib/my_definition.ex
+++ b/apps/forge/test/fixtures/navigations/lib/my_definition.ex
@@ -3,6 +3,8 @@ defmodule MyDefinition do
 
   defstruct [:field, another_field: nil]
 
+  defguard is_adult(age) when age >= 18
+
   defmacro __using__(_opts) do
     quote do
       import MyDefinition


### PR DESCRIPTION
Extend tests to cover jumping to the definition of `defguard` macros. This ensures guard macros are correctly resolved by code intelligence features.

Demo:

https://github.com/user-attachments/assets/890402cb-5ca3-457a-9ed9-4882b32b4426
