### PR TITLE
refactor: update client support function to match the configuration state

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -53,12 +53,12 @@ defmodule Expert.Configuration do
     :persistent_term.get(__MODULE__, false) || new()
   end
 
-  @spec client_supports?(atom()) :: boolean()
-  def client_supports?(key) when is_atom(key) do
-    client_supports?(get().support, key)
+  @spec client_support(atom()) :: term()
+  def client_support(key) when is_atom(key) do
+    client_support(get().support, key)
   end
 
-  defp client_supports?(%Support{} = client_support, key) do
+  defp client_support(%Support{} = client_support, key) do
     case Map.fetch(client_support, key) do
       {:ok, value} -> value
       :error -> raise ArgumentError, "unknown key: #{inspect(key)}"

--- a/apps/expert/lib/expert/project/progress/state.ex
+++ b/apps/expert/lib/expert/project/progress/state.ex
@@ -90,7 +90,7 @@ defmodule Expert.Project.Progress.State do
   end
 
   defp write_work_done(lsp, token) do
-    if Configuration.client_supports?(:work_done_progress) do
+    if Configuration.client_support(:work_done_progress) == true do
       GenLSP.request(lsp, %Requests.WindowWorkDoneProgressCreate{
         id: Id.next(),
         params: %Structures.WorkDoneProgressCreateParams{token: token}
@@ -99,7 +99,7 @@ defmodule Expert.Project.Progress.State do
   end
 
   defp write(lsp, %progress_module{token: token} = progress) when not is_nil(token) do
-    if Configuration.client_supports?(:work_done_progress) do
+    if Configuration.client_support(:work_done_progress) == true do
       GenLSP.notify(
         lsp,
         progress_module.to_protocol(progress)

--- a/apps/expert/test/expert/project/progress_test.exs
+++ b/apps/expert/test/expert/project/progress_test.exs
@@ -59,7 +59,7 @@ defmodule Expert.Project.ProgressTest do
   end
 
   def with_work_done_progress_support(_) do
-    patch(Configuration, :client_supports?, fn :work_done_progress -> true end)
+    patch(Configuration, :client_support, fn :work_done_progress -> true end)
     :ok
   end
 
@@ -67,7 +67,7 @@ defmodule Expert.Project.ProgressTest do
     setup [:with_patched_transport]
 
     test "it should be able to send the report progress", %{project: project} do
-      patch(Configuration, :client_supports?, fn :work_done_progress -> true end)
+      patch(Configuration, :client_support, fn :work_done_progress -> true end)
 
       begin_message = progress(:begin, "mix compile")
       EngineApi.broadcast(project, begin_message)
@@ -94,7 +94,7 @@ defmodule Expert.Project.ProgressTest do
     end
 
     test "it should write nothing when the client does not support work done", %{project: project} do
-      patch(Configuration, :client_supports?, fn :work_done_progress -> false end)
+      patch(Configuration, :client_support, fn :work_done_progress -> false end)
 
       begin_message = progress(:begin, "mix compile")
       EngineApi.broadcast(project, begin_message)


### PR DESCRIPTION
The previous function claimed to return a boolean, but given the nested nature of the configuration struct, it's more useful to make it return whatever is stored instead

Closes #113
