### PR TITLE
fix(engine): support go to definition when function is called via `__MODULE__`

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/entity.ex
+++ b/apps/engine/lib/engine/code_intelligence/entity.ex
@@ -346,6 +346,10 @@ defmodule Engine.CodeIntelligence.Entity do
     String.upcase(first_char) == first_char
   end
 
+  defp expand_alias({:var, ~c"__MODULE__"}, analysis, %Position{} = position) do
+    Engine.Analyzer.current_module(analysis, position)
+  end
+
   defp expand_alias({:alias, {:local_or_var, prefix}, charlist}, analysis, %Position{} = position) do
     expand_alias(prefix ++ [?.] ++ charlist, analysis, position)
   end

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -336,6 +336,50 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
       assert referenced_uri == subject_uri
     end
 
+    test "find the function definition when referenced via __MODULE__", %{
+      project: project,
+      subject_uri: subject_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesOwnFunction do
+          def greet do
+          end
+
+          def uses_greet do
+            __MODULE__.gree|t()
+          end
+        end
+      ]
+
+      {:ok, referenced_uri, definition_line} = definition(project, subject_module, subject_uri)
+
+      assert definition_line == ~S[  def «greet» do]
+      assert referenced_uri =~ "navigations/lib/my_module.ex"
+    end
+
+    test "find the function definition when alias __MODULE__ is used", %{
+      project: project,
+      subject_uri: subject_uri
+    } do
+      subject_module = ~q[
+        defmodule MyApp.UsesOwnFunction do
+          alias __MODULE__
+
+          def greet do
+          end
+
+          def uses_greet do
+            UsesOwnFunction.gree|t()
+          end
+        end
+      ]
+
+      {:ok, referenced_uri, definition_line} = definition(project, subject_module, subject_uri)
+
+      assert definition_line == ~S[  def «greet» do]
+      assert referenced_uri =~ "navigations/lib/my_module.ex"
+    end
+
     test "find the attribute", %{project: project, subject_uri: subject_uri} do
       subject_module = ~q[
         defmodule UsesAttribute do


### PR DESCRIPTION
This PR add support for function calls using `__MODULE__` special form, like:

```elixir
___MODULE__.function1()
```

It was not working, because Forge parses `__MODULE__` as `{:var, ~c"__MODULE__"}`, not as an atom/module. Because of that, a special handling case just for `{:var, ~c"__MODULE__"}` needed to be added.

Recognizing `__MODULE__` as `:var,` while might be semantically incorrect, does not seem to be a problem in scope of definition finding.

The PR also adds an additional test, making sure that a popular formula of using `alias __MODULE__` in the module is correctly handled by the Engine.