### PR TITLE
fix: position encoding to ensure correct formatting for special chars

### DIFF
--- a/apps/engine/lib/engine/code_mod/diff.ex
+++ b/apps/engine/lib/engine/code_mod/diff.ex
@@ -101,7 +101,7 @@ defmodule Engine.CodeMod.Diff do
   end
 
   defp advance(<<c::utf8, rest::binary>>, {line, unit}, edits) do
-    increment = CodeUnit.count(:utf8, <<c::utf8>>)
+    increment = CodeUnit.count(:utf16, <<c::utf8>>)
     advance(rest, {line, unit + increment}, edits)
   end
 

--- a/apps/engine/test/engine/code_mod/diff_test.exs
+++ b/apps/engine/test/engine/code_mod/diff_test.exs
@@ -180,7 +180,7 @@ defmodule Engine.CodeMod.DiffTest do
       final = ~S[{"🎸", "after"}]
 
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 10, 1, 12, ""))
+      assert_normalized(edit == edit(1, 8, 1, 10, ""))
       assert_edited(orig, final)
     end
 
@@ -189,7 +189,7 @@ defmodule Engine.CodeMod.DiffTest do
       final = ~S[🎸🎺🎸]
 
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 5, 1, 5, "🎺"))
+      assert_normalized(edit == edit(1, 3, 1, 3, "🎺"))
       assert_edited(orig, final)
     end
 
@@ -198,7 +198,7 @@ defmodule Engine.CodeMod.DiffTest do
       final = ~S[🎸🎸]
 
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 5, 1, 13, ""))
+      assert_normalized(edit == edit(1, 3, 1, 7, ""))
       assert_edited(orig, final)
     end
 

--- a/apps/engine/test/engine/code_mod/format_test.exs
+++ b/apps/engine/test/engine/code_mod/format_test.exs
@@ -114,5 +114,23 @@ defmodule Engine.CodeMod.FormatTest do
 
       assert result == formatted()
     end
+
+    test "it handles special characters", %{project: project} do
+      assert {:ok, result} =
+               ~q"""
+               [
+                 {"Karolína Plíšková","Kristýna Plíšková"}
+               ]
+               """
+               |> modify(project: project)
+
+      assert result ==
+               """
+               [
+                 {"Karolína Plíšková", "Kristýna Plíšková"}
+               ]
+               """
+               |> String.trim()
+    end
   end
 end


### PR DESCRIPTION
I'm working on a quick prototype to fix #242. It seems that `advance` needs to be converted to UTF-16 as per the position encoding LSP spec. The code needs to fix the code_mod_case.ex in the `apply_edits` function to convert it back to UTF-8 as well. 