### PR TITLE
feat: add missing require code action

### DIFF
--- a/apps/engine/lib/engine/code_action.ex
+++ b/apps/engine/lib/engine/code_action.ex
@@ -9,6 +9,7 @@ defmodule Engine.CodeAction do
     Handlers.ReplaceWithUnderscore,
     Handlers.OrganizeAliases,
     Handlers.AddAlias,
+    Handlers.Require,
     Handlers.RemoveUnusedAlias,
     Handlers.Refactorex
   ]

--- a/apps/engine/lib/engine/code_action/handlers/require.ex
+++ b/apps/engine/lib/engine/code_action/handlers/require.ex
@@ -1,0 +1,78 @@
+defmodule Engine.CodeAction.Handlers.Require do
+  alias Engine.CodeAction
+  alias Forge.Ast.Analysis
+  alias Forge.Ast.Analysis.Require
+  alias Forge.Document
+  alias Forge.Document.Changes
+  alias GenLSP.Enumerations.CodeActionKind
+
+  @behaviour CodeAction.Handler
+
+  @impl CodeAction.Handler
+  def actions(document, range, diagnostics) do
+    with {:ok, _doc, %Analysis{valid?: true} = analysis} <-
+           Document.Store.fetch(document.uri, :analysis),
+         diagnostic when not is_nil(diagnostic) <-
+           Enum.find(diagnostics, &(&1.message =~ "require")),
+         {:ok, module_string} <- get_module(diagnostic.message) do
+      current_requires = Engine.CodeMod.Requires.in_scope(analysis, range)
+
+      {insert_position, trailer} =
+        Engine.CodeMod.Requires.insert_position(analysis, range.start)
+
+      module_atom = Module.concat([module_string])
+      {:elixir, segments} = Forge.Ast.Module.safe_split(module_atom, as: :atoms)
+      require_to_add = %Require{module: segments, as: List.last(segments)}
+
+      edits =
+        Engine.CodeMod.Requires.to_edits(
+          [require_to_add | current_requires],
+          insert_position,
+          trailer
+        )
+
+      changes = Changes.new(analysis.document, edits)
+
+      [
+        Forge.CodeAction.new(
+          analysis.document.uri,
+          "Add require for #{module_string}",
+          CodeActionKind.quick_fix(),
+          changes
+        )
+      ]
+    else
+      _ ->
+        []
+    end
+  end
+
+  @impl CodeAction.Handler
+  def kinds do
+    [CodeActionKind.quick_fix()]
+  end
+
+  @impl CodeAction.Handler
+  def trigger_kind, do: :all
+
+  def get_module(message) do
+    patterns =
+      [
+        ~r/require\s+([A-Za-z0-9_.!?]+)\s+before/,
+        ~r/require\s+([A-Za-z0-9_.!?]+)\s+if you intend/
+      ]
+
+    result =
+      Enum.find_value(patterns, fn pattern ->
+        case Regex.run(pattern, message) do
+          [_, module] -> module
+          _ -> nil
+        end
+      end)
+
+    case result do
+      nil -> {:error, "require not found in diagnostic message"}
+      module -> {:ok, module}
+    end
+  end
+end

--- a/apps/engine/lib/engine/code_mod/aliases.ex
+++ b/apps/engine/lib/engine/code_mod/aliases.ex
@@ -1,14 +1,11 @@
 defmodule Engine.CodeMod.Aliases do
-  alias Forge.Ast
+  alias Engine.CodeMod.Directives
   alias Forge.Ast.Analysis
   alias Forge.Ast.Analysis.Alias
   alias Forge.Ast.Analysis.Scope
-  alias Forge.Document
   alias Forge.Document.Edit
   alias Forge.Document.Position
   alias Forge.Document.Range
-
-  alias Sourceror.Zipper
 
   @doc """
   Returns the aliases that are in scope at the given range.
@@ -42,7 +39,7 @@ defmodule Engine.CodeMod.Aliases do
   def insert_position(%Analysis{} = analysis, %Position{} = cursor_position) do
     range = Range.new(cursor_position, cursor_position)
     current_aliases = in_scope(analysis, range)
-    do_insert_position(analysis, current_aliases, range)
+    Directives.insert_position(analysis, range, current_aliases)
   end
 
   @doc """
@@ -54,39 +51,11 @@ defmodule Engine.CodeMod.Aliases do
   def to_edits([], _, _), do: []
 
   def to_edits(aliases, %Position{} = insert_position, trailer) do
-    aliases = sort(aliases)
-    initial_spaces = insert_position.character - 1
-
-    alias_text =
-      aliases
-      # get rid of duplicate aliases
-      |> Enum.uniq_by(& &1.module)
-      |> Enum.map_join("\n", fn %Alias{} = a ->
-        text =
-          if List.last(a.module) == a.as do
-            "alias #{join(a.module)}"
-          else
-            "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
-          end
-
-        indent(text, initial_spaces)
-      end)
-      |> String.trim_trailing()
-
-    zeroed = put_in(insert_position.character, 1)
-    new_alias_range = Range.new(zeroed, zeroed)
-
-    alias_text =
-      if is_binary(trailer) do
-        alias_text <> trailer
-      else
-        alias_text
-      end
-
-    edits = remove_old_aliases(aliases)
-
-    edits ++
-      [Edit.new(alias_text, new_alias_range)]
+    Directives.to_edits(aliases, insert_position, trailer,
+      render: &render_alias/1,
+      sort_by: &sort_key/1,
+      range: & &1.range
+    )
   end
 
   defp aliases_in_scope(%Scope{} = scope) do
@@ -101,156 +70,15 @@ defmodule Engine.CodeMod.Aliases do
     Enum.join(module, ".")
   end
 
-  defp indent(text, spaces) do
-    String.duplicate(" ", spaces) <> text
+  defp sort_key(%Alias{} = scope_alias) do
+    Enum.map(scope_alias.module, fn elem -> elem |> to_string() |> String.downcase() end)
   end
 
-  defp remove_old_aliases(aliases) do
-    ranges =
-      aliases
-      # Reject new aliases that don't have a range
-      |> Enum.reject(&is_nil(&1.range))
-      # iterating back to start means we won't have prior edits
-      # clobber subsequent edits
-      |> Enum.sort_by(& &1.range.start.line, :desc)
-      |> Enum.uniq_by(& &1.range)
-      |> Enum.map(fn %Alias{} = alias ->
-        orig_range = alias.range
-
-        orig_range
-        |> put_in([:start, :character], 1)
-        |> update_in([:end], fn %Position{} = pos ->
-          %Position{pos | character: 1, line: pos.line + 1}
-        end)
-      end)
-
-    first_alias_index = length(ranges) - 1
-
-    ranges
-    |> Enum.with_index()
-    |> Enum.map(fn
-      {range, ^first_alias_index} ->
-        # add a new line where the first alias was to make space
-        # for the rewritten aliases
-        Edit.new("\n", range)
-
-      {range, _} ->
-        Edit.new("", range)
-    end)
-    |> merge_adjacent_edits()
-  end
-
-  defp merge_adjacent_edits([]), do: []
-  defp merge_adjacent_edits([_] = edit), do: edit
-
-  defp merge_adjacent_edits([edit | rest]) do
-    rest
-    |> Enum.reduce([edit], fn %Edit{} = current, [%Edit{} = last | rest] = edits ->
-      with {same_text, same_text} <- {last.text, current.text},
-           {same, same} <- {to_tuple(current.range.end), to_tuple(last.range.start)} do
-        collapsed = put_in(current.range.end, last.range.end)
-
-        [collapsed | rest]
-      else
-        _ ->
-          [current | edits]
-      end
-    end)
-    |> Enum.reverse()
-  end
-
-  defp to_tuple(%Position{} = position) do
-    {position.line, position.character}
-  end
-
-  defp do_insert_position(%Analysis{}, [%Alias{} | _] = aliases, _) do
-    first = Enum.min_by(aliases, &{&1.range.start.line, &1.range.start.character})
-    {first.range.start, nil}
-  end
-
-  defp do_insert_position(%Analysis{} = analysis, _, range) do
-    case Analysis.module_scope(analysis, range) do
-      %Scope{id: :global} = scope ->
-        {scope.range.start, "\n"}
-
-      %Scope{} = scope ->
-        scope_start = scope.range.start
-        # we use the end position here because the start position is right after
-        # the do for modules, which puts it well into the line. The end position
-        # is before the end, which is equal to the indent of the scope.
-
-        initial_position =
-          scope_start
-          |> put_in([:line], scope_start.line + 1)
-          |> put_in([:character], scope.range.end.character)
-          |> constrain_to_range(scope.range)
-
-        position =
-          case Ast.zipper_at(analysis.document, scope_start) do
-            {:ok, zipper} ->
-              {_, position} =
-                Zipper.traverse(zipper, initial_position, fn
-                  %Zipper{node: {:@, _, [{:moduledoc, _, _}]}} = zipper, _acc ->
-                    # If we detect a moduledoc node, place the alias after it
-                    range = Sourceror.get_range(zipper.node)
-
-                    {zipper, after_node(analysis.document, scope.range, range)}
-
-                  zipper, acc ->
-                    {zipper, acc}
-                end)
-
-              position
-
-            _ ->
-              initial_position
-          end
-
-        maybe_move_cursor_to_token_start(position, analysis)
-    end
-  end
-
-  defp after_node(%Document{} = document, %Range{} = scope_range, %{
-         start: start_pos,
-         end: end_pos
-       }) do
-    document
-    |> Position.new(end_pos[:line] + 1, start_pos[:column])
-    |> constrain_to_range(scope_range)
-  end
-
-  defp constrain_to_range(%Position{} = position, %Range{} = scope_range) do
-    cond do
-      position.line == scope_range.end.line ->
-        character = min(scope_range.end.character, position.character)
-        %Position{position | character: character}
-
-      position.line > scope_range.end.line ->
-        %{scope_range.end | character: 1}
-
-      true ->
-        position
-    end
-  end
-
-  defp maybe_move_cursor_to_token_start(%Position{} = position, %Analysis{} = analysis) do
-    project = Engine.get_project()
-
-    with {:ok, env} <- Ast.Env.new(project, analysis, position),
-         false <- String.last(env.prefix) in [" ", ""] do
-      # `  en|d` -> `2`
-      # `en|d` -> `2`
-      non_empty_characters_count = env.prefix |> String.trim_leading() |> String.length()
-
-      new_position = %Position{
-        position
-        | character: position.character - non_empty_characters_count
-      }
-
-      {new_position, "\n"}
+  defp render_alias(%Alias{} = a) do
+    if List.last(a.module) == a.as do
+      "alias #{join(a.module)}"
     else
-      _ ->
-        {position, "\n"}
+      "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
     end
   end
 end

--- a/apps/engine/lib/engine/code_mod/directives.ex
+++ b/apps/engine/lib/engine/code_mod/directives.ex
@@ -1,0 +1,211 @@
+defmodule Engine.CodeMod.Directives do
+  alias Forge.Ast
+  alias Forge.Ast.Analysis
+  alias Forge.Document
+  alias Forge.Document.Edit
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  alias Sourceror.Zipper
+
+  @type render_fun :: (any -> String.t())
+  @type sort_fun :: (any -> term())
+  @type range_fun :: (any -> Range.t() | nil)
+
+  @spec insert_position(Analysis.t(), Range.t(), list()) :: {Position.t(), String.t() | nil}
+  def insert_position(%Analysis{} = analysis, %Range{} = range, current_items)
+      when is_list(current_items) do
+    do_insert_position(analysis, current_items, range)
+  end
+
+  @spec to_edits(list(), Position.t(), String.t() | nil, keyword()) :: [Edit.t()]
+  def to_edits(items, %Position{} = insert_position, trailer \\ nil, opts) when is_list(items) do
+    render_fun = Keyword.fetch!(opts, :render)
+    sort_fun = Keyword.fetch!(opts, :sort_by)
+    range_fun = Keyword.fetch!(opts, :range)
+
+    do_to_edits(items, insert_position, trailer, render_fun, sort_fun, range_fun)
+  end
+
+  defp do_to_edits([], _, _, _, _, _), do: []
+
+  defp do_to_edits(items, %Position{} = insert_position, trailer, render_fun, sort_fun, range_fun) do
+    # Collect all ranges from original items BEFORE deduping
+    # This ensures duplicate directives get their lines removed
+    all_ranges =
+      items
+      |> Enum.map(&range_fun.(&1))
+      |> Enum.reject(&is_nil/1)
+
+    unique_items =
+      items
+      |> Enum.uniq_by(sort_fun)
+      |> Enum.sort_by(sort_fun)
+
+    initial_spaces = insert_position.character - 1
+
+    block_text =
+      unique_items
+      |> Enum.map_join("\n", fn item ->
+        item
+        |> render_fun.()
+        |> indent(initial_spaces)
+      end)
+      |> String.trim_trailing()
+
+    zeroed = put_in(insert_position.character, 1)
+    new_range = Range.new(zeroed, zeroed)
+
+    block_text =
+      if is_binary(trailer) do
+        block_text <> trailer
+      else
+        block_text
+      end
+
+    edits = remove_old_directives(all_ranges)
+
+    edits ++ [Edit.new(block_text, new_range)]
+  end
+
+  defp indent(text, spaces) do
+    String.duplicate(" ", spaces) <> text
+  end
+
+  defp remove_old_directives(ranges) do
+    ranges =
+      ranges
+      |> Enum.sort_by(& &1.start.line, :desc)
+      |> Enum.uniq_by(& &1)
+      |> Enum.map(fn %Range{} = range ->
+        orig_range = range
+
+        orig_range
+        |> put_in([:start, :character], 1)
+        |> update_in([:end], fn %Position{} = pos ->
+          %Position{pos | character: 1, line: pos.line + 1}
+        end)
+      end)
+
+    first_index = length(ranges) - 1
+
+    ranges
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {range, ^first_index} ->
+        Edit.new("\n", range)
+
+      {range, _} ->
+        Edit.new("", range)
+    end)
+    |> merge_adjacent_edits()
+  end
+
+  defp merge_adjacent_edits([]), do: []
+  defp merge_adjacent_edits([_] = edit), do: edit
+
+  defp merge_adjacent_edits([edit | rest]) do
+    rest
+    |> Enum.reduce([edit], fn %Edit{} = current, [%Edit{} = last | rest] = edits ->
+      with {same_text, same_text} <- {last.text, current.text},
+           {same, same} <- {to_tuple(current.range.end), to_tuple(last.range.start)} do
+        collapsed = put_in(current.range.end, last.range.end)
+
+        [collapsed | rest]
+      else
+        _ ->
+          [current | edits]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp to_tuple(%Position{} = position) do
+    {position.line, position.character}
+  end
+
+  defp do_insert_position(%Analysis{}, [_item | _] = items, _) do
+    first = Enum.min_by(items, &{&1.range.start.line, &1.range.start.character})
+    {first.range.start, nil}
+  end
+
+  defp do_insert_position(%Analysis{} = analysis, _, range) do
+    case Analysis.module_scope(analysis, range) do
+      %Forge.Ast.Analysis.Scope{id: :global} = scope ->
+        {scope.range.start, "\n"}
+
+      %Forge.Ast.Analysis.Scope{} = scope ->
+        scope_start = scope.range.start
+
+        initial_position =
+          scope_start
+          |> put_in([:line], scope_start.line + 1)
+          |> put_in([:character], scope.range.end.character)
+          |> constrain_to_range(scope.range)
+
+        position =
+          case Ast.zipper_at(analysis.document, scope_start) do
+            {:ok, zipper} ->
+              {_, position} =
+                Zipper.traverse(zipper, initial_position, fn
+                  %Zipper{node: {:@, _, [{:moduledoc, _, _}]}} = zipper, _acc ->
+                    range = Sourceror.get_range(zipper.node)
+
+                    {zipper, after_node(analysis.document, scope.range, range)}
+
+                  zipper, acc ->
+                    {zipper, acc}
+                end)
+
+              position
+
+            _ ->
+              initial_position
+          end
+
+        maybe_move_cursor_to_token_start(position, analysis)
+    end
+  end
+
+  defp after_node(%Document{} = document, %Range{} = scope_range, %{
+         start: start_pos,
+         end: end_pos
+       }) do
+    document
+    |> Position.new(end_pos[:line] + 1, start_pos[:column])
+    |> constrain_to_range(scope_range)
+  end
+
+  defp constrain_to_range(%Position{} = position, %Range{} = scope_range) do
+    cond do
+      position.line == scope_range.end.line ->
+        character = min(scope_range.end.character, position.character)
+        %Position{position | character: character}
+
+      position.line > scope_range.end.line ->
+        %{scope_range.end | character: 1}
+
+      true ->
+        position
+    end
+  end
+
+  defp maybe_move_cursor_to_token_start(%Position{} = position, %Analysis{} = analysis) do
+    project = Engine.get_project()
+
+    with {:ok, env} <- Ast.Env.new(project, analysis, position),
+         false <- String.last(env.prefix) in [" ", ""] do
+      non_empty_characters_count = env.prefix |> String.trim_leading() |> String.length()
+
+      new_position = %Position{
+        position
+        | character: position.character - non_empty_characters_count
+      }
+
+      {new_position, "\n"}
+    else
+      _ ->
+        {position, "\n"}
+    end
+  end
+end

--- a/apps/engine/lib/engine/code_mod/requires.ex
+++ b/apps/engine/lib/engine/code_mod/requires.ex
@@ -1,0 +1,61 @@
+defmodule Engine.CodeMod.Requires do
+  alias Engine.CodeMod.Directives
+  alias Forge.Ast.Analysis
+  alias Forge.Ast.Analysis.Require
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  @doc """
+  Returns the position in the document where requires should be inserted
+  """
+  @spec insert_position(Analysis.t(), Position.t()) :: {Position.t(), String.t() | nil}
+  def insert_position(%Analysis{} = analysis, %Position{} = cursor_position) do
+    range = Range.new(cursor_position, cursor_position)
+    current_requires = requires_in_scope(analysis, range)
+    Directives.insert_position(analysis, range, current_requires)
+  end
+
+  @doc """
+  Returns the requires that are in scope at the given range.
+  """
+  @spec in_scope(Analysis.t(), Range.t()) :: [Require.t()]
+  def in_scope(%Analysis{} = analysis, %Range{} = range) do
+    requires_in_scope(analysis, range)
+  end
+
+  @doc """
+  Turns a list of requires into edits
+  """
+  @spec to_edits([Require.t()], Position.t(), trailer :: String.t() | nil) :: [
+          Forge.Document.Edit.t()
+        ]
+  def to_edits(requires, position, trailer \\ nil)
+  def to_edits([], _, _), do: []
+
+  def to_edits(requires, %Position{} = insert_position, trailer) do
+    Directives.to_edits(requires, insert_position, trailer,
+      render: &render_require/1,
+      sort_by: &sort_key/1,
+      range: & &1.range
+    )
+  end
+
+  defp requires_in_scope(%Analysis{} = analysis, %Range{} = range) do
+    scope = Analysis.module_scope(analysis, range)
+
+    scope.requires
+    |> Enum.filter(&Range.contains?(scope.range, &1.range.start))
+  end
+
+  defp sort_key(%Require{} = require) do
+    Enum.map(require.module, fn elem -> elem |> to_string() |> String.downcase() end)
+  end
+
+  defp render_require(%Require{} = require) do
+    "require " <> join(require.module)
+  end
+
+  defp join(module) do
+    Enum.join(module, ".")
+  end
+end

--- a/apps/engine/test/engine/code_action/handlers/require_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/require_test.exs
@@ -1,0 +1,152 @@
+defmodule Engine.CodeAction.Handlers.RequireTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Engine.CodeAction.Handlers.Require, as: RequireHandler
+  alias Forge.Document
+  alias Forge.Document.Range
+  alias GenLSP.Structures.Diagnostic
+
+  import Forge.Test.CodeSigil
+  import Forge.Test.CursorSupport
+
+  setup do
+    patch(Engine, :get_project, %Forge.Project{})
+    start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
+    :ok
+  end
+
+  defp make_diagnostic(message, range) do
+    %Diagnostic{message: message, range: range}
+  end
+
+  describe "actions/3" do
+    test "adds a require quick fix for Logger macro message" do
+      text = ~q[
+      defmodule MyModule do
+        def log do
+          Logger.info|("hi")
+        end
+      end
+      ]
+
+      {cursor, document} = pop_cursor(text, as: :document)
+      range = Range.new(cursor, cursor)
+      :ok = Document.Store.open(document.uri, Document.to_string(document), document.version)
+
+      diagnostics = [
+        make_diagnostic(
+          "Logger.info/1 is undefined or private. However, there is a macro with the same name and arity. Be sure to require Logger if you intend to invoke this macro",
+          range
+        )
+      ]
+
+      actions = RequireHandler.actions(document, range, diagnostics)
+
+      assert [action] = actions
+      assert action.title == "Add require for Logger"
+      assert action.kind == GenLSP.Enumerations.CodeActionKind.quick_fix()
+      assert action.changes.edits != []
+      assert Enum.any?(action.changes.edits, &String.contains?(&1.text, "require Logger"))
+    end
+
+    test "adds require Logger on new line when existing require Kernel is present" do
+      text = ~q[
+      defmodule Foo do
+        require Kernel
+
+        def foo do
+          Logger.info|("hello")
+        end
+      end
+      ]
+
+      {cursor, document} = pop_cursor(text, as: :document)
+      range = Range.new(cursor, cursor)
+      :ok = Document.Store.open(document.uri, Document.to_string(document), document.version)
+
+      diagnostics = [
+        make_diagnostic(
+          "Logger.info/1 is undefined or private. However, there is a macro with the same name and arity. Be sure to require Logger if you intend to invoke this macro",
+          range
+        )
+      ]
+
+      actions = RequireHandler.actions(document, range, diagnostics)
+
+      assert [action] = actions
+      assert action.title == "Add require for Logger"
+
+      # Verify edits contain require Logger
+      assert Enum.any?(action.changes.edits, &String.contains?(&1.text, "require Logger"))
+
+      # Apply edits and verify the result has both requires on separate lines
+      original_text = Document.to_string(document)
+
+      result_text =
+        Forge.Test.CodeMod.Case.apply_edits(original_text, action.changes.edits, trim: false)
+
+      assert result_text =~ ~r/require Kernel\n\s*require Logger/s or
+               result_text =~ ~r/require Logger\n\s*require Kernel/s
+    end
+
+    test "adds require without extra blank lines between existing requires" do
+      text = ~q[
+      defmodule Foo do
+        require Kernel
+        require Logger
+
+        def foo do
+          Foo.Test.some_macro|()
+        end
+      end
+      ]
+
+      {cursor, document} = pop_cursor(text, as: :document)
+      range = Range.new(cursor, cursor)
+      :ok = Document.Store.open(document.uri, Document.to_string(document), document.version)
+
+      diagnostics = [
+        make_diagnostic(
+          "Foo.Test.some_macro/0 is undefined or private. However, there is a macro with the same name and arity. Be sure to require Foo.Test if you intend to invoke this macro",
+          range
+        )
+      ]
+
+      actions = RequireHandler.actions(document, range, diagnostics)
+
+      assert [action] = actions
+      assert action.title == "Add require for Foo.Test"
+
+      # Apply edits
+      original_text = Document.to_string(document)
+
+      result_text =
+        Forge.Test.CodeMod.Case.apply_edits(original_text, action.changes.edits, trim: false)
+
+      # Verify no extra blank lines between requires (should be consecutive lines)
+      assert result_text =~ ~r/require Foo.Test\n\s+require Kernel\n\s+require Logger/
+
+      # Also verify there are no double newlines in the require block
+      refute result_text =~ ~r/require \w+\n\n\s+require/
+    end
+
+    test "returns empty list when no matching diagnostic" do
+      text = ~q[
+      defmodule MyModule do
+        def log do
+          Logger.info|("hi")
+        end
+      end
+      ]
+
+      {cursor, document} = pop_cursor(text, as: :document)
+      range = Range.new(cursor, cursor)
+      :ok = Document.Store.open(document.uri, Document.to_string(document), document.version)
+
+      diagnostics = [make_diagnostic("something else", range)]
+
+      assert [] == RequireHandler.actions(document, range, diagnostics)
+    end
+  end
+end

--- a/apps/engine/test/engine/code_mod/directives_test.exs
+++ b/apps/engine/test/engine/code_mod/directives_test.exs
@@ -1,0 +1,102 @@
+defmodule Engine.CodeMod.DirectivesTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Engine.CodeMod.Directives
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  import Forge.Test.CodeSigil
+  import Forge.Test.CursorSupport
+
+  setup do
+    patch(Engine, :get_project, %Forge.Project{})
+    :ok
+  end
+
+  describe "insert_position/3" do
+    test "returns global start with trailer when no directives" do
+      document = Document.new("file:///file.ex", ~q[IO.puts("hi")], 1)
+      cursor = Position.new(document, 1, 1)
+      analysis = Ast.analyze(document)
+
+      {position, trailer} = Directives.insert_position(analysis, Range.new(cursor, cursor), [])
+
+      assert position.line == 1
+      assert position.character == 1
+      assert trailer == "\n"
+    end
+
+    test "returns first existing directive position without trailer" do
+      {cursor, document} =
+        pop_cursor(~q[
+      defmodule MyModule do
+        alias Foo|
+        alias Bar
+      end
+      ],
+          as: :document
+        )
+
+      analysis = Ast.analyze(document)
+      range = Range.new(cursor, cursor)
+
+      first_alias_range = Range.new(Position.new(document, 2, 3), Position.new(document, 2, 6))
+      fake = %{range: first_alias_range}
+
+      {position, trailer} = Directives.insert_position(analysis, range, [fake])
+
+      assert position == first_alias_range.start
+      assert trailer == nil
+    end
+  end
+
+  describe "to_edits/4" do
+    defp render(%{text: text}), do: "decl " <> text
+    defp sort_key(%{text: text}), do: text
+    defp range_of(%{range: range}), do: range
+
+    test "dedupes, sorts, removes old ranges, and inserts block" do
+      document =
+        Document.new(
+          "file:///file.ex",
+          ~q[
+      defmodule MyModule do
+        decl b
+        decl a
+      end
+      ],
+          1
+        )
+
+      items = [
+        %{
+          text: "b",
+          range: Range.new(Position.new(document, 2, 3), Position.new(document, 2, 8))
+        },
+        %{
+          text: "a",
+          range: Range.new(Position.new(document, 3, 3), Position.new(document, 3, 8))
+        },
+        %{text: "a", range: nil}
+      ]
+
+      insert_position = Position.new(document, 2, 3)
+
+      edits =
+        Directives.to_edits(items, insert_position, "\n",
+          render: &render/1,
+          sort_by: &sort_key/1,
+          range: &range_of/1
+        )
+
+      # expect old ranges removed (replaced/emptied) and new block inserted
+      assert length(edits) == 3
+      assert Enum.any?(edits, &(&1.text == "\n"))
+      assert Enum.any?(edits, &String.contains?(&1.text, "decl a"))
+      assert Enum.any?(edits, &String.contains?(&1.text, "decl b"))
+    end
+  end
+end

--- a/apps/engine/test/engine/code_mod/requires_test.exs
+++ b/apps/engine/test/engine/code_mod/requires_test.exs
@@ -1,0 +1,98 @@
+defmodule Engine.CodeMod.RequiresTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Engine.CodeMod.Requires
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  import Forge.Test.CodeSigil
+  import Forge.Test.CursorSupport
+
+  setup do
+    patch(Engine, :get_project, %Forge.Project{})
+    :ok
+  end
+
+  def insert_position(orig) do
+    {cursor, document} = pop_cursor(orig, as: :document)
+    analysis = Ast.analyze(document)
+    {position, trailer} = Requires.insert_position(analysis, cursor)
+    {:ok, document, position, trailer}
+  end
+
+  describe "insert_position" do
+    test "is directly after a module's definition if there are no requires present" do
+      {:ok, document, position, _trailer} =
+        ~q[
+        defmodule MyModule do|
+        end
+        ]
+        |> insert_position()
+
+      assert decorate_cursor(document, position) =~ ~q[
+      defmodule MyModule do
+      |end
+      ]
+    end
+
+    test "is where existing requires are" do
+      {:ok, document, position, _trailer} =
+        ~q[
+        defmodule MyModule do|
+          require Something.That.Exists
+        end
+        ]
+        |> insert_position()
+
+      expected = ~q[
+        defmodule MyModule do
+          |require Something.That.Exists
+        end
+      ]
+
+      assert decorate_cursor(document, position) =~ expected
+    end
+  end
+
+  describe "to_edits" do
+    test "writes sorted unique requires and removes old ones" do
+      document =
+        Document.new(
+          "file:///file.ex",
+          ~q[
+      defmodule MyModule do
+        require B.A
+        require A.B
+      end
+      ],
+          1
+        )
+
+      analysis = Ast.analyze(document)
+
+      {insert_position, trailer} =
+        Requires.insert_position(analysis, Position.new(document, 2, 3))
+
+      require_a = %Forge.Ast.Analysis.Require{
+        module: [:A, :B],
+        as: :B,
+        range: Range.new(Position.new(document, 3, 3), Position.new(document, 3, 12))
+      }
+
+      require_b = %Forge.Ast.Analysis.Require{
+        module: [:B, :A],
+        as: :A,
+        range: Range.new(Position.new(document, 2, 3), Position.new(document, 2, 12))
+      }
+
+      edits = Requires.to_edits([require_a, require_b], insert_position, trailer)
+
+      block_edit = Enum.find(edits, &String.contains?(&1.text, "require"))
+      assert block_edit != nil
+      assert block_edit.text =~ ~r/require A\.B.*require B\.A/s
+    end
+  end
+end

--- a/apps/forge/lib/forge/ast/analysis/require.ex
+++ b/apps/forge/lib/forge/ast/analysis/require.ex
@@ -1,7 +1,15 @@
 defmodule Forge.Ast.Analysis.Require do
   alias Forge.Ast
   alias Forge.Document
+  alias Forge.Document.Range
+
   defstruct [:module, :as, :range]
+
+  @type t :: %__MODULE__{
+          module: [atom],
+          as: atom() | [atom],
+          range: Range.t() | nil
+        }
 
   def new(%Document{} = document, ast, module, as \\ nil) when is_list(module) do
     range = Ast.Range.get(ast, document)


### PR DESCRIPTION
Closes #137 

Adds an `Add require for <module>` code action.

https://github.com/user-attachments/assets/3ba42c80-0e49-4fd9-8cc8-f25eb4680b05


It uses these diagnostics to determine if the code action should be shown:
- You must require `<module>` before invoking the macro `<module>.<fun>/<arity>`
- `<module>.<fun>/<arity>` is undefined or private. However, there is a macro with the same name and arity. Be sure to require `<module>` if you intend to invoke this macro

There's also some minor refactors to generalize the Aliases logic to insert `require` directives and other directives we may want to add in this way