### PR TITLE
fix(expert): save new configuration after `workspace/didChangeConfiguration`

### DIFF
--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -84,8 +84,6 @@ defmodule Expert.State do
         GenLSP.request(Expert.get_lsp(), request)
         {:ok, %__MODULE__{state | configuration: config}}
     end
-
-    {:ok, state}
   end
 
   def apply(%__MODULE__{} = state, %GenLSP.Notifications.TextDocumentDidChange{params: params}) do


### PR DESCRIPTION
State handler of workspace/didChangeConfiguration message was always returning old configuration, so the changes to dialyzer support were not preserved.

This is maybe not super important, as the dialyzer config does not seem to be used anywhere, but it gets the general `didChangeConfiguration` flow right for the future - and I would like to add `projectDir` change handled by `didChangeConfiguration`, as this is default way to tweak the setting per-project in Emacs.