### PR TITLE
fix: nil.__struct__/0 is undefined when receiving shutdown

### DIFF
--- a/apps/expert/lib/expert/protocol/convert.ex
+++ b/apps/expert/lib/expert/protocol/convert.ex
@@ -16,6 +16,10 @@ defmodule Expert.Protocol.Convert do
     Convertible.to_lsp(other)
   end
 
+  def to_native(%GenLSP.Notifications.Exit{params: nil} = exit_notification) do
+    {:ok, exit_notification}
+  end
+
   def to_native(%{params: request_or_notification} = original_request) do
     context_document = Document.Container.context_document(request_or_notification, nil)
 


### PR DESCRIPTION
When stopping the server, e.g. via :LspStop on neovim:

```
** (UndefinedFunctionError) function nil.__struct__/0 is undefined
    nil.__struct__()
    (elixir 1.18.4) lib/map.ex:1030: Map.from_struct/1
    (xp_expert 0.1.0) lib/expert/protocol/convert.ex:29: XPExpert.Protocol.Convert.to_native/1
    (xp_expert 0.1.0) lib/expert.ex:158: XPExpert.handle_notification/2
    (xp_gen_lsp 0.11.1) lib/gen_lsp.ex:519: anonymous fn/2 in XPGenLSP.loop/3
    (xp_telemetry 1.3.0) /home/badosu/Code/expert/apps/expert/deps/telemetry/src/telemetry.erl:324: :xp_telemetry.span/3
    (xp_gen_lsp 0.11.1) lib/gen_lsp.ex:515: anonymous fn/4 in XPGenLSP.loop/3
    (xp_gen_lsp 0.11.1) lib/gen_lsp.ex:592: anonymous fn/4 in XPGenLSP.attempt/4
```