### PR TITLE
fix(engine): code lens exception when mix.exs not found

### DIFF
--- a/apps/expert/lib/expert/provider/handlers/code_lens.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_lens.ex
@@ -53,11 +53,14 @@ defmodule Expert.Provider.Handlers.CodeLens do
   end
 
   defp show_reindex_lens?(%Project{} = project, %Document{} = document) do
-    document_path = normalize_path(document.path)
-    mix_exs_path = normalize_path(Project.mix_exs_path(project))
+    case Project.mix_exs_path(project) do
+      nil ->
+        false
 
-    document_path == mix_exs_path and
-      not EngineApi.index_running?(project)
+      mix_exs_path ->
+        normalize_path(document.path) == normalize_path(mix_exs_path) and
+          not EngineApi.index_running?(project)
+    end
   end
 
   defp normalize_path(path) do

--- a/apps/expert/test/expert/provider/handlers/code_lens_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_lens_test.exs
@@ -88,11 +88,27 @@ defmodule Expert.Provider.Handlers.CodeLensTest do
       assert {:ok, []} = handle(request, project)
     end
 
-    test "does not emite a code lens for an umbrella app's mix.exs", %{project: project} do
+    test "does not emit a code lens for an umbrella app's mix.exs", %{project: project} do
       {:ok, request} =
         project
         |> Project.project_path()
         |> Path.join("apps/first/mix.exs")
+        |> build_request()
+
+      assert {:ok, []} = handle(request, project)
+    end
+  end
+
+  describe "code lens when mix.exs path is nil" do
+    setup [:with_indexing_enabled]
+
+    test "returns empty lenses when project has no mix.exs", %{project: project} do
+      patch(Project, :mix_exs_path, nil)
+
+      {:ok, request} =
+        project
+        |> Project.project_path()
+        |> Path.join("apps/first/lib/umbrella/first.ex")
         |> build_request()
 
       assert {:ok, []} = handle(request, project)


### PR DESCRIPTION
This happens to me when the project is opened where a Mix project is not in the root directory, but in a subdirectory (i.e. a typocal monorepo setting). Expert can still resolve some things (go to definition), some don't work (hover docs), but when it comes to code lens, it just throws an exception.

```
{"jsonrpc":"2.0","method":"window/logMessage","params":{"message":"** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1\n    (elixir 1.19.4) lib/io.ex:738: IO.chardata_to_string(nil)\n    (elixir 1.19.4) lib/path.ex:835: Path.expand_home/1\n    (elixir 1.19.4) lib/path.ex:195: Path.expand/1\n    (xp_expert 0.1.0) lib/expert/provider/handlers/code_lens.ex:65: XPExpert.Provider.Handlers.CodeLens.normalize_path/1\n    (xp_expert 0.1.0) lib/expert/provider/handlers/code_lens.ex:57: XPExpert.Provider.Handlers.CodeLens.show_reindex_lens?/2\n    (xp_expert 0.1.0) lib/expert/provider/handlers/code_lens.ex:31: XPExpert.Provider.Handlers.CodeLens.reindex_lens/2\n    (xp_expert 0.1.0) lib/expert/provider/handlers/code_lens.ex:22: XPExpert.Provider.Handlers.CodeLens.handle/2\n    (xp_expert 0.1.0) lib/expert.ex:115: XPExpert.handle_request/2\n","type":1}}
```

Given that `Project.mix_exs_path` can explicitly (based on a type spec) return `nil`, this situation should be handled gracefully and the function should return `false`, not result in an exception.