### PR TITLE
fix(engine): node start error reason not being shown

### DIFF
--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -88,7 +88,7 @@ defmodule Expert.EngineNode do
               IO.puts("ok")
 
             {:error, reason} ->
-              IO.puts("error starting node:\n \#{inspect(reason)}")
+              IO.puts("error starting node: #{inspect(reason)}")
           end
         end
 


### PR DESCRIPTION
we also make it a single line so that it has a better chance at being displayed as the last message from the node on other places that display errors