### PR TITLE
fix: clamp start_char for prefix completion

### DIFF
--- a/apps/expert/lib/expert/code_intelligence/completion/builder.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion/builder.ex
@@ -108,7 +108,7 @@ defmodule Expert.CodeIntelligence.Completion.Builder do
 
   defp prefix_range(%Env{} = env) do
     end_char = env.position.character
-    start_char = end_char - prefix_length(env)
+    start_char = max(end_char - prefix_length(env), 1)
     {start_char, end_char}
   end
 


### PR DESCRIPTION
Fixes #215
This is a mitigation based on the stacktrace, I wasn't able to reproduce the issue myself