### PR TITLE
feat: add module rename support

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -71,6 +71,10 @@ defmodule Engine do
 
   defdelegate runtime_versions, to: Forge.VM.Versions, as: :current
 
+  defdelegate prepare_rename(analysis, position), to: Engine.CodeMod.Rename, as: :prepare
+
+  defdelegate rename(analysis, position, new_name, client_name), to: Engine.CodeMod.Rename
+
   def list_apps do
     for {app, _, _} <- :application.loaded_applications(),
         not Forge.Namespace.Module.prefixed?(app),

--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -69,8 +69,6 @@ defmodule Engine do
 
   defdelegate workspace_symbols(query), to: CodeIntelligence.Symbols, as: :for_workspace
 
-  defdelegate runtime_versions, to: Forge.VM.Versions, as: :current
-
   defdelegate prepare_rename(analysis, position), to: Engine.CodeMod.Rename, as: :prepare
 
   defdelegate rename(analysis, position, new_name, client_name), to: Engine.CodeMod.Rename
@@ -78,6 +76,8 @@ defmodule Engine do
   defdelegate maybe_update_rename_progress(triggered_message),
     to: Engine.Commands.Rename,
     as: :update_progress
+
+  defdelegate runtime_versions, to: Forge.VM.Versions, as: :current
 
   def list_apps do
     for {app, _, _} <- :application.loaded_applications(),

--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -71,7 +71,8 @@ defmodule Engine do
 
   defdelegate prepare_rename(analysis, position), to: Engine.CodeMod.Rename, as: :prepare
 
-  defdelegate rename(analysis, position, new_name, client_name), to: Engine.CodeMod.Rename
+  defdelegate rename(analysis, position, new_name, client_name, rename_files?),
+    to: Engine.CodeMod.Rename
 
   defdelegate maybe_update_rename_progress(triggered_message),
     to: Engine.Commands.Rename,

--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -75,6 +75,10 @@ defmodule Engine do
 
   defdelegate rename(analysis, position, new_name, client_name), to: Engine.CodeMod.Rename
 
+  defdelegate maybe_update_rename_progress(triggered_message),
+    to: Engine.Commands.Rename,
+    as: :update_progress
+
   def list_apps do
     for {app, _, _} <- :application.loaded_applications(),
         not Forge.Namespace.Module.prefixed?(app),

--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -14,6 +14,7 @@ defmodule Engine.Application do
           Engine.CodeMod.Format.Cache,
           Engine.Api.Proxy,
           Engine.Commands.Reindex,
+          Engine.Commands.RenameSupervisor,
           Engine.Module.Loader,
           Engine.Compilation.TraceBuffer,
           Engine.Dispatch,

--- a/apps/engine/lib/engine/code_mod/aliases.ex
+++ b/apps/engine/lib/engine/code_mod/aliases.ex
@@ -1,11 +1,16 @@
 defmodule Engine.CodeMod.Aliases do
+  import Forge.Document.Line
+
   alias Engine.CodeMod.Directives
+  alias Forge.Ast
   alias Forge.Ast.Analysis
   alias Forge.Ast.Analysis.Alias
   alias Forge.Ast.Analysis.Scope
+  alias Forge.Document
   alias Forge.Document.Edit
   alias Forge.Document.Position
   alias Forge.Document.Range
+  alias Forge.Formats
 
   @doc """
   Returns the aliases that are in scope at the given range.
@@ -58,6 +63,51 @@ defmodule Engine.CodeMod.Aliases do
     )
   end
 
+  @doc false
+  def rename_grouped(%Analysis{} = analysis, %Position{} = position, old_name, target_name) do
+    with {:ok, path} <- Ast.path_at(analysis, position),
+         {alias_ast, base, members, options} <- Enum.find_value(path, &grouped_alias/1),
+         original_names =
+           Enum.map(members, &(Macro.to_string(base) <> "." <> Macro.to_string(&1))),
+         names =
+           Enum.map(original_names, fn name ->
+             if renamed_module?(name, old_name),
+               do: String.replace_prefix(name, old_name, target_name),
+               else: name
+           end),
+         true <-
+           original_names
+           |> Enum.zip_with(names, &(module_parent(&1) != module_parent(&2)))
+           |> Enum.any?() do
+      all_moved? = Enum.all?(original_names, &renamed_module?(&1, old_name))
+      range = Ast.Range.fetch!(alias_ast, analysis.document)
+      parents = names |> Enum.map(&module_parent/1) |> Enum.uniq()
+      same_parent? = length(parents) == 1 and List.first(parents) != []
+      options = alias_options(options)
+      aliases = Enum.map(names, &render_alias(&1, options))
+      {:alias, metadata, _arguments} = alias_ast
+
+      replacement =
+        cond do
+          all_moved? and same_parent? ->
+            parent = parents |> List.first() |> Enum.join(".")
+            members = Enum.map_join(names, ", ", &module_leaf/1)
+            render_alias("#{parent}.{#{members}}", options)
+
+          Keyword.has_key?(metadata, :end_of_expression) ->
+            {newline, indent} = line_layout(analysis.document, range)
+            Enum.join(aliases, newline <> indent)
+
+          true ->
+            "(" <> Enum.join(aliases, "; ") <> ")"
+        end
+
+      {:ok, alias_ast, Edit.new(grouped_alias_comments(analysis, range) <> replacement, range)}
+    else
+      _ -> :error
+    end
+  end
+
   defp aliases_in_scope(%Scope{} = scope) do
     scope.aliases
     |> Enum.filter(fn %Alias{} = scope_alias ->
@@ -76,9 +126,47 @@ defmodule Engine.CodeMod.Aliases do
 
   defp render_alias(%Alias{} = a) do
     if [List.last(a.module)] == a.as do
-      "alias #{join(a.module)}"
+      render_alias(join(a.module), nil)
     else
-      "alias #{join(a.module)}, as: #{join(a.as)}"
+      render_alias(join(a.module), "as: #{join(a.as)}")
     end
   end
+
+  defp render_alias(module, nil), do: "alias #{module}"
+  defp render_alias(module, options), do: "alias #{module}, #{options}"
+
+  defp grouped_alias({:alias, _, [{{:., _, [base, :{}]}, _, members} | options]} = ast) do
+    {ast, base, members, options}
+  end
+
+  defp grouped_alias(_ast), do: nil
+
+  defp renamed_module?(name, old_name),
+    do: name == old_name or String.starts_with?(name, old_name <> ".")
+
+  defp grouped_alias_comments(%Analysis{} = analysis, range) do
+    document = analysis.document
+    {newline, indent} = line_layout(document, range)
+
+    comments =
+      for %{line: line, column: column, text: text} <- Map.values(analysis.comments_by_line),
+          Range.contains?(range, Position.new(document, line, column)),
+          do: {line, text}
+
+    case Enum.sort(comments) do
+      [] -> ""
+      comments -> Enum.map_join(comments, newline <> indent, &elem(&1, 1)) <> newline <> indent
+    end
+  end
+
+  defp alias_options([]), do: nil
+  defp alias_options([options]), do: Sourceror.to_string(options, format: :splicing)
+
+  defp line_layout(document, range) do
+    {:ok, line(ending: newline)} = Document.fetch_line_at(document, range.start.line)
+    {newline, String.duplicate(" ", range.start.character - 1)}
+  end
+
+  defp module_parent(module), do: module |> Formats.module() |> String.split(".") |> Enum.drop(-1)
+  defp module_leaf(module), do: module |> Formats.module() |> String.split(".") |> List.last()
 end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -7,10 +7,14 @@ defmodule Engine.CodeMod.Rename do
   rename execution.
   """
   alias Engine.CodeMod.Rename
+  alias Engine.Commands
+  alias Engine.Progress
   alias Forge.Ast.Analysis
   alias Forge.Document
   alias Forge.Document.Position
   alias Forge.Document.Range
+
+  import Forge.EngineApi.Messages
 
   @doc """
   Prepares a rename operation at the given position.
@@ -31,16 +35,94 @@ defmodule Engine.CodeMod.Rename do
   Renames the entity at the given position to `new_name`, returning a list
   of document changes that should be applied.
 
-  The `client_name` parameter is currently unused but reserved for future
-  client-specific behavior (e.g., different progress tracking for VSCode vs Neovim).
+  The `client_name` parameter is used to determine client-specific behavior
+  for progress tracking (e.g., VSCode sends different events than Neovim).
   """
   @spec rename(Analysis.t(), Position.t(), String.t(), String.t() | nil) ::
           {:ok, [Document.Changes.t()]} | {:error, term()}
-  def rename(%Analysis{} = analysis, %Position{} = position, new_name, _client_name) do
+  def rename(%Analysis{} = analysis, %Position{} = position, new_name, client_name) do
     with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
       rename_module = Map.fetch!(@rename_mappings, renamable)
       results = rename_module.rename(range, new_name, entity)
+      set_rename_progress(results, client_name)
       {:ok, results}
     end
+  end
+
+  defp set_rename_progress(document_changes_list, client_name) do
+    # Progress tracking is optional - if the infrastructure isn't running
+    # (e.g., in tests), we just skip it
+    try do
+      do_set_rename_progress(document_changes_list, client_name)
+    rescue
+      _ -> :ok
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp do_set_rename_progress(document_changes_list, client_name) do
+    uri_to_expected_operation =
+      uri_to_expected_operation(client_name, document_changes_list)
+
+    {paths_to_delete, paths_to_reindex} =
+      for %Document.Changes{rename_file: rename_file, document: document} <- document_changes_list do
+        if rename_file do
+          {rename_file.old_uri, rename_file.new_uri}
+        else
+          {nil, document.uri}
+        end
+      end
+      |> Enum.unzip()
+
+    paths_to_delete = Enum.reject(paths_to_delete, &is_nil/1)
+    renaming_operation_count = Enum.count(uri_to_expected_operation)
+
+    total_operation_count =
+      renaming_operation_count + length(paths_to_delete) + length(paths_to_reindex)
+
+    {on_update_progress, on_complete} =
+      Progress.begin_percent("Renaming", total_operation_count)
+
+    Commands.RenameSupervisor.start_renaming(
+      uri_to_expected_operation,
+      paths_to_reindex,
+      paths_to_delete,
+      on_update_progress,
+      on_complete
+    )
+  end
+
+  # VSCode sends both file_changed and file_saved events
+  defp uri_to_expected_operation(client_name, document_changes_list)
+       when client_name in ["Visual Studio Code"] do
+    document_changes_list
+    |> Enum.flat_map(fn %Document.Changes{document: document, rename_file: rename_file} ->
+      if rename_file do
+        # when the file is renamed, we won't receive `DidSave` for the old file
+        [
+          {rename_file.old_uri, file_changed(uri: rename_file.old_uri)},
+          {rename_file.new_uri, file_saved(uri: rename_file.new_uri)}
+        ]
+      else
+        [{document.uri, file_saved(uri: document.uri)}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  # Other editors (like Neovim) may only send file_changed events
+  defp uri_to_expected_operation(_, document_changes_list) do
+    document_changes_list
+    |> Enum.flat_map(fn %Document.Changes{document: document, rename_file: rename_file} ->
+      if rename_file do
+        [{rename_file.new_uri, file_saved(uri: rename_file.new_uri)}]
+      else
+        # Some editors do not directly save the file after renaming, such as *neovim*.
+        # when the file is not renamed, we'll only received `DidChange` for the old file
+        [{document.uri, file_changed(uri: document.uri)}]
+      end
+    end)
+    |> Map.new()
   end
 end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -51,7 +51,7 @@ defmodule Engine.CodeMod.Rename do
 
   defp set_rename_progress(document_changes_list, client_name) do
     # Progress tracking is optional - if the infrastructure isn't running
-    # (e.g., in tests), we just skip it
+    # (e.g., in tests), we just skip it silently
     try do
       do_set_rename_progress(document_changes_list, client_name)
     rescue

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -1,0 +1,46 @@
+defmodule Engine.CodeMod.Rename do
+  @moduledoc """
+  Entry point for rename operations.
+
+  This module provides the main API for renaming entities (currently modules)
+  in Elixir code. It coordinates between the preparation phase and the actual
+  rename execution.
+  """
+  alias Engine.CodeMod.Rename
+  alias Forge.Ast.Analysis
+  alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  @doc """
+  Prepares a rename operation at the given position.
+
+  Returns `{:ok, entity_name, range}` if the entity can be renamed,
+  `{:ok, nil}` if at an unsupported location,
+  or `{:error, reason}` if renaming is not possible.
+  """
+  @spec prepare(Analysis.t(), Position.t()) ::
+          {:ok, String.t(), Range.t()} | {:ok, nil} | {:error, term()}
+  defdelegate prepare(analysis, position), to: Rename.Prepare
+
+  @rename_mappings %{module: Rename.Module}
+
+  @doc """
+  Executes a rename operation.
+
+  Renames the entity at the given position to `new_name`, returning a list
+  of document changes that should be applied.
+
+  The `client_name` parameter is currently unused but reserved for future
+  client-specific behavior (e.g., different progress tracking for VSCode vs Neovim).
+  """
+  @spec rename(Analysis.t(), Position.t(), String.t(), String.t() | nil) ::
+          {:ok, [Document.Changes.t()]} | {:error, term()}
+  def rename(%Analysis{} = analysis, %Position{} = position, new_name, _client_name) do
+    with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
+      rename_module = Map.fetch!(@rename_mappings, renamable)
+      results = rename_module.rename(range, new_name, entity)
+      {:ok, results}
+    end
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -92,34 +92,52 @@ defmodule Engine.CodeMod.Rename do
   defp ensure_destination_available(analysis, module, range, new_name) do
     old_name = Document.fragment(analysis.document, range.start, range.end)
     {old_suffix, new_suffix} = Rename.Module.Diff.diff(old_name, new_name)
-    target_name = module |> Formats.module() |> String.replace_suffix(old_suffix, new_suffix)
+    source_name = Formats.module(module)
+    target_name = String.replace_suffix(source_name, old_suffix, new_suffix)
 
-    if target_name == Formats.module(module) do
+    if source_name == target_name do
       :ok
     else
-      check_destination(target_name)
+      check_destination(source_name, target_name)
     end
   end
 
-  defp check_destination(target_name) do
-    case ManagerApi.search_store_prefix(Engine.get_project(), target_name,
-           type: :module,
-           subtype: :definition
-         ) do
-      {:ok, definitions} -> check_definitions(definitions, target_name)
-      {:error, _reason} = error -> error
-      [] -> {:error, :search_store_unavailable}
-    end
-  end
+  defp check_destination(source_name, target_name) do
+    project = Engine.get_project()
+    options = [type: :module, subtype: :definition]
 
-  defp check_definitions(definitions, target_name) do
-    Enum.find_value(definitions, :ok, fn definition ->
-      name = Formats.module(definition.subject)
+    with {:ok, source_definitions} <-
+           ManagerApi.search_store_prefix(project, source_name, options),
+         {:ok, destination_definitions} <-
+           ManagerApi.search_store_prefix(project, target_name, options) do
+      moving_names =
+        for definition <- source_definitions,
+            name = Formats.module(definition.subject),
+            name == source_name or String.starts_with?(name, source_name <> "."),
+            into: MapSet.new(),
+            do: name
 
-      if name == target_name or String.starts_with?(name, target_name <> ".") do
-        {:error, {:module_already_exists, name}}
+      produced_names =
+        MapSet.new(moving_names, &String.replace_prefix(&1, source_name, target_name))
+
+      collision =
+        Enum.reduce(destination_definitions, nil, fn definition, collision ->
+          name = Formats.module(definition.subject)
+
+          if MapSet.member?(produced_names, name) and not MapSet.member?(moving_names, name),
+            do: min(name, collision || name),
+            else: collision
+        end)
+
+      if collision do
+        {:error, {:module_already_exists, collision}}
+      else
+        :ok
       end
-    end)
+    else
+      [] -> {:error, :search_store_unavailable}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp start_progress do

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -6,6 +6,8 @@ defmodule Engine.CodeMod.Rename do
   in Elixir code. It coordinates between the preparation phase and the actual
   rename execution.
   """
+  import Forge.EngineApi.Messages
+
   alias Engine.CodeMod.Rename
   alias Engine.Commands
   alias Engine.Progress
@@ -13,8 +15,6 @@ defmodule Engine.CodeMod.Rename do
   alias Forge.Document
   alias Forge.Document.Position
   alias Forge.Document.Range
-
-  import Forge.EngineApi.Messages
 
   @doc """
   Prepares a rename operation at the given position.
@@ -49,16 +49,14 @@ defmodule Engine.CodeMod.Rename do
     end
   end
 
+  # Progress tracking is optional - if the infrastructure isn't running
+  # (e.g., in tests), we just skip it silently
   defp set_rename_progress(document_changes_list, client_name) do
-    # Progress tracking is optional - if the infrastructure isn't running
-    # (e.g., in tests), we just skip it silently
-    try do
-      do_set_rename_progress(document_changes_list, client_name)
-    rescue
-      _ -> :ok
-    catch
-      :exit, _ -> :ok
-    end
+    do_set_rename_progress(document_changes_list, client_name)
+  rescue
+    _ -> :ok
+  catch
+    :exit, _ -> :ok
   end
 
   defp do_set_rename_progress(document_changes_list, client_name) do

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -48,7 +48,7 @@ defmodule Engine.CodeMod.Rename do
         with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
           rename_module = Map.fetch!(@rename_mappings, renamable)
 
-          case rename_module.rename(range, new_name, entity) do
+          case rename_module.rename(analysis, range, new_name, entity) do
             {:error, _reason} = error -> error
             document_changes -> {:ok, document_changes}
           end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -10,11 +10,15 @@ defmodule Engine.CodeMod.Rename do
 
   alias Engine.CodeMod.Rename
   alias Engine.Commands
+  alias Engine.ManagerApi
   alias Engine.Progress
   alias Forge.Ast.Analysis
   alias Forge.Document
   alias Forge.Document.Position
   alias Forge.Document.Range
+  alias Forge.Formats
+
+  @module_name ~r/\A[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*\z/
 
   @doc """
   Prepares a rename operation at the given position.
@@ -51,7 +55,9 @@ defmodule Engine.CodeMod.Rename do
       token = start_progress()
 
       result =
-        with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
+        with :ok <- validate_module_name(new_name),
+             {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position),
+             :ok <- ensure_destination_available(analysis, entity, range, new_name) do
           rename_module = Map.fetch!(@rename_mappings, renamable)
 
           case rename_module.rename(analysis, range, new_name, entity, rename_files?) do
@@ -73,6 +79,47 @@ defmodule Engine.CodeMod.Rename do
           complete(token, error)
       end
     end
+  end
+
+  defp validate_module_name("Elixir"), do: {:error, {:invalid_module_name, "Elixir"}}
+
+  defp validate_module_name(name) when is_binary(name) do
+    if Regex.match?(@module_name, name), do: :ok, else: {:error, {:invalid_module_name, name}}
+  end
+
+  defp validate_module_name(name), do: {:error, {:invalid_module_name, name}}
+
+  defp ensure_destination_available(analysis, module, range, new_name) do
+    old_name = Document.fragment(analysis.document, range.start, range.end)
+    {old_suffix, new_suffix} = Rename.Module.Diff.diff(old_name, new_name)
+    target_name = module |> Formats.module() |> String.replace_suffix(old_suffix, new_suffix)
+
+    if target_name == Formats.module(module) do
+      :ok
+    else
+      check_destination(target_name)
+    end
+  end
+
+  defp check_destination(target_name) do
+    case ManagerApi.search_store_prefix(Engine.get_project(), target_name,
+           type: :module,
+           subtype: :definition
+         ) do
+      {:ok, definitions} -> check_definitions(definitions, target_name)
+      {:error, _reason} = error -> error
+      [] -> {:error, :search_store_unavailable}
+    end
+  end
+
+  defp check_definitions(definitions, target_name) do
+    Enum.find_value(definitions, :ok, fn definition ->
+      name = Formats.module(definition.subject)
+
+      if name == target_name or String.starts_with?(name, target_name <> ".") do
+        {:error, {:module_already_exists, name}}
+      end
+    end)
   end
 
   defp start_progress do

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -36,9 +36,15 @@ defmodule Engine.CodeMod.Rename do
   of document changes that should be applied.
 
   """
-  @spec rename(Analysis.t(), Position.t(), String.t(), String.t() | nil) ::
+  @spec rename(Analysis.t(), Position.t(), String.t(), String.t() | nil, boolean()) ::
           {:ok, [Document.Changes.t()]} | {:error, term()}
-  def rename(%Analysis{} = analysis, %Position{} = position, new_name, _client_name) do
+  def rename(
+        %Analysis{} = analysis,
+        %Position{} = position,
+        new_name,
+        _client_name,
+        rename_files? \\ true
+      ) do
     if Process.whereis(Commands.Rename) do
       {:error, :rename_in_progress}
     else
@@ -48,7 +54,7 @@ defmodule Engine.CodeMod.Rename do
         with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
           rename_module = Map.fetch!(@rename_mappings, renamable)
 
-          case rename_module.rename(analysis, range, new_name, entity) do
+          case rename_module.rename(analysis, range, new_name, entity, rename_files?) do
             {:error, _reason} = error -> error
             document_changes -> {:ok, document_changes}
           end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -42,35 +42,56 @@ defmodule Engine.CodeMod.Rename do
     if Process.whereis(Commands.Rename) do
       {:error, :rename_in_progress}
     else
-      with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
-        rename_module = Map.fetch!(@rename_mappings, renamable)
-        results = rename_module.rename(range, new_name, entity)
+      token = start_progress()
 
-        with :ok <- set_rename_progress(results) do
-          {:ok, results}
+      result =
+        with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
+          rename_module = Map.fetch!(@rename_mappings, renamable)
+          {:ok, rename_module.rename(range, new_name, entity)}
         end
+
+      case result do
+        {:ok, []} = result ->
+          complete(token, result)
+
+        {:ok, document_changes} = result ->
+          with :ok <- set_rename_progress(document_changes, token) do
+            result
+          end
+
+        {:error, _reason} = error ->
+          complete(token, error)
       end
     end
   end
 
-  defp set_rename_progress([]), do: :ok
+  defp start_progress do
+    case Progress.begin("Renaming", message: "Calculating edits") do
+      {:ok, token} -> token
+      {:error, _} -> Progress.noop_token()
+    end
+  end
 
   # Progress tracking is optional - if the infrastructure isn't running
   # (e.g., in tests), we just skip it silently
-  defp set_rename_progress(document_changes_list) do
-    case do_set_rename_progress(document_changes_list) do
+  defp set_rename_progress(document_changes_list, token) do
+    on_update_progress = fn _delta, message -> Progress.report(token, message: message) end
+    on_complete = fn -> Progress.complete(token) end
+
+    case do_set_rename_progress(document_changes_list, on_update_progress, on_complete) do
       {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> {:error, :rename_in_progress}
-      {:error, {:already_buffering, _pid}} -> {:error, :rename_in_progress}
-      _ -> :ok
+      {:error, {:already_started, _pid}} -> complete(token, {:error, :rename_in_progress})
+      {:error, {:already_buffering, _pid}} -> complete(token, {:error, :rename_in_progress})
+      _ -> complete(token, :ok)
     end
-  rescue
-    _ -> :ok
-  catch
-    :exit, _ -> :ok
   end
 
-  defp do_set_rename_progress(document_changes_list) do
+  defp complete(token, result) do
+    Progress.complete(token)
+    result
+  end
+
+  defp do_set_rename_progress(document_changes_list, on_update_progress, on_complete) do
     uri_to_expected_operation = uri_to_expected_operation(document_changes_list)
 
     {paths_to_delete, paths_to_reindex} =
@@ -85,30 +106,13 @@ defmodule Engine.CodeMod.Rename do
 
     paths_to_delete = Enum.reject(paths_to_delete, &is_nil/1)
 
-    {on_update_progress, on_complete} =
-      case Progress.begin("Renaming") do
-        {:ok, token} ->
-          {fn _delta, message -> Progress.report(token, message: message) end,
-           fn -> Progress.complete(token) end}
-
-        {:error, _} ->
-          {fn _delta, _message -> :ok end, fn -> :ok end}
-      end
-
-    case Commands.RenameSupervisor.start_renaming(
-           uri_to_expected_operation,
-           paths_to_reindex,
-           paths_to_delete,
-           on_update_progress,
-           on_complete
-         ) do
-      {:ok, _pid} = result ->
-        result
-
-      {:error, _reason} = error ->
-        on_complete.()
-        error
-    end
+    Commands.RenameSupervisor.start_renaming(
+      uri_to_expected_operation,
+      paths_to_reindex,
+      paths_to_delete,
+      on_update_progress,
+      on_complete
+    )
   end
 
   defp uri_to_expected_operation(document_changes_list) do

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -35,33 +35,43 @@ defmodule Engine.CodeMod.Rename do
   Renames the entity at the given position to `new_name`, returning a list
   of document changes that should be applied.
 
-  The `client_name` parameter is used to determine client-specific behavior
-  for progress tracking (e.g., VSCode sends different events than Neovim).
   """
   @spec rename(Analysis.t(), Position.t(), String.t(), String.t() | nil) ::
           {:ok, [Document.Changes.t()]} | {:error, term()}
-  def rename(%Analysis{} = analysis, %Position{} = position, new_name, client_name) do
-    with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
-      rename_module = Map.fetch!(@rename_mappings, renamable)
-      results = rename_module.rename(range, new_name, entity)
-      set_rename_progress(results, client_name)
-      {:ok, results}
+  def rename(%Analysis{} = analysis, %Position{} = position, new_name, _client_name) do
+    if Process.whereis(Commands.Rename) do
+      {:error, :rename_in_progress}
+    else
+      with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
+        rename_module = Map.fetch!(@rename_mappings, renamable)
+        results = rename_module.rename(range, new_name, entity)
+
+        with :ok <- set_rename_progress(results) do
+          {:ok, results}
+        end
+      end
     end
   end
 
+  defp set_rename_progress([]), do: :ok
+
   # Progress tracking is optional - if the infrastructure isn't running
   # (e.g., in tests), we just skip it silently
-  defp set_rename_progress(document_changes_list, client_name) do
-    do_set_rename_progress(document_changes_list, client_name)
+  defp set_rename_progress(document_changes_list) do
+    case do_set_rename_progress(document_changes_list) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> {:error, :rename_in_progress}
+      {:error, {:already_buffering, _pid}} -> {:error, :rename_in_progress}
+      _ -> :ok
+    end
   rescue
     _ -> :ok
   catch
     :exit, _ -> :ok
   end
 
-  defp do_set_rename_progress(document_changes_list, client_name) do
-    uri_to_expected_operation =
-      uri_to_expected_operation(client_name, document_changes_list)
+  defp do_set_rename_progress(document_changes_list) do
+    uri_to_expected_operation = uri_to_expected_operation(document_changes_list)
 
     {paths_to_delete, paths_to_reindex} =
       for %Document.Changes{rename_file: rename_file, document: document} <- document_changes_list do
@@ -85,45 +95,27 @@ defmodule Engine.CodeMod.Rename do
           {fn _delta, _message -> :ok end, fn -> :ok end}
       end
 
-    Commands.RenameSupervisor.start_renaming(
-      uri_to_expected_operation,
-      paths_to_reindex,
-      paths_to_delete,
-      on_update_progress,
-      on_complete
-    )
+    case Commands.RenameSupervisor.start_renaming(
+           uri_to_expected_operation,
+           paths_to_reindex,
+           paths_to_delete,
+           on_update_progress,
+           on_complete
+         ) do
+      {:ok, _pid} = result ->
+        result
+
+      {:error, _reason} = error ->
+        on_complete.()
+        error
+    end
   end
 
-  # VSCode sends both file_changed and file_saved events
-  defp uri_to_expected_operation(client_name, document_changes_list)
-       when client_name in ["Visual Studio Code"] do
+  defp uri_to_expected_operation(document_changes_list) do
     document_changes_list
-    |> Enum.flat_map(fn %Document.Changes{document: document, rename_file: rename_file} ->
-      if rename_file do
-        # when the file is renamed, we won't receive `DidSave` for the old file
-        [
-          {rename_file.old_uri, file_changed(uri: rename_file.old_uri)},
-          {rename_file.new_uri, file_saved(uri: rename_file.new_uri)}
-        ]
-      else
-        [{document.uri, file_saved(uri: document.uri)}]
-      end
+    |> Map.new(fn %Document.Changes{document: document, rename_file: rename_file} ->
+      uri = if rename_file, do: rename_file.new_uri, else: document.uri
+      {uri, file_saved(uri: uri)}
     end)
-    |> Map.new()
-  end
-
-  # Other editors (like Neovim) may only send file_changed events
-  defp uri_to_expected_operation(_, document_changes_list) do
-    document_changes_list
-    |> Enum.flat_map(fn %Document.Changes{document: document, rename_file: rename_file} ->
-      if rename_file do
-        [{rename_file.new_uri, file_saved(uri: rename_file.new_uri)}]
-      else
-        # Some editors do not directly save the file after renaming, such as *neovim*.
-        # when the file is not renamed, we'll only received `DidChange` for the old file
-        [{document.uri, file_changed(uri: document.uri)}]
-      end
-    end)
-    |> Map.new()
   end
 end

--- a/apps/engine/lib/engine/code_mod/rename.ex
+++ b/apps/engine/lib/engine/code_mod/rename.ex
@@ -47,7 +47,11 @@ defmodule Engine.CodeMod.Rename do
       result =
         with {:ok, {renamable, entity}, range} <- Rename.Prepare.resolve(analysis, position) do
           rename_module = Map.fetch!(@rename_mappings, renamable)
-          {:ok, rename_module.rename(range, new_name, entity)}
+
+          case rename_module.rename(range, new_name, entity) do
+            {:error, _reason} = error -> error
+            document_changes -> {:ok, document_changes}
+          end
         end
 
       case result do

--- a/apps/engine/lib/engine/code_mod/rename/entry.ex
+++ b/apps/engine/lib/engine/code_mod/rename/entry.ex
@@ -1,0 +1,46 @@
+defmodule Engine.CodeMod.Rename.Entry do
+  @moduledoc """
+  An entry wrapper for search indexer entries used in rename operations.
+
+  When renaming, we rely on the `Forge.Search.Indexer.Entry`,
+  and we also need some other fields used exclusively for renaming, such as `edit_range`.
+  """
+  alias Forge.Document.Range
+  alias Forge.Search.Indexer.Entry, as: IndexerEntry
+
+  @type t :: %__MODULE__{
+          id: IndexerEntry.entry_id(),
+          path: Forge.path(),
+          subject: IndexerEntry.subject(),
+          block_range: Range.t() | nil,
+          range: Range.t(),
+          edit_range: Range.t(),
+          subtype: IndexerEntry.entry_subtype()
+        }
+
+  defstruct [
+    :id,
+    :path,
+    :subject,
+    :block_range,
+    :range,
+    :edit_range,
+    :subtype
+  ]
+
+  @doc """
+  Creates a new Entry from an IndexerEntry.
+  """
+  @spec new(IndexerEntry.t()) :: t()
+  def new(%IndexerEntry{} = indexer_entry) do
+    %__MODULE__{
+      id: indexer_entry.id,
+      path: indexer_entry.path,
+      subject: indexer_entry.subject,
+      subtype: indexer_entry.subtype,
+      block_range: indexer_entry.block_range,
+      range: indexer_entry.range,
+      edit_range: indexer_entry.range
+    }
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename/entry.ex
+++ b/apps/engine/lib/engine/code_mod/rename/entry.ex
@@ -15,6 +15,7 @@ defmodule Engine.CodeMod.Rename.Entry do
           block_range: Range.t() | nil,
           range: Range.t(),
           edit_range: Range.t(),
+          replacement: String.t() | nil,
           subtype: IndexerEntry.entry_subtype()
         }
 
@@ -25,6 +26,7 @@ defmodule Engine.CodeMod.Rename.Entry do
     :block_range,
     :range,
     :edit_range,
+    :replacement,
     :subtype
   ]
 

--- a/apps/engine/lib/engine/code_mod/rename/entry.ex
+++ b/apps/engine/lib/engine/code_mod/rename/entry.ex
@@ -6,17 +6,17 @@ defmodule Engine.CodeMod.Rename.Entry do
   and we also need some other fields used exclusively for renaming, such as `edit_range`.
   """
   alias Forge.Document.Range
-  alias Forge.Search.Indexer.Entry, as: IndexerEntry
+  alias Forge.Search.Indexer.Entry
 
   @type t :: %__MODULE__{
-          id: IndexerEntry.entry_id(),
+          id: Entry.entry_id(),
           path: Forge.path(),
-          subject: IndexerEntry.subject(),
+          subject: Entry.subject(),
           block_range: Range.t() | nil,
           range: Range.t(),
           edit_range: Range.t(),
           replacement: String.t() | nil,
-          subtype: IndexerEntry.entry_subtype()
+          subtype: Entry.entry_subtype()
         }
 
   defstruct [
@@ -31,10 +31,10 @@ defmodule Engine.CodeMod.Rename.Entry do
   ]
 
   @doc """
-  Creates a new Entry from an IndexerEntry.
+  Creates a new entry from a `Forge.Search.Indexer.Entry`.
   """
-  @spec new(IndexerEntry.t()) :: t()
-  def new(%IndexerEntry{} = indexer_entry) do
+  @spec new(Entry.t()) :: t()
+  def new(%Entry{} = indexer_entry) do
     %__MODULE__{
       id: indexer_entry.id,
       path: indexer_entry.path,

--- a/apps/engine/lib/engine/code_mod/rename/file.ex
+++ b/apps/engine/lib/engine/code_mod/rename/file.ex
@@ -1,0 +1,165 @@
+defmodule Engine.CodeMod.Rename.File do
+  @moduledoc """
+  Handles file renaming logic during module renaming operations.
+
+  Determines if a file should be renamed when its containing module is renamed,
+  based on conventions and constraints.
+  """
+  alias Engine.CodeMod.Rename.Entry
+  alias Engine.Search.Indexer
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.ProcessCache
+  alias Forge.Project
+  alias Forge.Search.Indexer.Entry, as: IndexerEntry
+
+  @doc """
+  Determines if a file should be renamed when renaming a module.
+
+  Returns a `Forge.Document.Changes.RenameFile` struct if the file should be renamed,
+  or `nil` if no file rename is needed.
+  """
+  @spec maybe_rename(Document.t(), Entry.t(), String.t()) :: Document.Changes.RenameFile.t() | nil
+  def maybe_rename(%Document{} = document, %Entry{} = entry, new_suffix) do
+    if root_module?(entry, document) do
+      rename_file(document, entry, new_suffix)
+    end
+  end
+
+  defp root_module?(%Entry{} = entry, document) do
+    entries =
+      ProcessCache.trans("#{document.uri}-entries", 50, fn ->
+        with {:ok, entries} <-
+               Indexer.Source.index_document(document, [Indexer.Extractors.Module]) do
+          entries
+        end
+      end)
+
+    case Enum.filter(entries, &(&1.block_id == :root)) do
+      [%IndexerEntry{} = root_module] ->
+        root_module.subject == entry.subject and root_module.block_range == entry.block_range
+
+      _ ->
+        false
+    end
+  end
+
+  defp rename_file(document, %Entry{} = entry, new_suffix) do
+    root_path = root_path()
+    relative_path = Path.relative_to(entry.path, root_path)
+
+    with {:ok, prefix} <- fetch_conventional_prefix(relative_path),
+         {:ok, new_name} <- fetch_new_name(document, entry, new_suffix) do
+      extname = Path.extname(entry.path)
+
+      suffix =
+        new_name
+        |> Macro.underscore()
+        |> maybe_insert_special_phoenix_folder(entry.subject, relative_path)
+
+      new_path = Path.join([root_path, prefix, "#{suffix}#{extname}"])
+      new_uri = Document.Path.ensure_uri(new_path)
+
+      if document.uri != new_uri do
+        Document.Changes.RenameFile.new(document.uri, new_uri)
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  defp root_path do
+    Project.root_path(Engine.get_project())
+  end
+
+  defp fetch_new_name(document, %Entry{} = entry, new_suffix) do
+    text_edits = [Document.Edit.new(new_suffix, entry.edit_range)]
+
+    with {:ok, edited_document} <-
+           Document.apply_content_changes(document, document.version + 1, text_edits),
+         {:ok, %{context: {:alias, alias}}} <-
+           Ast.surround_context(edited_document, entry.edit_range.start) do
+      {:ok, to_string(alias)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp fetch_conventional_prefix(path) do
+    # To obtain the new relative path, we can't directly convert from the *new module* name.
+    # We also need a part of the prefix, and Elixir has some conventions in this regard,
+    # For example:
+    #
+    # in umbrella projects, the prefix is `Path.join(["apps", app_name, "lib"])`
+    # in non-umbrella projects, most file's prefix is `"lib"`
+    #
+    # ## Examples
+    #
+    # iex> fetch_conventional_prefix("apps/remote_control/lib/lexical/remote_control/code_mod/rename/file.ex")
+    # {:ok, "apps/remote_control/lib"}
+    segments =
+      case Path.split(path) do
+        ["apps", app_name, "lib" | _] -> ["apps", app_name, "lib"]
+        ["apps", app_name, "test" | _] -> ["apps", app_name, "test"]
+        ["lib" | _] -> ["lib"]
+        ["test" | _] -> ["test"]
+        _ -> nil
+      end
+
+    if segments do
+      {:ok, Path.join(segments)}
+    else
+      :error
+    end
+  end
+
+  defp maybe_insert_special_phoenix_folder(suffix, subject, relative_path) do
+    insertions =
+      cond do
+        phoenix_controller_module?(subject) ->
+          "controllers"
+
+        phoenix_liveview_module?(subject) ->
+          "live"
+
+        phoenix_component_module?(subject) ->
+          "components"
+
+        true ->
+          nil
+      end
+
+    # In some cases, users prefer to include the `insertions` in the module name,
+    # such as `DemoWeb.Components.Icons`.
+    # In this case, we should not insert the prefix in a nested manner.
+    prefer_to_include_insertions? = insertions in Path.split(suffix)
+    old_path_contains_insertions? = insertions in Path.split(relative_path)
+
+    if not is_nil(insertions) and old_path_contains_insertions? and
+         not prefer_to_include_insertions? do
+      suffix
+      |> Path.split()
+      |> List.insert_at(1, insertions)
+      |> Path.join()
+    else
+      suffix
+    end
+  end
+
+  defp phoenix_controller_module?(module) do
+    function_exists?(module, :call, 2) and function_exists?(module, :action, 2)
+  end
+
+  defp phoenix_liveview_module?(module) do
+    function_exists?(module, :mount, 3) and function_exists?(module, :render, 1)
+  end
+
+  defp phoenix_component_module?(module) do
+    function_exists?(module, :__components__, 0) or
+      function_exists?(module, :__live__, 0)
+  end
+
+  defp function_exists?(module, function, arity) do
+    function_exported?(module, function, arity)
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename/file.ex
+++ b/apps/engine/lib/engine/code_mod/rename/file.ex
@@ -41,7 +41,6 @@ defmodule Engine.CodeMod.Rename.File do
   alias Forge.Document
   alias Forge.Formats
   alias Forge.Project
-  alias Forge.Search.Indexer.Entry, as: IndexerEntry
 
   @conventions [
     {:phoenix, "components"},
@@ -68,7 +67,8 @@ defmodule Engine.CodeMod.Rename.File do
   defp root_module?(%Entry{} = entry, document) do
     with {:ok, entries} <-
            Indexer.Source.index_document(document, [Indexer.Extractors.Module]),
-         [%IndexerEntry{} = root_module] <- Enum.filter(entries, &(&1.block_id == :root)) do
+         [%Forge.Search.Indexer.Entry{} = root_module] <-
+           Enum.filter(entries, &(&1.block_id == :root)) do
       root_module.subject == entry.subject and root_module.block_range == entry.block_range
     else
       _ -> false

--- a/apps/engine/lib/engine/code_mod/rename/file.ex
+++ b/apps/engine/lib/engine/code_mod/rename/file.ex
@@ -1,25 +1,64 @@
 defmodule Engine.CodeMod.Rename.File do
   @moduledoc """
-  Handles file renaming logic during module renaming operations.
+  Builds file renames for module renames.
 
-  Determines if a file should be renamed when its containing module is renamed,
-  based on conventions and constraints.
+  A file rename is returned when the renamed module is the file's only
+  top-level module and the source path follows an Elixir or Phoenix naming
+  convention.
+
+  ## Examples
+
+  Regular and umbrella projects use the underscored module name:
+
+      MyApp.Users -> MyApp.Accounts
+
+      lib/my_app/users.ex
+      #=> lib/my_app/accounts.ex
+
+      apps/my_app/lib/my_app/users.ex
+      #=> apps/my_app/lib/my_app/accounts.ex
+
+  Namespace changes update the directory:
+
+      MyApp.Users -> Billing.Accounts
+
+      lib/my_app/users.ex
+      #=> lib/billing/accounts.ex
+
+  Phoenix `components`, `controllers`, and `live` directories are preserved:
+
+      MyAppWeb.UserController -> MyAppWeb.AccountController
+
+      lib/my_app_web/controllers/user_controller.ex
+      #=> lib/my_app_web/controllers/account_controller.ex
+
+  `nil` is returned for a custom source path, a nested module, or a file with
+  multiple top-level modules.
   """
   alias Engine.CodeMod.Rename.Entry
   alias Engine.Search.Indexer
   alias Forge.Ast
   alias Forge.Document
-  alias Forge.ProcessCache
+  alias Forge.Formats
   alias Forge.Project
   alias Forge.Search.Indexer.Entry, as: IndexerEntry
 
-  @doc """
-  Determines if a file should be renamed when renaming a module.
+  @conventions [
+    {:phoenix, "components"},
+    {:phoenix, "controllers"},
+    {:phoenix, "live"},
+    :standard
+  ]
 
-  Returns a `Forge.Document.Changes.RenameFile` struct if the file should be renamed,
-  or `nil` if no file rename is needed.
+  @doc """
+  Returns the file rename for `entry`, if its source path follows a supported
+  convention.
+
+  Returns `nil` when the file should remain in place, or
+  `{:error, {:file_already_exists, path}}` when the destination exists.
   """
-  @spec maybe_rename(Document.t(), Entry.t(), String.t()) :: Document.Changes.RenameFile.t() | nil
+  @spec maybe_rename(Document.t(), Entry.t(), String.t()) ::
+          Document.Changes.RenameFile.t() | nil | {:error, term()}
   def maybe_rename(%Document{} = document, %Entry{} = entry, new_suffix) do
     if root_module?(entry, document) do
       rename_file(document, entry, new_suffix)
@@ -27,49 +66,62 @@ defmodule Engine.CodeMod.Rename.File do
   end
 
   defp root_module?(%Entry{} = entry, document) do
-    entries =
-      ProcessCache.trans("#{document.uri}-entries", 50, fn ->
-        with {:ok, entries} <-
-               Indexer.Source.index_document(document, [Indexer.Extractors.Module]) do
-          entries
-        end
-      end)
-
-    case Enum.filter(entries, &(&1.block_id == :root)) do
-      [%IndexerEntry{} = root_module] ->
-        root_module.subject == entry.subject and root_module.block_range == entry.block_range
-
-      _ ->
-        false
+    with {:ok, entries} <-
+           Indexer.Source.index_document(document, [Indexer.Extractors.Module]),
+         [%IndexerEntry{} = root_module] <- Enum.filter(entries, &(&1.block_id == :root)) do
+      root_module.subject == entry.subject and root_module.block_range == entry.block_range
+    else
+      _ -> false
     end
   end
 
   defp rename_file(document, %Entry{} = entry, new_suffix) do
-    root_path = root_path()
+    root_path = Project.root_path(Engine.get_project())
     relative_path = Path.relative_to(entry.path, root_path)
+    extname = Path.extname(entry.path)
 
     with {:ok, prefix} <- fetch_conventional_prefix(relative_path),
+         {:ok, convention} <- fetch_convention(entry, relative_path, prefix, extname),
          {:ok, new_name} <- fetch_new_name(document, entry, new_suffix) do
-      extname = Path.extname(entry.path)
-
-      suffix =
-        new_name
-        |> Macro.underscore()
-        |> maybe_insert_special_phoenix_folder(entry.subject, relative_path)
-
+      suffix = conventional_suffix(new_name, convention)
       new_path = Path.join([root_path, prefix, "#{suffix}#{extname}"])
       new_uri = Document.Path.ensure_uri(new_path)
 
-      if document.uri != new_uri do
-        Document.Changes.RenameFile.new(document.uri, new_uri)
+      cond do
+        document.uri == new_uri -> nil
+        File.exists?(new_path) -> {:error, {:file_already_exists, new_path}}
+        true -> Document.Changes.RenameFile.new(document.uri, new_uri)
       end
     else
       _ -> nil
     end
   end
 
-  defp root_path do
-    Project.root_path(Engine.get_project())
+  defp fetch_convention(entry, relative_path, prefix, extname) do
+    Enum.find_value(@conventions, :error, fn convention ->
+      expected_path =
+        Path.join([prefix, "#{conventional_suffix(entry.subject, convention)}#{extname}"])
+
+      if relative_path == expected_path, do: {:ok, convention}
+    end)
+  end
+
+  defp conventional_suffix(module, :standard) when is_atom(module) do
+    module |> Formats.module() |> Macro.underscore()
+  end
+
+  defp conventional_suffix(module, :standard) when is_binary(module) do
+    Macro.underscore(module)
+  end
+
+  defp conventional_suffix(module, {:phoenix, folder}) do
+    module
+    |> conventional_suffix(:standard)
+    |> Path.split()
+    |> case do
+      [root, ^folder | rest] -> Path.join([root, folder | rest])
+      [root | rest] -> Path.join([root, folder | rest])
+    end
   end
 
   defp fetch_new_name(document, %Entry{} = entry, new_suffix) do
@@ -86,80 +138,15 @@ defmodule Engine.CodeMod.Rename.File do
   end
 
   defp fetch_conventional_prefix(path) do
-    # To obtain the new relative path, we can't directly convert from the *new module* name.
-    # We also need a part of the prefix, and Elixir has some conventions in this regard,
-    # For example:
-    #
-    # in umbrella projects, the prefix is `Path.join(["apps", app_name, "lib"])`
-    # in non-umbrella projects, most file's prefix is `"lib"`
-    #
-    # ## Examples
-    #
-    # iex> fetch_conventional_prefix("apps/remote_control/lib/lexical/remote_control/code_mod/rename/file.ex")
-    # {:ok, "apps/remote_control/lib"}
-    segments =
-      case Path.split(path) do
-        ["apps", app_name, "lib" | _] -> ["apps", app_name, "lib"]
-        ["apps", app_name, "test" | _] -> ["apps", app_name, "test"]
-        ["lib" | _] -> ["lib"]
-        ["test" | _] -> ["test"]
-        _ -> nil
-      end
+    case Path.split(path) do
+      ["apps", app_name, source | _] when source in ["lib", "test"] ->
+        {:ok, Path.join(["apps", app_name, source])}
 
-    if segments do
-      {:ok, Path.join(segments)}
-    else
-      :error
+      [source | _] when source in ["lib", "test"] ->
+        {:ok, source}
+
+      _ ->
+        :error
     end
-  end
-
-  defp maybe_insert_special_phoenix_folder(suffix, subject, relative_path) do
-    insertions =
-      cond do
-        phoenix_controller_module?(subject) ->
-          "controllers"
-
-        phoenix_liveview_module?(subject) ->
-          "live"
-
-        phoenix_component_module?(subject) ->
-          "components"
-
-        true ->
-          nil
-      end
-
-    # In some cases, users prefer to include the `insertions` in the module name,
-    # such as `DemoWeb.Components.Icons`.
-    # In this case, we should not insert the prefix in a nested manner.
-    prefer_to_include_insertions? = insertions in Path.split(suffix)
-    old_path_contains_insertions? = insertions in Path.split(relative_path)
-
-    if not is_nil(insertions) and old_path_contains_insertions? and
-         not prefer_to_include_insertions? do
-      suffix
-      |> Path.split()
-      |> List.insert_at(1, insertions)
-      |> Path.join()
-    else
-      suffix
-    end
-  end
-
-  defp phoenix_controller_module?(module) do
-    function_exists?(module, :call, 2) and function_exists?(module, :action, 2)
-  end
-
-  defp phoenix_liveview_module?(module) do
-    function_exists?(module, :mount, 3) and function_exists?(module, :render, 1)
-  end
-
-  defp phoenix_component_module?(module) do
-    function_exists?(module, :__components__, 0) or
-      function_exists?(module, :__live__, 0)
-  end
-
-  defp function_exists?(module, function, arity) do
-    function_exported?(module, function, arity)
   end
 end

--- a/apps/engine/lib/engine/code_mod/rename/file.ex
+++ b/apps/engine/lib/engine/code_mod/rename/file.ex
@@ -84,7 +84,10 @@ defmodule Engine.CodeMod.Rename.File do
          {:ok, convention} <- fetch_convention(entry, relative_path, prefix, extname),
          {:ok, new_name} <- fetch_new_name(document, entry, new_suffix) do
       suffix = conventional_suffix(new_name, convention)
-      new_path = Path.join([root_path, prefix, "#{suffix}#{extname}"])
+
+      new_path =
+        [root_path, prefix, "#{suffix}#{extname}"] |> Path.join() |> Forge.Path.normalize()
+
       new_uri = Document.Path.ensure_uri(new_path)
 
       cond do

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -1,0 +1,261 @@
+defmodule Engine.CodeMod.Rename.Module do
+  @moduledoc """
+  Handles module renaming logic.
+
+  This module is responsible for:
+  - Recognizing if a position is at a module definition
+  - Preparing the rename range
+  - Executing the rename across all references
+  """
+  alias Engine.CodeIntelligence.Entity
+  alias Engine.CodeMod.Rename
+  alias Engine.CodeMod.Rename.Entry
+  alias Engine.CodeMod.Rename.Module
+  alias Engine.Search.Store
+  alias Forge.Ast
+  alias Forge.Ast.Analysis
+  alias Forge.Document
+  alias Forge.Document.Edit
+  alias Forge.Document.Line
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+  alias Forge.Formats
+
+  require Logger
+  import Line
+
+  @doc """
+  Checks if the position is at a module that can be renamed.
+  """
+  @spec recognizes?(Analysis.t(), Position.t()) :: boolean()
+  def recognizes?(%Analysis{} = analysis, %Position{} = position) do
+    case resolve(analysis, position) do
+      {:ok, _, _} ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
+  Prepares the rename operation by returning the module and the range to be renamed.
+  """
+  @spec prepare(Analysis.t(), Position.t()) ::
+          {:ok, {:module, atom()}, Range.t()} | {:error, tuple() | atom()}
+  def prepare(%Analysis{} = analysis, %Position{} = position) do
+    with {:ok, {:module, _module}, _range} <- resolve(analysis, position) do
+      {module, range} = surround_the_whole_module(analysis, position)
+
+      if cursor_at_declaration?(module, range) do
+        {:ok, {:module, module}, range}
+      else
+        {:error, {:unsupported_location, :module}}
+      end
+    end
+  end
+
+  @doc """
+  Executes the rename operation, returning a list of document changes.
+  """
+  @spec rename(Range.t(), String.t(), atom()) :: [Document.Changes.t()]
+  def rename(%Range{} = old_range, new_name, module) do
+    {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
+    results = exacts(module, to_be_renamed) ++ descendants(module, to_be_renamed)
+
+    for {uri, entries} <- Enum.group_by(results, &Document.Path.ensure_uri(&1.path)),
+        result = to_document_changes(uri, entries, replacement),
+        match?({:ok, _}, result) do
+      {:ok, document_changes} = result
+      document_changes
+    end
+  end
+
+  defp resolve(%Analysis{} = analysis, %Position{} = position) do
+    case Entity.resolve(analysis, position) do
+      {:ok, {module_or_struct, module}, range} when module_or_struct in [:struct, :module] ->
+        {:ok, {:module, module}, range}
+
+      _ ->
+        {:error, :not_a_module}
+    end
+  end
+
+  defp resolve(path, %Position{} = position) do
+    uri = Document.Path.ensure_uri(path)
+
+    with {:ok, _} <- Document.Store.open_temporary(uri),
+         {:ok, _document, analysis} <- Document.Store.fetch(uri, :analysis) do
+      resolve(analysis, position)
+    end
+  end
+
+  defp cursor_at_declaration?(module, rename_range) do
+    case Store.exact(module, type: :module, subtype: :definition) do
+      {:ok, [definition]} ->
+        rename_range == definition.range
+
+      _ ->
+        false
+    end
+  end
+
+  defp surround_the_whole_module(analysis, position) do
+    # When renaming occurs, we want users to be able to choose any place in the defining module,
+    # not just the last local module, like: `defmodule |Foo.Bar do` also works.
+    {:ok, %{end: {_end_line, end_character}}} = Ast.surround_context(analysis, position)
+    end_position = %{position | character: end_character - 1}
+    {:ok, {:module, module}, range} = resolve(analysis, end_position)
+    {module, range}
+  end
+
+  defp exacts(module, to_be_renamed) do
+    module
+    |> query_for_exacts()
+    |> Enum.filter(&entry_matching?(&1, to_be_renamed))
+    |> adjust_range_for_exacts(to_be_renamed)
+  end
+
+  defp descendants(module, to_be_renamed) do
+    module
+    |> query_for_descendants()
+    |> Enum.filter(&(entry_matching?(&1, to_be_renamed) and has_dots_in_range?(&1)))
+    |> adjust_range_for_descendants(module, to_be_renamed)
+  end
+
+  defp query_for_exacts(module) do
+    module_string = Formats.module(module)
+
+    case Store.exact(module_string, type: :module) do
+      {:ok, entries} -> Enum.map(entries, &Entry.new/1)
+      {:error, _} -> []
+    end
+  end
+
+  defp query_for_descendants(module) do
+    module_string = Formats.module(module)
+    prefix = "#{module_string}."
+
+    case Store.prefix(prefix, type: :module) do
+      {:ok, entries} -> Enum.map(entries, &Entry.new/1)
+      {:error, _} -> []
+    end
+  end
+
+  defp maybe_rename_file(document, entries, replacement) do
+    entries
+    |> Enum.map(&Rename.File.maybe_rename(document, &1, replacement))
+    # every group should have only one `rename_file`
+    |> Enum.find(&(not is_nil(&1)))
+  end
+
+  defp entry_matching?(entry, to_be_renamed) do
+    entry.range |> range_text() |> String.contains?(to_be_renamed)
+  end
+
+  defp has_dots_in_range?(entry) do
+    entry.range |> range_text() |> String.contains?(".")
+  end
+
+  defp adjust_range_for_exacts(entries, to_be_renamed) do
+    old_suffix_length = String.length(to_be_renamed)
+
+    for %Entry{} = entry <- entries do
+      start_character = entry.edit_range.end.character - old_suffix_length
+      put_in(entry.edit_range.start.character, start_character)
+    end
+  end
+
+  defp adjust_range_for_descendants(entries, module, to_be_renamed) do
+    for %Entry{} = entry <- entries,
+        range_text = range_text(entry.edit_range),
+        matches = matches(range_text, to_be_renamed),
+        result = resolve_module_range(entry, module, matches),
+        match?({:ok, _}, result) do
+      {_, range} = result
+      %{entry | edit_range: range}
+    end
+  end
+
+  defp range_text(range) do
+    line(text: text) = range.end.context_line
+    String.slice(text, range.start.character - 1, range.end.character - range.start.character)
+  end
+
+  defp resolve_module_range(_entry, _module, []) do
+    {:error, :not_found}
+  end
+
+  defp resolve_module_range(entry, module, [[{start, length}]]) do
+    range = adjust_range_characters(entry.edit_range, {start, length})
+
+    with {:ok, {:module, ^module}, _} <- resolve(entry.path, range.end) do
+      {:ok, range}
+    end
+  end
+
+  defp resolve_module_range(entry, module, [[{start, length}] | tail] = _matches) do
+    # This function is mainly for the duplicated suffixes
+    # For example, if we have a module named `Foo.Bar.Foo.Bar` and we want to rename it to `Foo.Bar.Baz`
+    # The `Foo.Bar` will be duplicated in the range text, so we need to resolve the correct range
+    # and only rename the second occurrence of `Foo.Bar`
+    start_character = entry.edit_range.start.character + start
+    position = %{entry.edit_range.start | character: start_character}
+
+    with {:ok, {:module, result}, range} <- resolve(entry.path, position) do
+      if result == module do
+        range = adjust_range_characters(range, {start, length})
+        {:ok, range}
+      else
+        resolve_module_range(entry, module, tail)
+      end
+    end
+  end
+
+  defp matches(range_text, "") do
+    # When expanding a module, the to_be_renamed is an empty string,
+    # so we need to scan the module before the period
+    for [{start, length}] <- Regex.scan(~r/\w+(?=\.)/, range_text, return: :index) do
+      [{start + length, 0}]
+    end
+  end
+
+  defp matches(range_text, to_be_renamed) do
+    Regex.scan(~r/#{to_be_renamed}/, range_text, return: :index)
+  end
+
+  defp adjust_range_characters(%Range{} = range, {start, length} = _matched_old_suffix) do
+    start_character = range.start.character + start
+    end_character = start_character + length
+
+    range
+    |> put_in([:start, :character], start_character)
+    |> put_in([:end, :character], end_character)
+  end
+
+  defp to_document_changes(uri, entries, replacement) do
+    with {:ok, document} <- Document.Store.open_temporary(uri) do
+      rename_file = maybe_rename_file(document, entries, replacement)
+
+      edits =
+        Enum.map(entries, fn entry ->
+          reference? = entry.subtype == :reference
+
+          if reference? and not ancestor_is_alias?(document, entry.edit_range.start) do
+            replacement = replacement |> String.split(".") |> Enum.at(-1)
+            Edit.new(replacement, entry.edit_range)
+          else
+            Edit.new(replacement, entry.edit_range)
+          end
+        end)
+
+      {:ok, Document.Changes.new(document, edits, rename_file)}
+    end
+  end
+
+  defp ancestor_is_alias?(%Document{} = document, %Position{} = position) do
+    document
+    |> Ast.cursor_path(position)
+    |> Enum.any?(&match?({:alias, _, _}, &1))
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -306,7 +306,7 @@ defmodule Engine.CodeMod.Rename.Module do
   end
 
   defp matches(range_text, to_be_renamed) do
-    Regex.scan(~r/#{to_be_renamed}/, range_text, return: :index)
+    Regex.scan(~r/#{Regex.escape(to_be_renamed)}/, range_text, return: :index)
   end
 
   defp adjust_range_characters(%Range{} = range, {start, length} = _matched_old_suffix) do

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -58,18 +58,26 @@ defmodule Engine.CodeMod.Rename.Module do
   @doc """
   Executes the rename operation, returning a list of document changes.
   """
-  @spec rename(Range.t(), String.t(), atom()) :: [Document.Changes.t()]
+  @spec rename(Range.t(), String.t(), atom()) ::
+          [Document.Changes.t()] | {:error, term()}
   def rename(%Range{} = old_range, new_name, module) do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
 
     results =
       exacts(module, to_be_renamed, replacement, new_name) ++ descendants(module, to_be_renamed)
 
-    for {uri, entries} <- Enum.group_by(results, &Document.Path.ensure_uri(&1.path)),
-        result = to_document_changes(uri, entries, replacement),
-        match?({:ok, _}, result) do
-      {:ok, document_changes} = result
-      document_changes
+    results
+    |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
+    |> Enum.reduce_while([], fn {uri, entries}, changes ->
+      case to_document_changes(uri, entries, replacement) do
+        {:ok, document_changes} -> {:cont, [document_changes | changes]}
+        {:error, {:file_already_exists, _path}} = error -> {:halt, error}
+        {:error, _reason} -> {:cont, changes}
+      end
+    end)
+    |> case do
+      {:error, _reason} = error -> error
+      changes -> Enum.reverse(changes)
     end
   end
 
@@ -147,10 +155,16 @@ defmodule Engine.CodeMod.Rename.Module do
   end
 
   defp maybe_rename_file(document, entries, replacement) do
-    entries
-    |> Enum.map(&Rename.File.maybe_rename(document, &1, replacement))
-    # every group should have only one `rename_file`
-    |> Enum.find(&(not is_nil(&1)))
+    case Enum.find(entries, &(&1.subtype == :definition)) do
+      nil ->
+        {:ok, nil}
+
+      entry ->
+        case Rename.File.maybe_rename(document, entry, replacement) do
+          {:error, _reason} = error -> error
+          rename_file -> {:ok, rename_file}
+        end
+    end
   end
 
   defp entry_matching?(entry, to_be_renamed) do
@@ -263,9 +277,8 @@ defmodule Engine.CodeMod.Rename.Module do
 
   defp to_document_changes(uri, entries, replacement) do
     with {:ok, _document} <- Document.Store.open_temporary(uri),
-         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis) do
-      rename_file = maybe_rename_file(document, entries, replacement)
-
+         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis),
+         {:ok, rename_file} <- maybe_rename_file(document, entries, replacement) do
       edits =
         entries
         |> Enum.reject(&explicit_alias_reference?(document, analysis, &1))

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -60,9 +60,15 @@ defmodule Engine.CodeMod.Rename.Module do
   @doc """
   Executes the rename operation, returning a list of document changes.
   """
-  @spec rename(Analysis.t(), Range.t(), String.t(), atom()) ::
+  @spec rename(Analysis.t(), Range.t(), String.t(), atom(), boolean()) ::
           [Document.Changes.t()] | {:error, term()}
-  def rename(%Analysis{} = analysis, %Range{} = old_range, new_name, module) do
+  def rename(
+        %Analysis{} = analysis,
+        %Range{} = old_range,
+        new_name,
+        module,
+        rename_files? \\ true
+      ) do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
 
     with {:ok, declaration} <- declaration_entry(analysis, old_range, module),
@@ -71,7 +77,7 @@ defmodule Engine.CodeMod.Rename.Module do
       (exacts ++ descendants)
       |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
       |> Enum.reduce_while([], fn {uri, entries}, changes ->
-        case to_document_changes(uri, entries, replacement) do
+        case to_document_changes(uri, entries, replacement, rename_files?) do
           {:ok, document_changes} -> {:cont, [document_changes | changes]}
           {:error, {:file_already_exists, _path}} = error -> {:halt, error}
           {:error, _reason} -> {:cont, changes}
@@ -189,7 +195,9 @@ defmodule Engine.CodeMod.Rename.Module do
   defp to_entries({:error, _reason} = error), do: error
   defp to_entries([]), do: {:error, :search_store_unavailable}
 
-  defp maybe_rename_file(document, entries, replacement) do
+  defp maybe_rename_file(_document, _entries, _replacement, false), do: {:ok, nil}
+
+  defp maybe_rename_file(document, entries, replacement, true) do
     case Enum.find(entries, &(&1.subtype == :definition)) do
       nil ->
         {:ok, nil}
@@ -310,10 +318,12 @@ defmodule Engine.CodeMod.Rename.Module do
     |> put_in([:end, :character], end_character)
   end
 
-  defp to_document_changes(uri, entries, replacement) do
+  defp to_document_changes(uri, entries, replacement, rename_files?) do
     with {:ok, _document} <- Document.Store.open_temporary(uri),
-         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis),
-         {:ok, rename_file} <- maybe_rename_file(document, entries, replacement) do
+         {:ok, document, analysis, origin} <-
+           Document.Store.fetch_with_origin(uri, :analysis),
+         {:ok, rename_file} <-
+           maybe_rename_file(document, entries, replacement, rename_files?) do
       edits =
         entries
         |> Enum.reject(&explicit_alias_reference?(document, analysis, &1))
@@ -330,7 +340,8 @@ defmodule Engine.CodeMod.Rename.Module do
           end
         end)
 
-      {:ok, Document.Changes.new(document, edits, rename_file)}
+      expected_version = if origin == :open, do: document.version
+      {:ok, Document.Changes.new(document, edits, rename_file, expected_version)}
     end
   end
 

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -16,13 +16,15 @@ defmodule Engine.CodeMod.Rename.Module do
   alias Engine.ManagerApi
   alias Forge.Ast
   alias Forge.Ast.Analysis
-  alias Forge.Ast.Analysis.Alias, as: AstAlias
+  alias Forge.Ast.Analysis.Alias
   alias Forge.Ast.Analysis.Scope
   alias Forge.Document
   alias Forge.Document.Edit
   alias Forge.Document.Position
   alias Forge.Document.Range
   alias Forge.Formats
+
+  @module_defining_forms [:defmodule, :defprotocol]
 
   @doc """
   Checks if the position is at a module that can be renamed.
@@ -47,7 +49,7 @@ defmodule Engine.CodeMod.Rename.Module do
     with {:ok, {:module, _module}, _range} <- resolve(analysis, position) do
       {module, range} = surround_the_whole_module(analysis, position)
 
-      if cursor_at_declaration?(module, range) do
+      if cursor_at_declaration?(analysis, position, range) do
         {:ok, {:module, module}, range}
       else
         {:error, {:unsupported_location, :module}}
@@ -58,26 +60,27 @@ defmodule Engine.CodeMod.Rename.Module do
   @doc """
   Executes the rename operation, returning a list of document changes.
   """
-  @spec rename(Range.t(), String.t(), atom()) ::
+  @spec rename(Analysis.t(), Range.t(), String.t(), atom()) ::
           [Document.Changes.t()] | {:error, term()}
-  def rename(%Range{} = old_range, new_name, module) do
+  def rename(%Analysis{} = analysis, %Range{} = old_range, new_name, module) do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
 
-    results =
-      exacts(module, to_be_renamed, replacement, new_name) ++ descendants(module, to_be_renamed)
-
-    results
-    |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
-    |> Enum.reduce_while([], fn {uri, entries}, changes ->
-      case to_document_changes(uri, entries, replacement) do
-        {:ok, document_changes} -> {:cont, [document_changes | changes]}
-        {:error, {:file_already_exists, _path}} = error -> {:halt, error}
-        {:error, _reason} -> {:cont, changes}
+    with {:ok, declaration} <- declaration_entry(analysis, old_range, module),
+         {:ok, exacts} <- exacts(declaration, module, to_be_renamed, replacement, new_name),
+         {:ok, descendants} <- descendants(module, to_be_renamed) do
+      (exacts ++ descendants)
+      |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
+      |> Enum.reduce_while([], fn {uri, entries}, changes ->
+        case to_document_changes(uri, entries, replacement) do
+          {:ok, document_changes} -> {:cont, [document_changes | changes]}
+          {:error, {:file_already_exists, _path}} = error -> {:halt, error}
+          {:error, _reason} -> {:cont, changes}
+        end
+      end)
+      |> case do
+        {:error, _reason} = error -> error
+        changes -> Enum.reverse(changes)
       end
-    end)
-    |> case do
-      {:error, _reason} = error -> error
-      changes -> Enum.reverse(changes)
     end
   end
 
@@ -100,17 +103,39 @@ defmodule Engine.CodeMod.Rename.Module do
     end
   end
 
-  defp cursor_at_declaration?(module, rename_range) do
-    case ManagerApi.search_store_exact(Engine.get_project(), module,
-           type: :module,
-           subtype: :definition
-         ) do
-      {:ok, [definition]} ->
-        rename_range == definition.range
-
-      _ ->
-        false
+  defp cursor_at_declaration?(analysis, position, rename_range) do
+    with {:ok, path} <- Ast.path_at(analysis, position),
+         {_, _, [name | _]} <- module_declaration(path),
+         {:ok, declaration_range} <- Forge.Ast.Range.fetch(name, analysis.document) do
+      rename_range == declaration_range
+    else
+      _ -> false
     end
+  end
+
+  defp declaration_entry(analysis, range, module) do
+    with {:ok, path} <- Ast.path_at(analysis, range.start),
+         declaration when not is_nil(declaration) <- module_declaration(path),
+         {:ok, block_range} <- Forge.Ast.Range.fetch(declaration, analysis.document) do
+      {:ok,
+       %Entry{
+         path: analysis.document.path,
+         subject: module,
+         block_range: block_range,
+         range: range,
+         edit_range: range,
+         subtype: :definition
+       }}
+    else
+      _ -> {:error, :not_a_module_declaration}
+    end
+  end
+
+  defp module_declaration(path) do
+    Enum.find(
+      path,
+      &match?({form, _, [_ | _]} when form in @module_defining_forms, &1)
+    )
   end
 
   defp surround_the_whole_module(analysis, position) do
@@ -122,37 +147,47 @@ defmodule Engine.CodeMod.Rename.Module do
     {module, range}
   end
 
-  defp exacts(module, to_be_renamed, replacement, new_name) do
-    module
-    |> query_for_exacts()
-    |> adjust_range_for_exacts(module, to_be_renamed, replacement, new_name)
+  defp exacts(declaration, module, to_be_renamed, replacement, new_name) do
+    with {:ok, entries} <- query_for_exacts(module) do
+      exacts =
+        [declaration | entries]
+        |> adjust_range_for_exacts(module, to_be_renamed, replacement, new_name)
+
+      {:ok, exacts}
+    end
   end
 
   defp descendants(module, to_be_renamed) do
-    module
-    |> query_for_descendants()
-    |> Enum.filter(&(entry_matching?(&1, to_be_renamed) and has_dots_in_range?(&1)))
-    |> adjust_range_for_descendants(module, to_be_renamed)
+    with {:ok, entries} <- query_for_descendants(module) do
+      descendants =
+        entries
+        |> Enum.filter(&(entry_matching?(&1, to_be_renamed) and has_dots_in_range?(&1)))
+        |> adjust_range_for_descendants(module, to_be_renamed)
+
+      {:ok, descendants}
+    end
   end
 
   defp query_for_exacts(module) do
     module_string = Formats.module(module)
 
-    case ManagerApi.search_store_exact(Engine.get_project(), module_string, type: :module) do
-      {:ok, entries} -> Enum.map(entries, &Entry.new/1)
-      {:error, _} -> []
-    end
+    Engine.get_project()
+    |> ManagerApi.search_store_exact(module_string, type: :module, subtype: :reference)
+    |> to_entries()
   end
 
   defp query_for_descendants(module) do
     module_string = Formats.module(module)
     prefix = "#{module_string}."
 
-    case ManagerApi.search_store_prefix(Engine.get_project(), prefix, type: :module) do
-      {:ok, entries} -> Enum.map(entries, &Entry.new/1)
-      {:error, _} -> []
-    end
+    Engine.get_project()
+    |> ManagerApi.search_store_prefix(prefix, type: :module)
+    |> to_entries()
   end
+
+  defp to_entries({:ok, entries}), do: {:ok, Enum.map(entries, &Entry.new/1)}
+  defp to_entries({:error, _reason} = error), do: error
+  defp to_entries([]), do: {:error, :search_store_unavailable}
 
   defp maybe_rename_file(document, entries, replacement) do
     case Enum.find(entries, &(&1.subtype == :definition)) do
@@ -310,8 +345,9 @@ defmodule Engine.CodeMod.Rename.Module do
         scope
         |> Scope.alias_map(entry.range.start)
         |> Enum.any?(fn
-          {as, %AstAlias{explicit_as?: true} = alias} ->
-            alias_name(as) == source and AstAlias.to_module(alias) == entry.subject
+          {as, %Alias{explicit_as?: true} = alias} ->
+            alias_name(as) == source and
+              Alias.to_module(alias) == entry.subject
 
           _alias ->
             false

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -10,6 +10,7 @@ defmodule Engine.CodeMod.Rename.Module do
   import Forge.Document.Line
 
   alias Engine.CodeIntelligence.Entity
+  alias Engine.CodeMod.Aliases
   alias Engine.CodeMod.Rename
   alias Engine.CodeMod.Rename.Entry
   alias Engine.CodeMod.Rename.Module
@@ -17,7 +18,6 @@ defmodule Engine.CodeMod.Rename.Module do
   alias Engine.Search.Indexer.Quoted
   alias Forge.Ast
   alias Forge.Ast.Analysis
-  alias Forge.Ast.Analysis.Alias
   alias Forge.Ast.Analysis.Scope
   alias Forge.Document
   alias Forge.Document.Edit
@@ -71,6 +71,8 @@ defmodule Engine.CodeMod.Rename.Module do
         rename_files? \\ true
       ) do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
+    old_name = Formats.module(module)
+    target_name = String.replace_suffix(old_name, to_be_renamed, replacement)
 
     with {:ok, declaration} <- declaration_entry(analysis, old_range, module),
          {:ok, entries} <-
@@ -78,7 +80,14 @@ defmodule Engine.CodeMod.Rename.Module do
       entries
       |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
       |> Enum.reduce_while([], fn {uri, entries}, changes ->
-        case to_document_changes(uri, entries, replacement, rename_files?) do
+        case to_document_changes(
+               uri,
+               entries,
+               replacement,
+               old_name,
+               target_name,
+               rename_files?
+             ) do
           {:ok, document_changes} -> {:cont, [document_changes | changes]}
           {:error, {:file_already_exists, _path}} = error -> {:halt, error}
           {:error, _reason} -> {:cont, changes}
@@ -361,32 +370,65 @@ defmodule Engine.CodeMod.Rename.Module do
     |> put_in([:end, :character], end_character)
   end
 
-  defp to_document_changes(uri, entries, replacement, rename_files?) do
+  defp to_document_changes(uri, entries, replacement, old_name, target_name, rename_files?) do
     with {:ok, _document} <- Document.Store.open_temporary(uri),
          {:ok, document, analysis, origin} <-
            Document.Store.fetch_with_origin(uri, :analysis),
          {:ok, rename_file} <-
            maybe_rename_file(document, entries, replacement, rename_files?) do
+      entries = Enum.reject(entries, &explicit_alias_reference?(document, analysis, &1))
+
+      {grouped_edits, entries} =
+        grouped_alias_edits(analysis, entries, old_name, target_name)
+
       edits =
         entries
-        |> Enum.reject(&explicit_alias_reference?(document, analysis, &1))
-        |> Enum.map(fn entry ->
-          reference? = entry.subtype == :reference
-          entry_replacement = entry.replacement || replacement
-
-          if is_nil(entry.replacement) and reference? and
-               not ancestor_is_alias?(document, entry.edit_range.start) do
-            replacement = replacement |> String.split(".") |> Enum.at(-1)
-            Edit.new(replacement, entry.edit_range)
-          else
-            Edit.new(entry_replacement, entry.edit_range)
-          end
-        end)
+        |> Enum.map(&edit_for_entry(document, &1, replacement))
+        |> Enum.concat(grouped_edits)
+        |> Enum.sort_by(&{&1.range.start.line, &1.range.start.character}, :desc)
 
       expected_version = if origin == :open, do: document.version
       {:ok, Document.Changes.new(document, edits, rename_file, expected_version)}
     end
   end
+
+  defp edit_for_entry(document, entry, replacement) do
+    reference? = entry.subtype == :reference
+    entry_replacement = entry.replacement || replacement
+
+    if is_nil(entry.replacement) and reference? and
+         not ancestor_is_alias?(document, entry.edit_range.start) do
+      replacement = replacement |> String.split(".") |> List.last()
+      Edit.new(replacement, entry.edit_range)
+    else
+      Edit.new(entry_replacement, entry.edit_range)
+    end
+  end
+
+  defp grouped_alias_edits(%Analysis{} = analysis, entries, old_name, target_name) do
+    {aliases, entries} =
+      Enum.reduce(entries, {%{}, []}, fn entry, {aliases, entries} ->
+        case grouped_alias_edit(analysis, entry, old_name, target_name) do
+          {:ok, alias_ast, edit} ->
+            {Map.put(aliases, alias_ast, edit), entries}
+
+          :error ->
+            {aliases, [entry | entries]}
+        end
+      end)
+
+    {Map.values(aliases), Enum.reverse(entries)}
+  end
+
+  defp grouped_alias_edit(
+         analysis,
+         %Entry{subtype: :reference} = entry,
+         old_name,
+         target_name
+       ),
+       do: Aliases.rename_grouped(analysis, entry.range.start, old_name, target_name)
+
+  defp grouped_alias_edit(_analysis, _entry, _old_name, _target_name), do: :error
 
   defp explicit_alias_reference?(document, analysis, %Entry{subtype: :reference} = entry) do
     source = range_text(entry.range)
@@ -399,9 +441,9 @@ defmodule Engine.CodeMod.Rename.Module do
         scope
         |> Scope.alias_map(entry.range.start)
         |> Enum.any?(fn
-          {as, %Alias{explicit_as?: true} = alias} ->
+          {as, %Analysis.Alias{explicit_as?: true} = alias} ->
             alias_name(as) == source and
-              Alias.to_module(alias) == entry.subject
+              Analysis.Alias.to_module(alias) == entry.subject
 
           _alias ->
             false

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -7,11 +7,13 @@ defmodule Engine.CodeMod.Rename.Module do
   - Preparing the rename range
   - Executing the rename across all references
   """
+  import Forge.Document.Line
+
   alias Engine.CodeIntelligence.Entity
   alias Engine.CodeMod.Rename
   alias Engine.CodeMod.Rename.Entry
   alias Engine.CodeMod.Rename.Module
-  alias Engine.Search.Store
+  alias Engine.ManagerApi
   alias Forge.Ast
   alias Forge.Ast.Analysis
   alias Forge.Document
@@ -20,9 +22,6 @@ defmodule Engine.CodeMod.Rename.Module do
   alias Forge.Document.Position
   alias Forge.Document.Range
   alias Forge.Formats
-
-  require Logger
-  import Line
 
   @doc """
   Checks if the position is at a module that can be renamed.
@@ -91,7 +90,10 @@ defmodule Engine.CodeMod.Rename.Module do
   end
 
   defp cursor_at_declaration?(module, rename_range) do
-    case Store.exact(module, type: :module, subtype: :definition) do
+    case ManagerApi.search_store_exact(Engine.get_project(), module,
+           type: :module,
+           subtype: :definition
+         ) do
       {:ok, [definition]} ->
         rename_range == definition.range
 
@@ -126,7 +128,7 @@ defmodule Engine.CodeMod.Rename.Module do
   defp query_for_exacts(module) do
     module_string = Formats.module(module)
 
-    case Store.exact(module_string, type: :module) do
+    case ManagerApi.search_store_exact(Engine.get_project(), module_string, type: :module) do
       {:ok, entries} -> Enum.map(entries, &Entry.new/1)
       {:error, _} -> []
     end
@@ -136,7 +138,7 @@ defmodule Engine.CodeMod.Rename.Module do
     module_string = Formats.module(module)
     prefix = "#{module_string}."
 
-    case Store.prefix(prefix, type: :module) do
+    case ManagerApi.search_store_prefix(Engine.get_project(), prefix, type: :module) do
       {:ok, entries} -> Enum.map(entries, &Entry.new/1)
       {:error, _} -> []
     end

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -16,9 +16,10 @@ defmodule Engine.CodeMod.Rename.Module do
   alias Engine.ManagerApi
   alias Forge.Ast
   alias Forge.Ast.Analysis
+  alias Forge.Ast.Analysis.Alias, as: AstAlias
+  alias Forge.Ast.Analysis.Scope
   alias Forge.Document
   alias Forge.Document.Edit
-  alias Forge.Document.Line
   alias Forge.Document.Position
   alias Forge.Document.Range
   alias Forge.Formats
@@ -60,7 +61,9 @@ defmodule Engine.CodeMod.Rename.Module do
   @spec rename(Range.t(), String.t(), atom()) :: [Document.Changes.t()]
   def rename(%Range{} = old_range, new_name, module) do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
-    results = exacts(module, to_be_renamed) ++ descendants(module, to_be_renamed)
+
+    results =
+      exacts(module, to_be_renamed, replacement, new_name) ++ descendants(module, to_be_renamed)
 
     for {uri, entries} <- Enum.group_by(results, &Document.Path.ensure_uri(&1.path)),
         result = to_document_changes(uri, entries, replacement),
@@ -111,11 +114,10 @@ defmodule Engine.CodeMod.Rename.Module do
     {module, range}
   end
 
-  defp exacts(module, to_be_renamed) do
+  defp exacts(module, to_be_renamed, replacement, new_name) do
     module
     |> query_for_exacts()
-    |> Enum.filter(&entry_matching?(&1, to_be_renamed))
-    |> adjust_range_for_exacts(to_be_renamed)
+    |> adjust_range_for_exacts(module, to_be_renamed, replacement, new_name)
   end
 
   defp descendants(module, to_be_renamed) do
@@ -159,13 +161,35 @@ defmodule Engine.CodeMod.Rename.Module do
     entry.range |> range_text() |> String.contains?(".")
   end
 
-  defp adjust_range_for_exacts(entries, to_be_renamed) do
+  defp adjust_range_for_exacts(entries, module, to_be_renamed, replacement, new_name) do
     old_suffix_length = String.length(to_be_renamed)
+    old_name = Formats.module(module)
+    old_leaf = old_name |> String.split(".") |> List.last()
+    new_leaf = new_name |> String.split(".") |> List.last()
 
-    for %Entry{} = entry <- entries do
-      start_character = entry.edit_range.end.character - old_suffix_length
-      put_in(entry.edit_range.start.character, start_character)
-    end
+    Enum.flat_map(entries, fn %Entry{} = entry ->
+      source = range_text(entry.range)
+
+      cond do
+        source == old_leaf ->
+          entry_replacement = if source == old_name, do: new_name, else: new_leaf
+          [%{entry | replacement: entry_replacement}]
+
+        source == to_be_renamed ->
+          [%{entry | replacement: new_name}]
+
+        String.ends_with?(source, ".#{to_be_renamed}") ->
+          start_character = entry.edit_range.end.character - old_suffix_length
+          entry = put_in(entry.edit_range.start.character, start_character)
+          [%{entry | replacement: replacement}]
+
+        String.contains?(source, ".") ->
+          [%{entry | replacement: new_name}]
+
+        true ->
+          []
+      end
+    end)
   end
 
   defp adjust_range_for_descendants(entries, module, to_be_renamed) do
@@ -236,24 +260,66 @@ defmodule Engine.CodeMod.Rename.Module do
   end
 
   defp to_document_changes(uri, entries, replacement) do
-    with {:ok, document} <- Document.Store.open_temporary(uri) do
+    with {:ok, _document} <- Document.Store.open_temporary(uri),
+         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis) do
       rename_file = maybe_rename_file(document, entries, replacement)
 
       edits =
-        Enum.map(entries, fn entry ->
+        entries
+        |> Enum.reject(&explicit_alias_reference?(document, analysis, &1))
+        |> Enum.map(fn entry ->
           reference? = entry.subtype == :reference
+          entry_replacement = entry.replacement || replacement
 
-          if reference? and not ancestor_is_alias?(document, entry.edit_range.start) do
+          if is_nil(entry.replacement) and reference? and
+               not ancestor_is_alias?(document, entry.edit_range.start) do
             replacement = replacement |> String.split(".") |> Enum.at(-1)
             Edit.new(replacement, entry.edit_range)
           else
-            Edit.new(replacement, entry.edit_range)
+            Edit.new(entry_replacement, entry.edit_range)
           end
         end)
 
       {:ok, Document.Changes.new(document, edits, rename_file)}
     end
   end
+
+  defp explicit_alias_reference?(document, analysis, %Entry{subtype: :reference} = entry) do
+    source = range_text(entry.range)
+
+    case {alias_target?(document, entry), Analysis.scopes_at(analysis, entry.range.start)} do
+      {true, _scopes} ->
+        false
+
+      {false, [%Scope{} = scope | _]} ->
+        scope
+        |> Scope.alias_map(entry.range.start)
+        |> Enum.any?(fn
+          {as, %AstAlias{explicit_as?: true} = alias} ->
+            alias_name(as) == source and AstAlias.to_module(alias) == entry.subject
+
+          _alias ->
+            false
+        end)
+
+      {false, []} ->
+        false
+    end
+  end
+
+  defp explicit_alias_reference?(_document, _analysis, _entry), do: false
+
+  defp alias_target?(document, entry) do
+    with {:ok, path} <- Ast.path_at(document, entry.range.start),
+         {:alias, _, [target | _options]} <- Enum.find(path, &match?({:alias, _, _}, &1)),
+         {:ok, target_range} <- Ast.Range.fetch(target, document) do
+      Range.contains?(target_range, entry.range.start)
+    else
+      _ -> false
+    end
+  end
+
+  defp alias_name(as), do: Enum.map_join(as, ".", &Atom.to_string/1)
 
   defp ancestor_is_alias?(%Document{} = document, %Position{} = position) do
     document

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -172,7 +172,9 @@ defmodule Engine.CodeMod.Rename.Module do
 
       cond do
         source == old_leaf ->
-          entry_replacement = if source == old_name, do: new_name, else: new_leaf
+          entry_replacement =
+            if source == old_name or entry.subtype == :definition, do: new_name, else: new_leaf
+
           [%{entry | replacement: entry_replacement}]
 
         source == to_be_renamed ->

--- a/apps/engine/lib/engine/code_mod/rename/module.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module.ex
@@ -14,6 +14,7 @@ defmodule Engine.CodeMod.Rename.Module do
   alias Engine.CodeMod.Rename.Entry
   alias Engine.CodeMod.Rename.Module
   alias Engine.ManagerApi
+  alias Engine.Search.Indexer.Quoted
   alias Forge.Ast
   alias Forge.Ast.Analysis
   alias Forge.Ast.Analysis.Alias
@@ -72,9 +73,9 @@ defmodule Engine.CodeMod.Rename.Module do
     {to_be_renamed, replacement} = old_range |> range_text() |> Module.Diff.diff(new_name)
 
     with {:ok, declaration} <- declaration_entry(analysis, old_range, module),
-         {:ok, exacts} <- exacts(declaration, module, to_be_renamed, replacement, new_name),
-         {:ok, descendants} <- descendants(module, to_be_renamed) do
-      (exacts ++ descendants)
+         {:ok, entries} <-
+           references(declaration, module, to_be_renamed, replacement, new_name) do
+      entries
       |> Enum.group_by(&Document.Path.ensure_uri(&1.path))
       |> Enum.reduce_while([], fn {uri, entries}, changes ->
         case to_document_changes(uri, entries, replacement, rename_files?) do
@@ -153,24 +154,36 @@ defmodule Engine.CodeMod.Rename.Module do
     {module, range}
   end
 
-  defp exacts(declaration, module, to_be_renamed, replacement, new_name) do
-    with {:ok, entries} <- query_for_exacts(module) do
+  defp references(declaration, module, to_be_renamed, replacement, new_name) do
+    module_string = Formats.module(module)
+    prefix = "#{module_string}."
+
+    with {:ok, exact_entries} <- query_for_exacts(module),
+         {:ok, descendant_entries} <- query_for_descendants(module) do
+      entries =
+        refresh_entries(exact_entries ++ descendant_entries, fn entry ->
+          entry.type == :module and
+            (Formats.module(entry.subject) == module_string or
+               String.starts_with?(Formats.module(entry.subject), prefix))
+        end)
+
       exacts =
-        [declaration | entries]
+        entries
+        |> Enum.filter(
+          &(&1.subtype == :reference and Formats.module(&1.subject) == module_string)
+        )
+        |> then(&[declaration | &1])
         |> adjust_range_for_exacts(module, to_be_renamed, replacement, new_name)
 
-      {:ok, exacts}
-    end
-  end
-
-  defp descendants(module, to_be_renamed) do
-    with {:ok, entries} <- query_for_descendants(module) do
       descendants =
         entries
-        |> Enum.filter(&(entry_matching?(&1, to_be_renamed) and has_dots_in_range?(&1)))
+        |> Enum.filter(
+          &(String.starts_with?(Formats.module(&1.subject), prefix) and
+              entry_matching?(&1, to_be_renamed) and has_dots_in_range?(&1))
+        )
         |> adjust_range_for_descendants(module, to_be_renamed)
 
-      {:ok, descendants}
+      {:ok, exacts ++ descendants}
     end
   end
 
@@ -194,6 +207,36 @@ defmodule Engine.CodeMod.Rename.Module do
   defp to_entries({:ok, entries}), do: {:ok, Enum.map(entries, &Entry.new/1)}
   defp to_entries({:error, _reason} = error), do: error
   defp to_entries([]), do: {:error, :search_store_unavailable}
+
+  defp refresh_entries(entries, predicate) do
+    entries
+    |> Enum.group_by(& &1.path)
+    |> Enum.flat_map(fn {path, _entries} ->
+      case refresh_path(path, predicate) do
+        {:ok, current} -> current
+        {:error, _reason} -> []
+      end
+    end)
+  end
+
+  defp refresh_path(path, predicate) do
+    uri = Document.Path.ensure_uri(path)
+
+    with {:ok, _document} <- Document.Store.open_temporary(uri),
+         {:ok, _document, %Analysis{valid?: true} = analysis} <-
+           Document.Store.fetch(uri, :analysis),
+         {:ok, current_entries} <- Quoted.index_with_cleanup(analysis) do
+      current_entries =
+        current_entries
+        |> Enum.filter(predicate)
+        |> Enum.map(&Entry.new/1)
+
+      {:ok, current_entries}
+    else
+      {:ok, _document, %Analysis{valid?: false}} -> {:error, {:invalid_document, path}}
+      {:error, _reason} = error -> error
+    end
+  end
 
   defp maybe_rename_file(_document, _entries, _replacement, false), do: {:ok, nil}
 

--- a/apps/engine/lib/engine/code_mod/rename/module/diff.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module/diff.ex
@@ -1,0 +1,50 @@
+defmodule Engine.CodeMod.Rename.Module.Diff do
+  @moduledoc """
+  A module for computing the diff between old and new module names during renaming.
+  """
+
+  @doc """
+  Computes the parts of the module name that need to be renamed and their replacements.
+
+  Returns a tuple `{to_be_renamed, replacement}` where:
+  - `to_be_renamed` is the suffix of the old name that needs to be changed
+  - `replacement` is what it should be changed to
+
+  ## Examples
+
+      iex> diff("TopLevel.Parent.Child", "TopLevel.Renamed.Child")
+      {"Parent", "Renamed"}
+
+      iex> diff("TopLevel.Parent.Child", "TopLevel.Child")
+      {"Parent.Child", "Child"}
+
+      iex> diff("Foo.Bar", "Baz.Qux")
+      {"Foo.Bar", "Baz.Qux"}
+  """
+  @spec diff(String.t(), String.t()) :: {String.t(), String.t()}
+  def diff(old_name, new_name) do
+    with [{:eq, eq} | _] <- String.myers_difference(old_name, new_name),
+         equal_segment <- trim_last_dot_part(eq),
+         true <- not is_nil(equal_segment) do
+      to_be_renamed = replace_leading_eq(old_name, equal_segment)
+      replacement = replace_leading_eq(new_name, equal_segment)
+      {to_be_renamed, replacement}
+    else
+      _ ->
+        {old_name, new_name}
+    end
+  end
+
+  defp trim_last_dot_part(module) do
+    split = module |> String.reverse() |> String.split(".", parts: 2)
+
+    if length(split) == 2 do
+      [_, rest] = split
+      rest |> String.reverse()
+    end
+  end
+
+  defp replace_leading_eq(module, eq) do
+    module |> String.replace(~r"^#{eq}", "") |> String.trim_leading(".")
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename/module/diff.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module/diff.ex
@@ -45,6 +45,6 @@ defmodule Engine.CodeMod.Rename.Module.Diff do
   end
 
   defp replace_leading_eq(module, eq) do
-    module |> String.replace(~r"^#{eq}", "") |> String.trim_leading(".")
+    module |> String.replace_prefix(eq, "") |> String.trim_leading(".")
   end
 end

--- a/apps/engine/lib/engine/code_mod/rename/module/diff.ex
+++ b/apps/engine/lib/engine/code_mod/rename/module/diff.ex
@@ -24,7 +24,7 @@ defmodule Engine.CodeMod.Rename.Module.Diff do
   @spec diff(String.t(), String.t()) :: {String.t(), String.t()}
   def diff(old_name, new_name) do
     with [{:eq, eq} | _] <- String.myers_difference(old_name, new_name),
-         equal_segment <- trim_last_dot_part(eq),
+         equal_segment = trim_last_dot_part(eq),
          true <- not is_nil(equal_segment) do
       to_be_renamed = replace_leading_eq(old_name, equal_segment)
       replacement = replace_leading_eq(new_name, equal_segment)

--- a/apps/engine/lib/engine/code_mod/rename/prepare.ex
+++ b/apps/engine/lib/engine/code_mod/rename/prepare.ex
@@ -34,8 +34,8 @@ defmodule Engine.CodeMod.Rename.Prepare do
       {:error, {:unsupported_location, _}} ->
         {:ok, nil}
 
-      {:error, {:unsupported_entity, entity_type}} ->
-        {:error, "Renaming #{inspect(entity_type)} is not supported for now"}
+      {:error, {:unsupported_entity, _entity_type}} ->
+        {:ok, nil}
 
       {:error, error} ->
         {:error, error}

--- a/apps/engine/lib/engine/code_mod/rename/prepare.ex
+++ b/apps/engine/lib/engine/code_mod/rename/prepare.ex
@@ -1,0 +1,70 @@
+defmodule Engine.CodeMod.Rename.Prepare do
+  @moduledoc """
+  Handles the preparation phase of rename operations.
+
+  The preparation phase determines:
+  - Whether the entity at the cursor can be renamed
+  - What the current name is
+  - What range should be replaced
+  """
+  alias Engine.CodeIntelligence.Entity
+  alias Engine.CodeMod.Rename
+  alias Forge.Ast.Analysis
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+  alias Forge.Formats
+
+  require Logger
+
+  @renaming_modules [Rename.Module]
+
+  @doc """
+  Prepares a rename operation at the given position.
+
+  Returns `{:ok, module_name_string, range}` if the entity can be renamed,
+  or an appropriate error.
+  """
+  @spec prepare(Analysis.t(), Position.t()) ::
+          {:ok, String.t(), Range.t()} | {:ok, nil} | {:error, term()}
+  def prepare(%Analysis{} = analysis, %Position{} = position) do
+    case resolve(analysis, position) do
+      {:ok, {:module, module}, range} ->
+        {:ok, Formats.module(module), range}
+
+      {:error, {:unsupported_location, _}} ->
+        {:ok, nil}
+
+      {:error, {:unsupported_entity, entity_type}} ->
+        {:error, "Renaming #{inspect(entity_type)} is not supported for now"}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Resolves the entity at the given position for renaming.
+
+  Returns `{:ok, {entity_type, entity}, range}` if the entity can be renamed,
+  or an error tuple.
+  """
+  @spec resolve(Analysis.t(), Position.t()) ::
+          {:ok, {atom(), atom()}, Range.t()} | {:error, tuple() | atom()}
+  def resolve(%Analysis{} = analysis, %Position{} = position) do
+    prepare_result =
+      Enum.find_value(@renaming_modules, fn module ->
+        if module.recognizes?(analysis, position) do
+          module.prepare(analysis, position)
+        end
+      end)
+
+    prepare_result || handle_unsupported_entity(analysis, position)
+  end
+
+  defp handle_unsupported_entity(analysis, position) do
+    with {:ok, other, _range} <- Entity.resolve(analysis, position) do
+      Logger.info("Unsupported entity for renaming: #{inspect(other)}")
+      {:error, {:unsupported_entity, elem(other, 0)}}
+    end
+  end
+end

--- a/apps/engine/lib/engine/code_mod/rename/prepare.ex
+++ b/apps/engine/lib/engine/code_mod/rename/prepare.ex
@@ -10,9 +10,9 @@ defmodule Engine.CodeMod.Rename.Prepare do
   alias Engine.CodeIntelligence.Entity
   alias Engine.CodeMod.Rename
   alias Forge.Ast.Analysis
+  alias Forge.Document
   alias Forge.Document.Position
   alias Forge.Document.Range
-  alias Forge.Formats
 
   require Logger
 
@@ -28,8 +28,8 @@ defmodule Engine.CodeMod.Rename.Prepare do
           {:ok, String.t(), Range.t()} | {:ok, nil} | {:error, term()}
   def prepare(%Analysis{} = analysis, %Position{} = position) do
     case resolve(analysis, position) do
-      {:ok, {:module, module}, range} ->
-        {:ok, Formats.module(module), range}
+      {:ok, {:module, _module}, range} ->
+        {:ok, Document.fragment(analysis.document, range.start, range.end), range}
 
       {:error, {:unsupported_location, _}} ->
         {:ok, nil}

--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -96,14 +96,27 @@ defmodule Engine.Commands.Reindex do
     end
 
     defp entries_for_uri(uri) do
-      with {:ok, %Document{} = document, %Analysis{} = analysis} <-
-             Document.Store.fetch(uri, :analysis),
+      with {:ok, %Document{} = document, %Analysis{} = analysis} <- ensure_open(uri),
            {:ok, entries} <- Indexer.Quoted.index_with_cleanup(analysis) do
         {:ok, document.path, entries}
       else
         error ->
           Logger.error("Could not update index because #{inspect(error)}")
           error
+      end
+    end
+
+    defp ensure_open(uri) do
+      case Document.Store.fetch(uri, :analysis) do
+        {:ok, %Document{} = document, analysis} ->
+          {:ok, document, analysis}
+
+        {:error, :not_open} ->
+          # Sometimes, some operations are received long after the reindex is triggered,
+          # such as new files after a batch rename
+          with {:ok, _} <- Document.Store.open_temporary(uri) do
+            Document.Store.fetch(uri, :analysis)
+          end
       end
     end
 

--- a/apps/engine/lib/engine/commands/rename.ex
+++ b/apps/engine/lib/engine/commands/rename.ex
@@ -1,0 +1,206 @@
+defmodule Engine.Commands.Rename do
+  @moduledoc """
+  Tracks rename progress and triggers reindexing after rename operations complete.
+
+  This GenServer is started when a rename operation begins. It tracks expected file
+  operations (file_changed, file_saved) and when all operations are received, it
+  reindexes the modified files and clears old entries from the search index.
+
+  This is necessary because after a rename, the search index still contains the old
+  module names. Without reindexing, subsequent renames won't find the new entries.
+  """
+
+  alias Engine.Commands.Reindex
+  alias Engine.Search.Store
+  alias Forge.EngineApi.Messages
+
+  require Logger
+  import Messages
+
+  use GenServer
+
+  defmodule State do
+    @moduledoc false
+
+    @type uri_to_expected_operation :: %{
+            Forge.uri() => Messages.file_changed() | Messages.file_saved()
+          }
+
+    @type t :: %__MODULE__{
+            uri_to_expected_operation: uri_to_expected_operation(),
+            paths_to_reindex: list(Forge.uri()),
+            paths_to_delete: list(Forge.uri()),
+            on_update_progress: (integer(), String.t() -> :ok),
+            on_complete: (-> :ok)
+          }
+
+    defstruct uri_to_expected_operation: %{},
+              paths_to_reindex: [],
+              paths_to_delete: [],
+              on_update_progress: nil,
+              on_complete: nil
+
+    def new(
+          uri_to_expected_operation,
+          paths_to_reindex,
+          paths_to_delete,
+          on_update_progress,
+          on_complete
+        ) do
+      %__MODULE__{
+        uri_to_expected_operation: uri_to_expected_operation,
+        paths_to_reindex: paths_to_reindex,
+        paths_to_delete: paths_to_delete,
+        on_update_progress: on_update_progress,
+        on_complete: on_complete
+      }
+    end
+
+    def update_progress(%__MODULE__{} = state, file_changed(uri: uri)) do
+      update_progress(state, uri, file_changed(uri: uri))
+    end
+
+    def update_progress(%__MODULE__{} = state, file_saved(uri: uri)) do
+      update_progress(state, uri, file_saved(uri: uri))
+    end
+
+    defp update_progress(%__MODULE__{} = state, uri, message) do
+      new_uri_with_expected_operation =
+        maybe_pop_expected_operation(
+          state.uri_to_expected_operation,
+          uri,
+          message,
+          state.on_update_progress
+        )
+
+      if Enum.empty?(new_uri_with_expected_operation) do
+        reindex_all_modified_files(state)
+        state.on_complete.()
+      end
+
+      %__MODULE__{state | uri_to_expected_operation: new_uri_with_expected_operation}
+    end
+
+    def in_progress?(%__MODULE__{} = state) do
+      state.uri_to_expected_operation != %{}
+    end
+
+    defp maybe_pop_expected_operation(uri_to_operation, uri, message, on_update_progress) do
+      case uri_to_operation do
+        %{^uri => ^message} ->
+          on_update_progress.(1, "")
+          Map.delete(uri_to_operation, uri)
+
+        _ ->
+          uri_to_operation
+      end
+    end
+
+    defp reindex_all_modified_files(%__MODULE__{} = state) do
+      Enum.each(state.paths_to_reindex, fn uri ->
+        Reindex.uri(uri)
+        state.on_update_progress.(1, "reindexing")
+      end)
+
+      Enum.each(state.paths_to_delete, fn uri ->
+        Store.clear(uri)
+        state.on_update_progress.(1, "deleting old index")
+      end)
+    end
+  end
+
+  @spec child_spec(
+          %{Forge.uri() => Messages.file_changed() | Messages.file_saved()},
+          list(Forge.uri()),
+          list(Forge.uri()),
+          (integer(), String.t() -> :ok),
+          (-> :ok)
+        ) :: Supervisor.child_spec()
+  def child_spec(
+        uri_to_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_update_progress,
+        on_complete
+      ) do
+    %{
+      id: __MODULE__,
+      start:
+        {__MODULE__, :start_link,
+         [
+           uri_to_expected_operation,
+           paths_to_reindex,
+           paths_to_delete,
+           on_update_progress,
+           on_complete
+         ]},
+      restart: :transient
+    }
+  end
+
+  def start_link(
+        uri_to_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_update_progress,
+        on_complete
+      ) do
+    state =
+      State.new(
+        uri_to_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_update_progress,
+        on_complete
+      )
+
+    GenServer.start_link(__MODULE__, state, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    {:ok, state, {:continue, :start_buffering}}
+  end
+
+  @doc """
+  Updates the rename progress with a file operation message.
+
+  This should be called when files are changed or saved during rename.
+  Returns `:ok` if the message was processed, `{:error, :not_in_rename_progress}`
+  if no rename is in progress.
+  """
+  @spec update_progress(Messages.file_changed() | Messages.file_saved()) ::
+          :ok | {:error, :not_in_rename_progress}
+  def update_progress(message) do
+    pid = Process.whereis(__MODULE__)
+
+    if pid && Process.alive?(pid) do
+      GenServer.cast(__MODULE__, {:update_progress, message})
+    else
+      {:error, :not_in_rename_progress}
+    end
+  end
+
+  @impl true
+  def handle_continue(:start_buffering, state) do
+    Engine.Api.Proxy.start_buffering()
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:in_progress?, _from, state) do
+    {:reply, State.in_progress?(state), state}
+  end
+
+  @impl true
+  def handle_cast({:update_progress, message}, state) do
+    new_state = State.update_progress(state, message)
+
+    if State.in_progress?(new_state) do
+      {:noreply, new_state}
+    else
+      Logger.info("Rename process completed.")
+      {:stop, :normal, new_state}
+    end
+  end
+end

--- a/apps/engine/lib/engine/commands/rename.ex
+++ b/apps/engine/lib/engine/commands/rename.ex
@@ -145,6 +145,11 @@ defmodule Engine.Commands.Rename do
         on_update_progress,
         on_complete
       ) do
+    Logger.info(
+      "Starting rename tracking: #{map_size(uri_to_expected_operation)} operations, " <>
+        "#{length(paths_to_reindex)} to reindex, #{length(paths_to_delete)} to delete"
+    )
+
     state =
       State.new(
         uri_to_expected_operation,

--- a/apps/engine/lib/engine/commands/rename.ex
+++ b/apps/engine/lib/engine/commands/rename.ex
@@ -10,14 +10,16 @@ defmodule Engine.Commands.Rename do
   module names. Without reindexing, subsequent renames won't find the new entries.
   """
 
+  use GenServer
+
+  import Forge.EngineApi.Messages
+
   alias Engine.Commands.Reindex
-  alias Engine.Search.Store
+  alias Engine.ManagerApi
+  alias Forge.Document
   alias Forge.EngineApi.Messages
 
   require Logger
-  import Messages
-
-  use GenServer
 
   defmodule State do
     @moduledoc false
@@ -103,7 +105,8 @@ defmodule Engine.Commands.Rename do
       end)
 
       Enum.each(state.paths_to_delete, fn uri ->
-        Store.clear(uri)
+        project = Engine.get_project()
+        ManagerApi.search_store_clear(project, Document.Path.ensure_path(uri))
         state.on_update_progress.(1, "deleting old index")
       end)
     end

--- a/apps/engine/lib/engine/commands/rename.ex
+++ b/apps/engine/lib/engine/commands/rename.ex
@@ -21,6 +21,8 @@ defmodule Engine.Commands.Rename do
 
   require Logger
 
+  @timeout :timer.seconds(30)
+
   defmodule State do
     @moduledoc false
 
@@ -59,19 +61,18 @@ defmodule Engine.Commands.Rename do
     end
 
     def update_progress(%__MODULE__{} = state, file_changed(uri: uri)) do
-      update_progress(state, uri, file_changed(uri: uri))
+      consume_operation(state, uri)
     end
 
     def update_progress(%__MODULE__{} = state, file_saved(uri: uri)) do
-      update_progress(state, uri, file_saved(uri: uri))
+      consume_operation(state, uri)
     end
 
-    defp update_progress(%__MODULE__{} = state, uri, message) do
+    defp consume_operation(%__MODULE__{} = state, uri) do
       new_uri_with_expected_operation =
         maybe_pop_expected_operation(
           state.uri_to_expected_operation,
           uri,
-          message,
           state.on_update_progress
         )
 
@@ -87,9 +88,9 @@ defmodule Engine.Commands.Rename do
       state.uri_to_expected_operation != %{}
     end
 
-    defp maybe_pop_expected_operation(uri_to_operation, uri, message, on_update_progress) do
+    defp maybe_pop_expected_operation(uri_to_operation, uri, on_update_progress) do
       case uri_to_operation do
-        %{^uri => ^message} ->
+        %{^uri => _expected_message} ->
           on_update_progress.(1, "")
           Map.delete(uri_to_operation, uri)
 
@@ -167,7 +168,14 @@ defmodule Engine.Commands.Rename do
 
   @impl true
   def init(state) do
-    {:ok, state, {:continue, :start_buffering}}
+    case Engine.Api.Proxy.start_buffering() do
+      :ok ->
+        Process.send_after(self(), :timeout, @timeout)
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
   end
 
   @doc """
@@ -190,12 +198,6 @@ defmodule Engine.Commands.Rename do
   end
 
   @impl true
-  def handle_continue(:start_buffering, state) do
-    Engine.Api.Proxy.start_buffering()
-    {:noreply, state}
-  end
-
-  @impl true
   def handle_call(:in_progress?, _from, state) do
     {:reply, State.in_progress?(state), state}
   end
@@ -210,5 +212,15 @@ defmodule Engine.Commands.Rename do
       Logger.info("Rename process completed.")
       {:stop, :normal, new_state}
     end
+  end
+
+  @impl true
+  def handle_info(:timeout, state) do
+    Logger.warning(
+      "Rename tracking timed out with #{map_size(state.uri_to_expected_operation)} pending operations"
+    )
+
+    state.on_complete.()
+    {:stop, :normal, state}
   end
 end

--- a/apps/engine/lib/engine/commands/rename_supervisor.ex
+++ b/apps/engine/lib/engine/commands/rename_supervisor.ex
@@ -1,0 +1,58 @@
+defmodule Engine.Commands.RenameSupervisor do
+  @moduledoc """
+  DynamicSupervisor for managing rename progress tracking GenServers.
+
+  Each rename operation spawns a transient child that tracks progress
+  and shuts down when the rename is complete.
+  """
+
+  alias Engine.Commands.Rename
+
+  use DynamicSupervisor
+
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
+  def start_link do
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Starts a new rename progress tracker.
+
+  ## Parameters
+
+  - `uri_to_expected_operation` - Map of URIs to expected messages (file_changed/file_saved)
+  - `paths_to_reindex` - List of URIs that need to be reindexed after rename
+  - `paths_to_delete` - List of URIs whose entries should be deleted from the index
+  - `on_update_progress` - Callback function receiving (increment, message)
+  - `on_complete` - Callback function called when rename is complete
+  """
+  def start_renaming(
+        uri_to_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_update_progress,
+        on_complete
+      ) do
+    DynamicSupervisor.start_child(
+      __MODULE__,
+      Rename.child_spec(
+        uri_to_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_update_progress,
+        on_complete
+      )
+    )
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/apps/engine/lib/engine/commands/rename_supervisor.ex
+++ b/apps/engine/lib/engine/commands/rename_supervisor.ex
@@ -6,9 +6,9 @@ defmodule Engine.Commands.RenameSupervisor do
   and shuts down when the rename is complete.
   """
 
-  alias Engine.Commands.Rename
-
   use DynamicSupervisor
+
+  alias Engine.Commands.Rename
 
   def child_spec(_) do
     %{

--- a/apps/engine/lib/engine/progress.ex
+++ b/apps/engine/lib/engine/progress.ex
@@ -7,14 +7,6 @@ defmodule Engine.Progress do
 
   alias Engine.Dispatch
 
-  import Forge.EngineApi.Messages
-
-  @type label :: String.t()
-  @type message :: String.t()
-  @type delta :: pos_integer()
-  @type on_complete_callback :: (-> any())
-  @type report_progress_callback :: (delta(), message() -> any())
-
   @impl true
   def begin(title, opts \\ []) when is_list(opts) do
     Dispatch.erpc_call(Expert.Progress, :begin, [title, opts])
@@ -35,40 +27,5 @@ defmodule Engine.Progress do
   def complete(token, opts) when is_token(token) and is_list(opts) do
     Dispatch.erpc_cast(Expert.Progress, :complete, [token, opts])
     :ok
-  end
-
-  @doc """
-  Begins a percent-based progress operation.
-
-  Returns a tuple of `{report_progress_callback, on_complete_callback}` that can
-  be used to report progress and signal completion.
-
-  ## Parameters
-
-  - `label` - The label/title for the progress
-  - `max` - The maximum value (total number of operations)
-
-  ## Example
-
-      {report_progress, on_complete} = Progress.begin_percent("Renaming", 10)
-      report_progress.(1, "Processing file...")
-      on_complete.()
-  """
-  @spec begin_percent(label(), pos_integer()) ::
-          {report_progress_callback(), on_complete_callback()}
-  def begin_percent(label, max) do
-    Engine.broadcast(percent_progress(label: label, max: max, stage: :begin))
-
-    report_progress = fn delta, message ->
-      Engine.broadcast(
-        percent_progress(label: label, message: message, delta: delta, stage: :report)
-      )
-    end
-
-    complete = fn ->
-      Engine.broadcast(percent_progress(label: label, stage: :complete))
-    end
-
-    {report_progress, complete}
   end
 end

--- a/apps/engine/lib/engine/progress.ex
+++ b/apps/engine/lib/engine/progress.ex
@@ -7,6 +7,14 @@ defmodule Engine.Progress do
 
   alias Engine.Dispatch
 
+  import Forge.EngineApi.Messages
+
+  @type label :: String.t()
+  @type message :: String.t()
+  @type delta :: pos_integer()
+  @type on_complete_callback :: (-> any())
+  @type report_progress_callback :: (delta(), message() -> any())
+
   @impl true
   def begin(title, opts \\ []) when is_list(opts) do
     Dispatch.erpc_call(Expert.Progress, :begin, [title, opts])
@@ -27,5 +35,40 @@ defmodule Engine.Progress do
   def complete(token, opts) when is_token(token) and is_list(opts) do
     Dispatch.erpc_cast(Expert.Progress, :complete, [token, opts])
     :ok
+  end
+
+  @doc """
+  Begins a percent-based progress operation.
+
+  Returns a tuple of `{report_progress_callback, on_complete_callback}` that can
+  be used to report progress and signal completion.
+
+  ## Parameters
+
+  - `label` - The label/title for the progress
+  - `max` - The maximum value (total number of operations)
+
+  ## Example
+
+      {report_progress, on_complete} = Progress.begin_percent("Renaming", 10)
+      report_progress.(1, "Processing file...")
+      on_complete.()
+  """
+  @spec begin_percent(label(), pos_integer()) ::
+          {report_progress_callback(), on_complete_callback()}
+  def begin_percent(label, max) do
+    Engine.broadcast(percent_progress(label: label, max: max, stage: :begin))
+
+    report_progress = fn delta, message ->
+      Engine.broadcast(
+        percent_progress(label: label, message: message, delta: delta, stage: :report)
+      )
+    end
+
+    complete = fn ->
+      Engine.broadcast(percent_progress(label: label, stage: :complete))
+    end
+
+    {report_progress, complete}
   end
 end

--- a/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
+++ b/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
@@ -1,0 +1,27 @@
+defmodule Engine.CodeMod.Rename.Module.DiffTest do
+  alias Engine.CodeMod.Rename.Module.Diff
+
+  use ExUnit.Case, async: true
+
+  describe "diff/2" do
+    test "returns the local module pair if only the local name is changed" do
+      assert Diff.diff("A.B.C", "A.B.D") == {"C", "D"}
+    end
+
+    test "returns the local module pair even if the part of local name is changed" do
+      assert Diff.diff("A.B.CD", "A.B.CC") == {"CD", "CC"}
+    end
+
+    test "returns the suffix when extending the middle part" do
+      assert Diff.diff("Foo.Bar", "Foo.Baz.Bar") == {"Bar", "Baz.Bar"}
+    end
+
+    test "returns the suffix if the middle part is removed" do
+      assert Diff.diff("Foo.Baz.Bar", "Foo.Bar") == {"Baz.Bar", "Bar"}
+    end
+
+    test "returns the entire module pair if the change starts from the first module" do
+      assert Diff.diff("Foo.Bar", "Foa.Bar") == {"Foo.Bar", "Foa.Bar"}
+    end
+  end
+end

--- a/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
+++ b/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
@@ -23,5 +23,9 @@ defmodule Engine.CodeMod.Rename.Module.DiffTest do
     test "returns the entire module pair if the change starts from the first module" do
       assert Diff.diff("Foo.Bar", "Foa.Bar") == {"Foo.Bar", "Foa.Bar"}
     end
+
+    test "treats regular expression metacharacters as text" do
+      assert Diff.diff("Foo[Bar.Baz", "Foo[Bar.Qux") == {"Baz", "Qux"}
+    end
   end
 end

--- a/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
+++ b/apps/engine/test/engine/code_mod/rename/module/diff_test.exs
@@ -1,7 +1,7 @@
 defmodule Engine.CodeMod.Rename.Module.DiffTest do
-  alias Engine.CodeMod.Rename.Module.Diff
-
   use ExUnit.Case, async: true
+
+  alias Engine.CodeMod.Rename.Module.Diff
 
   describe "diff/2" do
     test "returns the local module pair if only the local name is changed" do

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -1,0 +1,193 @@
+defmodule Engine.CodeMod.RenameTest do
+  alias Engine.CodeMod.Rename
+  alias Engine.Search
+  alias Engine.Search.Store.Backends
+  alias Forge.Document
+
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.CodeSigil
+  import Forge.Test.CursorSupport
+  import Forge.Test.Fixtures
+  import Forge.Test.EventualAssertions
+
+  setup do
+    project = project()
+
+    Backends.Ets.destroy_all(project)
+    Engine.set_project(project)
+
+    start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
+    start_supervised!(Engine.Dispatch)
+    start_supervised!(Backends.Ets)
+
+    start_supervised!(
+      {Search.Store, [project, fn _ -> {:ok, []} end, fn _, _ -> {:ok, [], []} end, Backends.Ets]}
+    )
+
+    Search.Store.enable()
+    assert_eventually Search.Store.loaded?(), 1500
+
+    on_exit(fn ->
+      Backends.Ets.destroy_all(project)
+    end)
+
+    {:ok, project: project}
+  end
+
+  describe "prepare/2" do
+    test "returns the module name" do
+      {:ok, result, _} =
+        ~q[
+        defmodule |Foo do
+        end
+      ]
+        |> prepare()
+
+      assert result == "Foo"
+    end
+
+    test "returns the whole module name" do
+      {:ok, result, _} =
+        ~q[
+        defmodule TopLevel.|Foo do
+        end
+      ]
+        |> prepare()
+
+      assert result == "TopLevel.Foo"
+    end
+
+    test "returns the whole module name even if the cursor is not at the end" do
+      {:ok, result, _} =
+        ~q[
+        defmodule Top|Level.Foo do
+        end
+      ]
+        |> prepare()
+
+      assert result == "TopLevel.Foo"
+    end
+
+    test "returns `nil` when renaming a module occurs in a reference" do
+      assert {:ok, nil} =
+               ~q[
+        defmodule Foo do
+        end
+
+        defmodule Bar do
+          alias |Foo
+        end
+      ]
+               |> prepare()
+    end
+
+    test "returns error when the entity is not found" do
+      assert {:error, "Renaming :variable is not supported for now"} =
+               ~q[
+          x = 1
+          |x
+      ]
+               |> prepare()
+    end
+  end
+
+  describe "rename exact module" do
+    test "succeeds when the cursor is at the definition" do
+      {:ok, result} =
+        ~q[
+        defmodule |Foo do
+        end
+      ]
+        |> rename("Renamed")
+
+      assert result =~ ~S[defmodule Renamed do]
+    end
+
+    test "failed when the cursor is at the alias" do
+      assert {:error, {:unsupported_location, :module}} ==
+               ~q[
+        defmodule Baz do
+          alias |Foo
+        end
+      ]
+               |> rename("Renamed")
+    end
+
+    test "succeeds when the module has multiple dots" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel.Foo.|Bar do
+        end
+      ]
+        |> rename("TopLevel.Foo.Renamed")
+
+      assert result =~ ~S[defmodule TopLevel.Foo.Renamed do]
+    end
+
+    test "succeeds when renaming the middle part of the module" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel.Foo.|Bar do
+        end
+      ]
+        |> rename("TopLevel.Renamed.Bar")
+
+      assert result =~ ~S[defmodule TopLevel.Renamed.Bar do]
+    end
+
+    test "succeeds when simplifying the module name" do
+      {:ok, result} =
+        ~q[
+        defmodule TopLevel.Foo.|Bar do
+        end
+      ]
+        |> rename("TopLevel.Bar")
+
+      assert result =~ ~S[defmodule TopLevel.Bar do]
+    end
+  end
+
+  defp prepare(code) do
+    with {position, code} <- pop_cursor(code),
+         {:ok, _document, analysis} <- index(code) do
+      Rename.prepare(analysis, position)
+    end
+  end
+
+  defp rename(code, new_name) do
+    with {position, code} <- pop_cursor(code),
+         {:ok, document, analysis} <- index(code),
+         {:ok, results} <- Rename.rename(analysis, position, new_name, nil) do
+      case results do
+        [%Document.Changes{edits: edits, document: doc}] ->
+          {:ok, edited_doc} =
+            Document.apply_content_changes(doc, doc.version + 1, edits)
+
+          {:ok, Document.to_string(edited_doc)}
+
+        [] ->
+          {:ok, Document.to_string(document)}
+      end
+    end
+  end
+
+  defp index(code) do
+    project = project()
+    uri = module_uri(project)
+
+    with :ok <- Document.Store.open(uri, code, 1),
+         {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis),
+         {:ok, entries} <- Engine.Search.Indexer.Quoted.index(analysis) do
+      Search.Store.replace(entries)
+      {:ok, document, analysis}
+    end
+  end
+
+  defp module_uri(project) do
+    project
+    |> file_path(Path.join("lib", "my_module.ex"))
+    |> Document.Path.ensure_uri()
+  end
+end

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -27,7 +27,7 @@ defmodule Engine.CodeMod.RenameTest do
     )
 
     Search.Store.enable()
-    assert_eventually Search.Store.loaded?(), 1500
+    assert_eventually(Search.Store.loaded?(), 1500)
 
     on_exit(fn ->
       Backends.Ets.destroy_all(project)
@@ -37,53 +37,53 @@ defmodule Engine.CodeMod.RenameTest do
   end
 
   describe "prepare/2" do
-    test "returns the module name" do
+    test "returns module name" do
       {:ok, result, _} =
         ~q[
-        defmodule |Foo do
+        defmodule |Users do
         end
       ]
         |> prepare()
 
-      assert result == "Foo"
+      assert result == "Users"
     end
 
-    test "returns the whole module name" do
+    test "returns full module name" do
       {:ok, result, _} =
         ~q[
-        defmodule TopLevel.|Foo do
+        defmodule MyApp.|Users do
         end
       ]
         |> prepare()
 
-      assert result == "TopLevel.Foo"
+      assert result == "MyApp.Users"
     end
 
-    test "returns the whole module name even if the cursor is not at the end" do
+    test "returns full module name when cursor is in the middle" do
       {:ok, result, _} =
         ~q[
-        defmodule Top|Level.Foo do
+        defmodule My|App.Users do
         end
       ]
         |> prepare()
 
-      assert result == "TopLevel.Foo"
+      assert result == "MyApp.Users"
     end
 
-    test "returns `nil` when renaming a module occurs in a reference" do
+    test "returns nil for module reference" do
       assert {:ok, nil} =
                ~q[
-        defmodule Foo do
+        defmodule MyApp.Users do
         end
 
-        defmodule Bar do
-          alias |Foo
+        defmodule MyApp.Accounts do
+          alias |MyApp.Users
         end
       ]
                |> prepare()
     end
 
-    test "returns error when the entity is not found" do
+    test "returns error for unsupported entity" do
       assert {:error, "Renaming :variable is not supported for now"} =
                ~q[
           x = 1
@@ -93,61 +93,742 @@ defmodule Engine.CodeMod.RenameTest do
     end
   end
 
-  describe "rename exact module" do
-    test "succeeds when the cursor is at the definition" do
+  describe "rename/4 basic" do
+    test "renames at definition" do
       {:ok, result} =
         ~q[
-        defmodule |Foo do
+        defmodule |Users do
         end
       ]
-        |> rename("Renamed")
+        |> rename("Accounts")
 
-      assert result =~ ~S[defmodule Renamed do]
+      assert result =~ ~S[defmodule Accounts do]
     end
 
-    test "failed when the cursor is at the alias" do
+    test "fails at alias reference" do
       assert {:error, {:unsupported_location, :module}} ==
                ~q[
-        defmodule Baz do
-          alias |Foo
+        defmodule MyApp.Accounts do
+          alias |MyApp.Users
         end
       ]
-               |> rename("Renamed")
+               |> rename("Members")
     end
 
-    test "succeeds when the module has multiple dots" do
-      {:ok, result} =
-        ~q[
-        defmodule TopLevel.Foo.|Bar do
+    test "fails at module call reference" do
+      assert {:error, {:unsupported_location, :module}} ==
+               ~q[
+        defmodule MyApp.Accounts do
+          alias MyApp.Users
+          Use|rs.list()
         end
       ]
-        |> rename("TopLevel.Foo.Renamed")
-
-      assert result =~ ~S[defmodule TopLevel.Foo.Renamed do]
+               |> rename("Members")
     end
 
-    test "succeeds when renaming the middle part of the module" do
+    test "renames multi-part module" do
       {:ok, result} =
         ~q[
-        defmodule TopLevel.Foo.|Bar do
+        defmodule MyApp.Auth.|Session do
         end
       ]
-        |> rename("TopLevel.Renamed.Bar")
+        |> rename("MyApp.Auth.Token")
 
-      assert result =~ ~S[defmodule TopLevel.Renamed.Bar do]
+      assert result =~ ~S[defmodule MyApp.Auth.Token do]
     end
 
-    test "succeeds when simplifying the module name" do
+    test "renames middle segment" do
       {:ok, result} =
         ~q[
-        defmodule TopLevel.Foo.|Bar do
+        defmodule MyApp.Auth.|Session do
         end
       ]
-        |> rename("TopLevel.Bar")
+        |> rename("MyApp.Identity.Session")
 
-      assert result =~ ~S[defmodule TopLevel.Bar do]
+      assert result =~ ~S[defmodule MyApp.Identity.Session do]
+    end
+
+    test "simplifies module name" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.Auth.|Session do
+        end
+      ]
+        |> rename("MyApp.Session")
+
+      assert result =~ ~S[defmodule MyApp.Session do]
+    end
+
+    test "renames nested module definition" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.Users do
+          defmodule |Query do
+          end
+        end
+
+        defmodule MyApp.UsersTest do
+          alias MyApp.Users.Query
+        end
+      ]
+        |> rename("Filter")
+
+      assert result == ~q[
+        defmodule MyApp.Users do
+          defmodule Filter do
+          end
+        end
+
+        defmodule MyApp.UsersTest do
+          alias MyApp.Users.Filter
+        end
+      ]
+    end
+
+    test "renames multi-alias syntax" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.|Accounts do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.{
+            Users, Accounts,
+            Auth.Session
+          }
+        end
+      ]
+        |> rename("MyApp.Members")
+
+      assert result =~ ~S[  Users, Members,]
     end
   end
+
+  describe "rename/4 with references" do
+    test "does not rename similar module names" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.UsersTest do
+        end
+        ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[defmodule MyApp.UsersTest do]
+    end
+
+    test "renames local references when local name changes" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.UsersTest do
+          alias MyApp.Users
+          Users.list()
+        end
+        ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[alias MyApp.Accounts]
+      assert result =~ ~S[ Accounts.list()]
+    end
+
+    test "keeps local reference when local name unchanged" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.Admin do
+          alias MyApp.Users
+
+          Users.list() # no change
+        end
+      ]
+        |> rename("MyApp.Core.Users")
+
+      assert result =~ ~S[defmodule MyApp.Core.Users do]
+      assert result =~ ~S[alias MyApp.Core.Users]
+      assert result =~ ~S[ Users.list() # no change]
+    end
+
+    test "keeps local reference when only prefix changes" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Core.Utils do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.Core.Utils
+
+          Utils.format() # no change
+        end
+      ]
+        |> rename("MyApp.Shared.Utils")
+
+      assert result =~ ~S[defmodule MyApp.Shared.Utils do]
+      assert result =~ ~S[alias MyApp.Shared.Utils]
+      assert result =~ ~S[ Utils.format() # no change]
+    end
+  end
+
+  describe "rename/4 descendants" do
+    test "renames descendants" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.|Users do
+        end
+
+        defmodule MyApp.Users.Query do
+        end
+      ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[defmodule MyApp.Accounts.Query]
+      assert result =~ ~S[defmodule MyApp.Accounts do]
+    end
+
+    test "renames descendants when expanding name" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.|Users do
+          alias MyApp.Users.Query
+        end
+
+        defmodule MyApp.Users.Query do
+        end
+      ]
+        |> rename("MyApp.Core.Users")
+
+      assert result =~ ~S[defmodule MyApp.Core.Users]
+      assert result =~ ~S[alias MyApp.Core.Users.Query]
+      assert result =~ ~S[defmodule MyApp.Core.Users.Query do]
+    end
+
+    test "renames descendants with multi-part expansion" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.|Auth do
+        end
+
+        defmodule MyApp.Auth.Session do
+        end
+
+        defmodule MyApp.AuthTest do
+          alias MyApp.Auth
+          alias MyApp.Auth.Session
+        end
+      ]
+        |> rename("MyApp.Auth.OAuth")
+
+      assert result =~ ~S[defmodule MyApp.Auth.OAuth do]
+      assert result =~ ~S[alias MyApp.Auth.OAuth]
+      assert result =~ ~S[alias MyApp.Auth.OAuth.Session]
+    end
+
+    test "handles repeated module name in path" do
+      {:ok, result} =
+        ~q[
+          defmodule MyApp.Core.MyApp.|Core do
+          end
+
+          defmodule MyApp.Core.MyApp.Core.Utils do
+          end
+
+          defmodule MyApp.Web do
+            alias MyApp.Core.MyApp.Core.Utils
+          end
+        ]
+        |> rename("MyApp.Core.MyApp.Shared")
+
+      assert result =~ ~S[defmodule MyApp.Core.MyApp.Shared do]
+      assert result =~ ~S[defmodule MyApp.Core.MyApp.Shared.Utils do]
+      assert result =~ ~S[alias MyApp.Core.MyApp.Shared.Utils]
+    end
+
+    test "skips same-named nested modules" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.|Users do
+          defmodule Users do # skip this
+          end
+        end
+
+        defmodule MyApp.Admin do
+          alias MyApp.Users.Users
+        end
+      ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[defmodule MyApp.Accounts do]
+      assert result =~ ~S[defmodule Users do # skip this]
+      assert result =~ ~S[alias MyApp.Accounts.Users]
+    end
+
+    test "renames when removing middle segment" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Core.Users do
+        end
+
+        defmodule MyApp.Core.Users.Query do
+          alias MyApp.Core.Users.Query
+        end
+      ]
+        |> rename("MyApp.Users")
+
+      assert result =~ ~S[defmodule MyApp.Users.Query do]
+      assert result =~ ~S[alias MyApp.Users.Query]
+    end
+
+    test "does not rename modules containing old suffix as substring" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Ast do
+        end
+
+        defmodule MyApp.Parser do
+          alias MyApp.Ast.Detection
+
+          Detection.Bitstring.detected?() # Bitstring contains the old suffix: `st`
+        end
+      ]
+        |> rename("MyApp.AST")
+
+      refute result =~ ~S[Detection.BitSTring.detected?()]
+    end
+  end
+
+  describe "rename/4 struct" do
+    test "renames struct references" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.User do
+          defstruct name: nil, email: nil
+        end
+
+        defmodule MyApp.Accounts do
+          def new do
+            %MyApp.User{}
+          end
+        end
+      ]
+        |> rename("MyApp.Account")
+
+      assert result =~ ~S[defmodule MyApp.Account do]
+      assert result =~ ~S[%MyApp.Account{}]
+    end
+
+    test "renames struct in pattern matching" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.User do
+          defstruct name: nil, email: nil
+        end
+
+        defmodule MyApp.Accounts do
+          def get_name(%MyApp.User{name: name}), do: name
+        end
+      ]
+        |> rename("MyApp.Account")
+
+      assert result =~ ~S[def get_name(%MyApp.Account{name: name})]
+    end
+
+    test "renames struct update syntax" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.User do
+          defstruct name: nil, email: nil
+        end
+
+        defmodule MyApp.Accounts do
+          def update(user, name) do
+            %MyApp.User{user | name: name}
+          end
+        end
+      ]
+        |> rename("MyApp.Account")
+
+      assert result =~ ~S[%MyApp.Account{user | name: name}]
+    end
+  end
+
+  describe "rename/4 edge cases" do
+    test "does not rename module with similar prefix" do
+      # MyApp.User should not affect MyApp.UserProfile
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.User do
+        end
+
+        defmodule MyApp.UserProfile do
+        end
+
+        defmodule MyApp.Consumer do
+          alias MyApp.User
+          alias MyApp.UserProfile
+        end
+      ]
+        |> rename("MyApp.Account")
+
+      assert result =~ ~S[defmodule MyApp.Account do]
+      # UserProfile should NOT be renamed
+      assert result =~ ~S[defmodule MyApp.UserProfile do]
+      assert result =~ ~S[alias MyApp.UserProfile]
+    end
+
+    test "does not rename module that contains old name as substring" do
+      # Renaming MyApp.API should not affect MyApp.SomeAPIService
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.API do
+        end
+
+        defmodule MyApp.SomeAPIService do
+        end
+      ]
+        |> rename("MyApp.Gateway")
+
+      assert result =~ ~S[defmodule MyApp.Gateway do]
+      # SomeAPIService should NOT be renamed to SomeGatewayService
+      assert result =~ ~S[defmodule MyApp.SomeAPIService do]
+    end
+
+    test "correctly renames when old and new names share common prefix" do
+      # MyApp.User -> MyApp.UserAccount (extending the name)
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.User do
+        end
+
+        defmodule MyApp.Consumer do
+          alias MyApp.User
+        end
+      ]
+        |> rename("MyApp.UserAccount")
+
+      assert result =~ ~S[defmodule MyApp.UserAccount do]
+      assert result =~ ~S[alias MyApp.UserAccount]
+    end
+
+    test "correctly renames when new name is shorter" do
+      # MyApp.UserAccount -> MyApp.User (shortening the name)
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.UserAccount do
+        end
+
+        defmodule MyApp.Consumer do
+          alias MyApp.UserAccount
+        end
+      ]
+        |> rename("MyApp.User")
+
+      assert result =~ ~S[defmodule MyApp.User do]
+      assert result =~ ~S[alias MyApp.User]
+    end
+
+    test "handles renaming module with single segment name" do
+      {:ok, result} =
+        ~q[
+        defmodule |Users do
+        end
+
+        defmodule Consumer do
+          alias Users
+        end
+      ]
+        |> rename("Accounts")
+
+      assert result =~ ~S[defmodule Accounts do]
+      assert result =~ ~S[alias Accounts]
+    end
+
+    test "handles renaming to completely different module path" do
+      # MyApp.Users -> OtherApp.Accounts (different prefix entirely)
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.Consumer do
+          alias MyApp.Users
+        end
+      ]
+        |> rename("OtherApp.Accounts")
+
+      assert result =~ ~S[defmodule OtherApp.Accounts do]
+      assert result =~ ~S[alias OtherApp.Accounts]
+    end
+
+    test "renames deeply nested module correctly" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Core.Domain.Users.Query do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.Core.Domain.Users.Query
+        end
+      ]
+        |> rename("MyApp.Core.Domain.Users.Filter")
+
+      assert result =~ ~S[defmodule MyApp.Core.Domain.Users.Filter do]
+      assert result =~ ~S[alias MyApp.Core.Domain.Users.Filter]
+    end
+
+    test "does not corrupt nearby code when renaming" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+          @moduledoc "Users module"
+
+          def list, do: :ok
+        end
+
+        defmodule MyApp.UsersTest do
+          use ExUnit.Case
+        end
+      ]
+        |> rename("MyApp.Accounts")
+
+      # Verify the module is renamed
+      assert result =~ ~S[defmodule MyApp.Accounts do]
+      # Verify other code is preserved
+      assert result =~ ~S[@moduledoc "Users module"]
+      assert result =~ ~S[def list, do: :ok]
+      # UsersTest should NOT be renamed (different module)
+      assert result =~ ~S[defmodule MyApp.UsersTest do]
+    end
+  end
+
+  describe "rename/4 file renaming" do
+    setup do
+      patch(Engine.CodeMod.Rename.File, :function_exists?, false)
+      :ok
+    end
+
+    test "does not rename file with parent module", %{project: project} do
+      {:ok, {_applied, nil}} =
+        ~q[
+        defmodule MyApp.Server do
+          defmodule |State do
+          end
+        end
+        ]
+        |> rename_with_file("Config", "lib/my_app/server.ex", project)
+    end
+
+    test "does not rename file with sibling modules", %{project: project} do
+      assert {:ok, {_applied, nil}} =
+               ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.Accounts do
+        end
+        ]
+               |> rename_with_file("Members", "lib/my_app/users.ex", project)
+    end
+
+    test "does not rename file for non-conventional path", %{project: project} do
+      assert {:ok, {_applied, nil}} =
+               ~q[
+        defmodule |MyApp.MixProject do
+        end
+        ]
+               |> rename_with_file("MyApp.Renamed", "mix.exs", project)
+    end
+
+    test "renames lib file", %{project: project} do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+      ]
+        |> rename_with_file("MyApp.Accounts", "lib/my_app/users.ex", project)
+
+      assert rename_file.new_uri == subject_uri(project, "lib/my_app/accounts.ex")
+    end
+
+    test "does not rename file when only case changes", %{project: project} do
+      assert {:ok, {_applied, nil}} =
+               ~q[
+        defmodule |MyApp.Users do
+        end
+        ]
+               |> rename_with_file("MyApp.USERS", "lib/my_app/users.ex", project)
+    end
+
+    test "renames umbrella app file", %{project: project} do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+      ]
+        |> rename_with_file("MyApp.Accounts", "apps/my_app/lib/my_app/users.ex", project)
+
+      assert rename_file.new_uri == subject_uri(project, "apps/my_app/lib/my_app/accounts.ex")
+    end
+
+    test "renames umbrella app nested file", %{project: project} do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule |Engine.CodeMod do
+        end
+      ]
+        |> rename_with_file(
+          "Engine.Refactor",
+          "apps/engine/lib/engine/code_mod.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "apps/engine/lib/engine/refactor.ex")
+    end
+
+    test "renames test file", %{project: project} do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule |MyApp.UsersTest do
+        end
+      ]
+        |> rename_with_file("MyApp.AccountsTest", "test/my_app/users_test.exs", project)
+
+      assert rename_file.new_uri == subject_uri(project, "test/my_app/accounts_test.exs")
+    end
+
+    test "preserves components folder for phoenix component", %{project: project} do
+      patch(Engine.CodeMod.Rename.File, :phoenix_component_module?, fn MyAppWeb.IconComponent ->
+        true
+      end)
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.|IconComponent do
+        end
+      ]
+        |> rename_with_file(
+          "MyAppWeb.BadgeComponent",
+          "lib/my_app_web/components/icon_component.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/my_app_web/components/badge_component.ex")
+    end
+
+    test "preserves components folder for nested component", %{project: project} do
+      patch(
+        Engine.CodeMod.Rename.File,
+        :phoenix_component_module?,
+        fn MyAppWeb.Admin.IconComponent -> true end
+      )
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.Admin.|IconComponent do
+        end
+      ]
+        |> rename_with_file(
+          "MyAppWeb.Admin.BadgeComponent",
+          "lib/my_app_web/components/admin/icon_component.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/my_app_web/components/admin/badge_component.ex")
+    end
+
+    test "preserves components folder when Components in module name", %{project: project} do
+      patch(
+        Engine.CodeMod.Rename.File,
+        :phoenix_component_module?,
+        fn MyAppWeb.Components.Icons ->
+          true
+        end
+      )
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.Components.|Icons do
+        end
+      ]
+        |> rename_with_file(
+          "MyAppWeb.Components.Badges",
+          "lib/my_app_web/components/icons.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/my_app_web/components/badges.ex")
+    end
+
+    test "preserves controllers folder", %{project: project} do
+      patch(
+        Engine.CodeMod.Rename.File,
+        :phoenix_controller_module?,
+        fn MyAppWeb.UserController -> true end
+      )
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.|UserController do
+        end
+      ]
+        |> rename_with_file(
+          "MyAppWeb.AccountController",
+          "lib/my_app_web/controllers/user_controller.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/my_app_web/controllers/account_controller.ex")
+    end
+
+    test "preserves controllers folder for JSON module", %{project: project} do
+      patch(
+        Engine.CodeMod.Rename.File,
+        :phoenix_controller_module?,
+        fn MyAppWeb.UserController.JSON -> true end
+      )
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.UserController.|JSON do
+        end
+      ]
+        |> rename_with_file(
+          "MyAppWeb.UserController.API",
+          "lib/my_app_web/controllers/user_controller/json.ex",
+          project
+        )
+
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/my_app_web/controllers/user_controller/api.ex")
+    end
+
+    test "preserves live folder", %{project: project} do
+      patch(Engine.CodeMod.Rename.File, :phoenix_liveview_module?, fn MyAppWeb.UserLive ->
+        true
+      end)
+
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.|UserLive do
+        end
+      ]
+        |> rename_with_file("MyAppWeb.AccountLive", "lib/my_app_web/live/user_live.ex", project)
+
+      assert rename_file.new_uri == subject_uri(project, "lib/my_app_web/live/account_live.ex")
+    end
+  end
+
+  # Helpers
 
   defp prepare(code) do
     with {position, code} <- pop_cursor(code),
@@ -173,6 +854,23 @@ defmodule Engine.CodeMod.RenameTest do
     end
   end
 
+  defp rename_with_file(code, new_name, path, project) do
+    uri = subject_uri(project, path)
+
+    with {position, text} <- pop_cursor(code),
+         {:ok, document} <- open_document(uri, text),
+         {:ok, entries} <- Engine.Search.Indexer.Source.index_document(document),
+         :ok <- Search.Store.replace(entries),
+         {:ok, _document, analysis} <- Document.Store.fetch(uri, :analysis),
+         {:ok, document_changes} <- Rename.rename(analysis, position, new_name, nil) do
+      changes = document_changes |> Enum.map(& &1.edits) |> List.flatten()
+      applied = apply_edits(document, changes)
+      rename_file = document_changes |> Enum.map(& &1.rename_file) |> List.first()
+
+      {:ok, {applied, rename_file}}
+    end
+  end
+
   defp index(code) do
     project = project()
     uri = module_uri(project)
@@ -189,5 +887,22 @@ defmodule Engine.CodeMod.RenameTest do
     project
     |> file_path(Path.join("lib", "my_module.ex"))
     |> Document.Path.ensure_uri()
+  end
+
+  defp subject_uri(project, path) do
+    project
+    |> file_path(path)
+    |> Document.Path.ensure_uri()
+  end
+
+  defp open_document(uri, content) do
+    with :ok <- Document.Store.open(uri, content, 0) do
+      Document.Store.fetch(uri)
+    end
+  end
+
+  defp apply_edits(document, text_edits) do
+    {:ok, edited_document} = Document.apply_content_changes(document, 1, text_edits)
+    Document.to_string(edited_document)
   end
 end

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -83,7 +83,22 @@ defmodule Engine.CodeMod.RenameTest do
                |> prepare()
     end
 
-    test "returns error for unsupported entity" do
+    # Returns {:ok, nil} instead of an error because gen_lsp 0.11.x has a
+    # serialization bug where ErrorResponse crashes in Schematic.oneof.
+    # See commit message for details.
+    test "returns nil for unsupported entity" do
+      assert {:ok, nil} =
+               ~q[
+          x = 1
+          |x
+      ]
+               |> prepare()
+    end
+
+    @tag :skip
+    # TODO: restore once gen_lsp fixes ErrorResponse serialization in oneof,
+    # so we can return a user-friendly message via the LSP error response.
+    test "returns error with friendly message for unsupported entity" do
       assert {:error, "Renaming :variable is not supported for now"} =
                ~q[
           x = 1

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -922,13 +922,24 @@ defmodule Engine.CodeMod.RenameTest do
     end
   end
 
-  describe "rename/4 file renaming" do
-    setup do
-      patch(Engine.CodeMod.Rename.File, :function_exists?, false)
-      :ok
+  describe "rename/4 file rename eligibility" do
+    test "checks file rename eligibility once per document" do
+      patch(Rename.File, :maybe_rename, nil)
+
+      assert {:ok, _result} =
+               ~q[
+               defmodule |MyApp.Users do
+                 def current, do: MyApp.Users
+               end
+               ]
+               |> rename("MyApp.Accounts")
+
+      assert_called_once(
+        Rename.File.maybe_rename(_, %Engine.CodeMod.Rename.Entry{subtype: :definition}, _)
+      )
     end
 
-    test "does not rename file with parent module", %{project: project} do
+    test "does not rename a nested module's file", %{project: project} do
       {:ok, {_applied, nil}} =
         ~q[
         defmodule MyApp.Server do
@@ -939,7 +950,7 @@ defmodule Engine.CodeMod.RenameTest do
         |> rename_with_file("Config", "lib/my_app/server.ex", project)
     end
 
-    test "does not rename file with sibling modules", %{project: project} do
+    test "does not rename a file with multiple top-level modules", %{project: project} do
       assert {:ok, {_applied, nil}} =
                ~q[
         defmodule |MyApp.Users do
@@ -951,16 +962,20 @@ defmodule Engine.CodeMod.RenameTest do
                |> rename_with_file("Members", "lib/my_app/users.ex", project)
     end
 
-    test "does not rename file for non-conventional path", %{project: project} do
+    test "does not rename a file when its path matches neither convention", %{project: project} do
       assert {:ok, {_applied, nil}} =
                ~q[
-        defmodule |MyApp.MixProject do
+        defmodule |MyApp.Orders do
         end
         ]
-               |> rename_with_file("MyApp.Renamed", "mix.exs", project)
+               |> rename_with_file("MyApp.Ordering", "lib/my_app/index.ex", project)
     end
+  end
 
-    test "renames lib file", %{project: project} do
+  describe "rename/4 standard file convention" do
+    test "renames a file when its path matches the standard lib convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule |MyApp.Users do
@@ -971,7 +986,36 @@ defmodule Engine.CodeMod.RenameTest do
       assert rename_file.new_uri == subject_uri(project, "lib/my_app/accounts.ex")
     end
 
-    test "does not rename file when only case changes", %{project: project} do
+    test "derives the destination from the new module using the matched standard convention", %{
+      project: project
+    } do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+      ]
+        |> rename_with_file("Billing.Accounts", "lib/my_app/users.ex", project)
+
+      assert rename_file.new_uri == subject_uri(project, "lib/billing/accounts.ex")
+    end
+
+    test "rejects an existing destination file", %{project: project} do
+      destination = file_path(project, "lib/accounts.ex")
+      refute File.exists?(destination)
+      File.write!(destination, "defmodule Accounts do\nend\n")
+      on_exit(fn -> File.rm!(destination) end)
+
+      assert {:error, {:file_already_exists, ^destination}} =
+               ~q[
+               defmodule |Users do
+               end
+               ]
+               |> rename_with_file("Accounts", "lib/users.ex", project)
+    end
+
+    test "does not emit a file rename when the conventional destination is unchanged", %{
+      project: project
+    } do
       assert {:ok, {_applied, nil}} =
                ~q[
         defmodule |MyApp.Users do
@@ -980,7 +1024,9 @@ defmodule Engine.CodeMod.RenameTest do
                |> rename_with_file("MyApp.USERS", "lib/my_app/users.ex", project)
     end
 
-    test "renames umbrella app file", %{project: project} do
+    test "renames a file when its path matches the standard umbrella convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule |MyApp.Users do
@@ -991,7 +1037,9 @@ defmodule Engine.CodeMod.RenameTest do
       assert rename_file.new_uri == subject_uri(project, "apps/my_app/lib/my_app/accounts.ex")
     end
 
-    test "renames umbrella app nested file", %{project: project} do
+    test "derives the conventional destination inside the same umbrella application", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule |Engine.CodeMod do
@@ -1007,7 +1055,9 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "apps/engine/lib/engine/refactor.ex")
     end
 
-    test "renames test file", %{project: project} do
+    test "renames a file when its path matches the standard test convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule |MyApp.UsersTest do
@@ -1017,12 +1067,12 @@ defmodule Engine.CodeMod.RenameTest do
 
       assert rename_file.new_uri == subject_uri(project, "test/my_app/accounts_test.exs")
     end
+  end
 
-    test "preserves components folder for phoenix component", %{project: project} do
-      patch(Engine.CodeMod.Rename.File, :phoenix_component_module?, fn MyAppWeb.IconComponent ->
-        true
-      end)
-
+  describe "rename/4 Phoenix file convention" do
+    test "renames a file when its path matches the Phoenix components convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.|IconComponent do
@@ -1038,13 +1088,9 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "lib/my_app_web/components/badge_component.ex")
     end
 
-    test "preserves components folder for nested component", %{project: project} do
-      patch(
-        Engine.CodeMod.Rename.File,
-        :phoenix_component_module?,
-        fn MyAppWeb.Admin.IconComponent -> true end
-      )
-
+    test "preserves the Phoenix components convention for a nested module", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.Admin.|IconComponent do
@@ -1060,15 +1106,7 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "lib/my_app_web/components/admin/badge_component.ex")
     end
 
-    test "preserves components folder when Components in module name", %{project: project} do
-      patch(
-        Engine.CodeMod.Rename.File,
-        :phoenix_component_module?,
-        fn MyAppWeb.Components.Icons ->
-          true
-        end
-      )
-
+    test "does not duplicate a Phoenix folder present in the module name", %{project: project} do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.Components.|Icons do
@@ -1084,13 +1122,9 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "lib/my_app_web/components/badges.ex")
     end
 
-    test "preserves controllers folder", %{project: project} do
-      patch(
-        Engine.CodeMod.Rename.File,
-        :phoenix_controller_module?,
-        fn MyAppWeb.UserController -> true end
-      )
-
+    test "renames a file when its path matches the Phoenix controllers convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.|UserController do
@@ -1106,13 +1140,27 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "lib/my_app_web/controllers/account_controller.ex")
     end
 
-    test "preserves controllers folder for JSON module", %{project: project} do
-      patch(
-        Engine.CodeMod.Rename.File,
-        :phoenix_controller_module?,
-        fn MyAppWeb.UserController.JSON -> true end
-      )
+    test "derives the destination from the new module using the matched Phoenix convention", %{
+      project: project
+    } do
+      {:ok, {_applied, rename_file}} =
+        ~q[
+        defmodule MyAppWeb.Admin.|UserController do
+        end
+      ]
+        |> rename_with_file(
+          "BillingWeb.AccountController",
+          "lib/my_app_web/controllers/admin/user_controller.ex",
+          project
+        )
 
+      assert rename_file.new_uri ==
+               subject_uri(project, "lib/billing_web/controllers/account_controller.ex")
+    end
+
+    test "preserves the Phoenix controllers convention for a nested module", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.UserController.|JSON do
@@ -1128,11 +1176,9 @@ defmodule Engine.CodeMod.RenameTest do
                subject_uri(project, "lib/my_app_web/controllers/user_controller/api.ex")
     end
 
-    test "preserves live folder", %{project: project} do
-      patch(Engine.CodeMod.Rename.File, :phoenix_liveview_module?, fn MyAppWeb.UserLive ->
-        true
-      end)
-
+    test "renames a file when its path matches the Phoenix live convention", %{
+      project: project
+    } do
       {:ok, {_applied, rename_file}} =
         ~q[
         defmodule MyAppWeb.|UserLive do

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -287,10 +287,29 @@ defmodule Engine.CodeMod.RenameTest do
              ~q[
              defmodule |MyApp.Users do
              end
+             defmodule MyApp.Users.Query do
+             end
              defmodule MyApp.Accounts.Query do
              end
              ]
              |> rename("MyApp.Accounts")
+  end
+
+  test "allows an existing destination namespace" do
+    assert {:ok, result} =
+             ~q[
+             defmodule |Parent2 do
+             end
+             defmodule Parent.ChildA do
+             end
+             defmodule Parent.ChildB do
+             end
+             ]
+             |> rename("Parent")
+
+    assert result =~ "defmodule Parent do"
+    assert result =~ "defmodule Parent.ChildA do"
+    assert result =~ "defmodule Parent.ChildB do"
   end
 
   test "rejects rename while proxy is still buffering" do
@@ -541,6 +560,78 @@ defmodule Engine.CodeMod.RenameTest do
         |> rename("MyApp.Members")
 
       assert result =~ ~S[  Users, Members,]
+    end
+
+    test "renames the shared prefix in multi-alias syntax" do
+      {:ok, result} =
+        ~q[
+        defmodule Parent.|Child do
+        end
+
+        defmodule Parent do
+          alias Parent.{Child}
+        end
+        ]
+        |> rename("Parent2.Child")
+
+      assert result =~ ~S[alias Parent2.{Child}]
+    end
+
+    test "preserves grouped-alias siblings when a member changes namespace" do
+      {:ok, result} =
+        ~q[
+        defmodule Parent.|Child do
+        end
+
+        defmodule Consumer do
+          alias Parent.{
+            # keep this comment
+            Child, Other
+          }, warn: false
+        end
+        ]
+        |> rename("Parent2.Child")
+
+      assert result =~ "# keep this comment"
+      assert result =~ "alias Parent2.Child, warn: false\n  alias Parent.Other, warn: false"
+      assert match?({:ok, _, _}, Forge.Ast.from(result))
+    end
+
+    test "renames multiple affected grouped-alias members" do
+      {:ok, result} =
+        ~q[
+        defmodule Parent.|Child do
+        end
+
+        defmodule Parent.Child.Sub do
+        end
+
+        defmodule Consumer do
+          alias Parent.{Other, Child, Child.Sub,}
+        end
+        ]
+        |> rename("Parent2.RenamedChild")
+
+      assert result =~
+               "alias Parent.Other\n  alias Parent2.RenamedChild\n  alias Parent2.RenamedChild.Sub"
+
+      assert match?({:ok, _, _}, Forge.Ast.from(result))
+    end
+
+    test "keeps split grouped aliases inside their enclosing expression" do
+      {:ok, result} =
+        ~q[
+        defmodule Parent.|Child do
+        end
+
+        defmodule Consumer do
+          if enabled?(), do: alias Parent.{Child, Other}
+        end
+        ]
+        |> rename("Parent2.Child")
+
+      assert result =~ "if enabled?(), do: (alias Parent2.Child; alias Parent.Other)"
+      assert match?({:ok, _, _}, Forge.Ast.from(result))
     end
   end
 

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -220,6 +220,90 @@ defmodule Engine.CodeMod.RenameTest do
   end
 
   describe "rename/4 with references" do
+    test "renames use reference" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Users do
+        end
+
+        defmodule MyApp.Web do
+          use MyApp.Users
+        end
+        ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[use MyApp.Accounts]
+    end
+
+    test "renames local use reference" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Auth.Session do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.Auth.Session
+          use Session
+        end
+        ]
+        |> rename("MyApp.Identity.Token")
+
+      assert result =~ ~S[alias MyApp.Identity.Token]
+      assert result =~ ~S[use Token]
+    end
+
+    test "renames use reference through alias" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Auth.Session do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.Auth, as: Auth
+          alias MyApp.Identity.Token
+          use Auth.Session
+        end
+        ]
+        |> rename("MyApp.Identity.Token")
+
+      assert result =~ ~S[use MyApp.Identity.Token]
+      refute result =~ ~S[use Identity.Token]
+    end
+
+    test "keeps explicit alias in use reference" do
+      {:ok, result} =
+        ~q[
+        defmodule |MyApp.Auth.Session do
+        end
+
+        defmodule MyApp.Web do
+          alias MyApp.Auth.Session, as: Session
+          use Session
+        end
+        ]
+        |> rename("MyApp.Identity.Token")
+
+      assert result =~ ~S[alias MyApp.Identity.Token, as: Session]
+      assert result =~ ~S[use Session]
+    end
+
+    test "keeps explicit alias for single segment module" do
+      {:ok, result} =
+        ~q[
+        defmodule |Users do
+        end
+
+        defmodule MyApp.Web do
+          alias Users, as: Users
+          use Users
+        end
+        ]
+        |> rename("Accounts")
+
+      assert result =~ ~S[alias Accounts, as: Users]
+      assert result =~ ~S[use Users]
+    end
+
     test "does not rename similar module names" do
       {:ok, result} =
         ~q[
@@ -561,6 +645,22 @@ defmodule Engine.CodeMod.RenameTest do
 
       assert result =~ ~S[defmodule Accounts do]
       assert result =~ ~S[alias Accounts]
+    end
+
+    test "renames single segment module to full module name" do
+      {:ok, result} =
+        ~q[
+        defmodule |Users do
+        end
+
+        defmodule MyApp.Web do
+          use Users
+        end
+      ]
+        |> rename("MyApp.Accounts")
+
+      assert result =~ ~S[defmodule MyApp.Accounts do]
+      assert result =~ ~S[use MyApp.Accounts]
     end
 
     test "handles renaming to completely different module path" do

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -2,11 +2,14 @@ defmodule Engine.CodeMod.RenameTest do
   use ExUnit.Case, async: false
   use Patch
 
+  import Forge.EngineApi.Messages
   import Forge.Test.CodeSigil
   import Forge.Test.CursorSupport
+  import Forge.Test.EventualAssertions
   import Forge.Test.Fixtures
 
   alias Engine.CodeMod.Rename
+  alias Engine.Commands.RenameSupervisor
   alias Engine.ManagerApi
   alias Forge.Document
 
@@ -33,7 +36,7 @@ defmodule Engine.CodeMod.RenameTest do
       {:ok, query_entries(store, subject, constraints, :prefix)}
     end)
 
-    {:ok, project: project}
+    {:ok, project: project, store: store}
   end
 
   describe "prepare/2" do
@@ -106,6 +109,82 @@ defmodule Engine.CodeMod.RenameTest do
       ]
                |> prepare()
     end
+  end
+
+  test "does not track rename without document changes", %{project: project, store: store} do
+    patch(ManagerApi, :search_store_exact, fn ^project, subject, constraints ->
+      if Keyword.get(constraints, :subtype) == :definition do
+        {:ok, query_entries(store, subject, constraints, :exact)}
+      else
+        {:ok, []}
+      end
+    end)
+
+    patch(ManagerApi, :search_store_prefix, fn _project, _subject, _constraints -> {:ok, []} end)
+
+    assert {:ok, _result} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+
+    refute_called(RenameSupervisor.start_renaming(_, _, _, _, _))
+  end
+
+  test "rejects rename while another rename is in progress" do
+    start_supervised!(RenameSupervisor)
+    patch(Engine.Api.Proxy, :start_buffering, :ok)
+    uri = "file://file.ex"
+
+    {:ok, pid} =
+      RenameSupervisor.start_renaming(
+        %{uri => file_saved(uri: uri)},
+        [],
+        [],
+        fn _delta, _message -> :ok end,
+        fn -> :ok end
+      )
+
+    assert {:error, :rename_in_progress} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+
+    send(pid, :timeout)
+    refute_eventually Process.whereis(Engine.Commands.Rename)
+  end
+
+  test "rejects rename when progress tracking starts concurrently" do
+    patch(Engine.Progress, :begin, {:error, :unsupported})
+    patch(RenameSupervisor, :start_renaming, {:error, {:already_started, self()}})
+
+    assert {:error, :rename_in_progress} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
+  test "rejects rename while proxy is still buffering" do
+    test = self()
+    start_supervised!(RenameSupervisor)
+    patch(Engine.Progress, :begin, {:ok, :rename})
+    patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
+    patch(Engine.Api.Proxy, :start_buffering, {:error, {:already_buffering, self()}})
+
+    assert {:error, :rename_in_progress} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+
+    assert_receive :complete_progress
+    refute_receive :complete_progress
   end
 
   describe "rename/4 basic" do

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -12,6 +12,7 @@ defmodule Engine.CodeMod.RenameTest do
   alias Engine.CodeMod.Rename.Prepare
   alias Engine.Commands.RenameSupervisor
   alias Engine.ManagerApi
+  alias Engine.Search.Indexer.Source
   alias Forge.Document
 
   setup do
@@ -191,7 +192,7 @@ defmodule Engine.CodeMod.RenameTest do
 
     patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
 
-    patch(Rename.Module, :rename, fn _analysis, _range, _new_name, _module ->
+    patch(Rename.Module, :rename, fn _analysis, _range, _new_name, _module, _rename_files? ->
       send(test, {:calculating_edits, self()})
       receive do: (:continue -> [])
     end)
@@ -1062,6 +1063,56 @@ defmodule Engine.CodeMod.RenameTest do
         ]
                |> rename_with_file("MyApp.Ordering", "lib/my_app/index.ex", project)
     end
+
+    test "does not rename files when file operations are disabled", %{project: project} do
+      assert {:ok, {_applied, nil}} =
+               ~q[
+               defmodule |MyApp.Users do
+               end
+               ]
+               |> rename_with_file("MyApp.Accounts", "lib/my_app/users.ex", project, false)
+    end
+  end
+
+  describe "rename/4 document versions" do
+    test "captures the version of an open document" do
+      {position, code} =
+        pop_cursor(~q[
+        defmodule |MyApp.Users do
+        end
+        ])
+
+      {:ok, _document, analysis} = index(code)
+
+      assert {:ok, [%Document.Changes{expected_version: 1}]} =
+               Rename.rename(analysis, position, "MyApp.Accounts", nil)
+    end
+
+    test "omits the version for a reference loaded from disk", %{
+      project: project,
+      store: store
+    } do
+      {position, code} =
+        pop_cursor(~q[
+        defmodule |MyApp.Users do
+        end
+        ])
+
+      {:ok, _document, analysis} = index(code)
+      path = file_path(project, "lib/rename_version_consumer.ex")
+      File.write!(path, "defmodule Consumer do\n  alias MyApp.Users\nend\n")
+      on_exit(fn -> File.rm!(path) end)
+
+      reference_document = Document.new(path, File.read!(path), 1)
+      {:ok, entries} = Source.index_document(reference_document)
+      Agent.update(store, &(&1 ++ entries))
+
+      assert {:ok, changes} = Rename.rename(analysis, position, "MyApp.Accounts", nil)
+      reference_uri = Document.Path.ensure_uri(path)
+
+      assert %Document.Changes{expected_version: nil} =
+               Enum.find(changes, &(&1.document.uri == reference_uri))
+    end
   end
 
   describe "rename/4 standard file convention" do
@@ -1308,15 +1359,16 @@ defmodule Engine.CodeMod.RenameTest do
     end
   end
 
-  defp rename_with_file(code, new_name, path, project) do
+  defp rename_with_file(code, new_name, path, project, rename_files? \\ true) do
     uri = subject_uri(project, path)
 
     with {position, text} <- pop_cursor(code),
          {:ok, document} <- open_document(uri, text),
-         {:ok, entries} <- Engine.Search.Indexer.Source.index_document(document),
+         {:ok, entries} <- Source.index_document(document),
          :ok <- ManagerApi.search_store_replace(project, entries),
          {:ok, _document, analysis} <- Document.Store.fetch(uri, :analysis),
-         {:ok, document_changes} <- Rename.rename(analysis, position, new_name, nil) do
+         {:ok, document_changes} <-
+           Rename.rename(analysis, position, new_name, nil, rename_files?) do
       changes = document_changes |> Enum.map(& &1.edits) |> List.flatten()
       applied = apply_edits(document, changes)
       rename_file = document_changes |> Enum.map(& &1.rename_file) |> List.first()

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -1,36 +1,36 @@
 defmodule Engine.CodeMod.RenameTest do
-  alias Engine.CodeMod.Rename
-  alias Engine.Search
-  alias Engine.Search.Store.Backends
-  alias Forge.Document
-
   use ExUnit.Case, async: false
   use Patch
 
   import Forge.Test.CodeSigil
   import Forge.Test.CursorSupport
   import Forge.Test.Fixtures
-  import Forge.Test.EventualAssertions
+
+  alias Engine.CodeMod.Rename
+  alias Engine.ManagerApi
+  alias Forge.Document
 
   setup do
     project = project()
 
-    Backends.Ets.destroy_all(project)
     Engine.set_project(project)
+    {:ok, store} = Agent.start_link(fn -> [] end)
 
+    start_supervised!(Engine.ApplicationCache)
     start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
     start_supervised!(Engine.Dispatch)
-    start_supervised!(Backends.Ets)
 
-    start_supervised!(
-      {Search.Store, [project, fn _ -> {:ok, []} end, fn _, _ -> {:ok, [], []} end, Backends.Ets]}
-    )
+    patch(ManagerApi, :search_store_replace, fn ^project, entries ->
+      Agent.update(store, fn _ -> entries end)
+      :ok
+    end)
 
-    Search.Store.enable()
-    assert_eventually(Search.Store.loaded?(), 1500)
+    patch(ManagerApi, :search_store_exact, fn ^project, subject, constraints ->
+      {:ok, query_entries(store, subject, constraints, :exact)}
+    end)
 
-    on_exit(fn ->
-      Backends.Ets.destroy_all(project)
+    patch(ManagerApi, :search_store_prefix, fn ^project, subject, constraints ->
+      {:ok, query_entries(store, subject, constraints, :prefix)}
     end)
 
     {:ok, project: project}
@@ -875,7 +875,7 @@ defmodule Engine.CodeMod.RenameTest do
     with {position, text} <- pop_cursor(code),
          {:ok, document} <- open_document(uri, text),
          {:ok, entries} <- Engine.Search.Indexer.Source.index_document(document),
-         :ok <- Search.Store.replace(entries),
+         :ok <- ManagerApi.search_store_replace(project, entries),
          {:ok, _document, analysis} <- Document.Store.fetch(uri, :analysis),
          {:ok, document_changes} <- Rename.rename(analysis, position, new_name, nil) do
       changes = document_changes |> Enum.map(& &1.edits) |> List.flatten()
@@ -887,16 +887,42 @@ defmodule Engine.CodeMod.RenameTest do
   end
 
   defp index(code) do
-    project = project()
+    project = Engine.get_project()
     uri = module_uri(project)
 
     with :ok <- Document.Store.open(uri, code, 1),
          {:ok, document, analysis} <- Document.Store.fetch(uri, :analysis),
          {:ok, entries} <- Engine.Search.Indexer.Quoted.index(analysis) do
-      Search.Store.replace(entries)
+      ManagerApi.search_store_replace(project, entries)
       {:ok, document, analysis}
     end
   end
+
+  defp query_entries(store, subject, constraints, match_type) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+    subject = format_subject(subject)
+
+    store
+    |> Agent.get(& &1)
+    |> Enum.filter(fn entry ->
+      matches_constraint?(entry.type, type) and matches_constraint?(entry.subtype, subtype) and
+        matches_subject?(format_subject(entry.subject), subject, match_type)
+    end)
+  end
+
+  defp matches_subject?(entry_subject, subject, :exact), do: entry_subject == subject
+
+  defp matches_subject?(entry_subject, subject, :prefix),
+    do: String.starts_with?(entry_subject, subject)
+
+  defp matches_constraint?(_value, :_), do: true
+  defp matches_constraint?(value, value), do: true
+  defp matches_constraint?(_, _), do: false
+
+  defp format_subject(subject) when is_atom(subject), do: Forge.Formats.module(subject)
+  defp format_subject(subject) when is_binary(subject), do: subject
+  defp format_subject(subject), do: to_string(subject)
 
   defp module_uri(project) do
     project

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -9,6 +9,7 @@ defmodule Engine.CodeMod.RenameTest do
   import Forge.Test.Fixtures
 
   alias Engine.CodeMod.Rename
+  alias Engine.CodeMod.Rename.Prepare
   alias Engine.Commands.RenameSupervisor
   alias Engine.ManagerApi
   alias Forge.Document
@@ -35,6 +36,10 @@ defmodule Engine.CodeMod.RenameTest do
     patch(ManagerApi, :search_store_prefix, fn ^project, subject, constraints ->
       {:ok, query_entries(store, subject, constraints, :prefix)}
     end)
+
+    patch(Engine.Progress, :begin, {:error, :rejected})
+    patch(Engine.Api.Proxy, :start_buffering, :ok)
+    start_supervised!(RenameSupervisor)
 
     {:ok, project: project, store: store}
   end
@@ -132,9 +137,52 @@ defmodule Engine.CodeMod.RenameTest do
     refute_called(RenameSupervisor.start_renaming(_, _, _, _, _))
   end
 
+  test "reports progress before calculating edits" do
+    test = self()
+
+    patch(Engine.Progress, :begin, fn "Renaming", [message: message] ->
+      send(test, {:begin_progress, message})
+      {:ok, :rename}
+    end)
+
+    patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
+
+    patch(Rename.Module, :rename, fn _range, _new_name, _module ->
+      send(test, {:calculating_edits, self()})
+      receive do: (:continue -> [])
+    end)
+
+    task =
+      Task.async(fn ->
+        ~q[defmodule |MyApp.Users do
+        end]
+        |> rename("MyApp.Accounts")
+      end)
+
+    assert_receive {:begin_progress, "Calculating edits"}
+    assert_receive {:calculating_edits, planner}
+    send(planner, :continue)
+
+    assert {:ok, _changes} = Task.await(task)
+    assert_receive :complete_progress
+  end
+
+  test "completes progress when planning fails" do
+    test = self()
+
+    patch(Engine.Progress, :begin, {:ok, :rename})
+    patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
+    patch(Prepare, :resolve, {:error, :planning_failed})
+
+    assert {:error, :planning_failed} =
+             ~q[defmodule |MyApp.Users do
+             end]
+             |> rename("MyApp.Accounts")
+
+    assert_receive :complete_progress
+  end
+
   test "rejects rename while another rename is in progress" do
-    start_supervised!(RenameSupervisor)
-    patch(Engine.Api.Proxy, :start_buffering, :ok)
     uri = "file://file.ex"
 
     {:ok, pid} =
@@ -171,7 +219,6 @@ defmodule Engine.CodeMod.RenameTest do
 
   test "rejects rename while proxy is still buffering" do
     test = self()
-    start_supervised!(RenameSupervisor)
     patch(Engine.Progress, :begin, {:ok, :rename})
     patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
     patch(Engine.Api.Proxy, :start_buffering, {:error, {:already_buffering, self()}})

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -262,6 +262,37 @@ defmodule Engine.CodeMod.RenameTest do
              |> rename("MyApp.Accounts")
   end
 
+  for invalid_name <- ["", "Elixir", "my_app.Users", "MyApp..Users", "MyApp.Users;System.halt()"] do
+    test "rejects invalid module name #{inspect(invalid_name)}" do
+      assert {:error, {:invalid_module_name, unquote(invalid_name)}} =
+               ~q[defmodule |MyApp.Users do
+               end]
+               |> rename(unquote(invalid_name))
+    end
+  end
+
+  test "rejects an existing destination module" do
+    assert {:error, {:module_already_exists, "MyApp.Accounts"}} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             defmodule MyApp.Accounts do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
+  test "rejects an existing destination descendant" do
+    assert {:error, {:module_already_exists, "MyApp.Accounts.Query"}} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             defmodule MyApp.Accounts.Query do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
   test "rejects rename while proxy is still buffering" do
     test = self()
     patch(Engine.Progress, :begin, {:ok, :rename})

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -104,6 +104,32 @@ defmodule Engine.CodeMod.RenameTest do
       assert result == "Admin.Query"
     end
 
+    test "prepares an Ecto repo declaration from source while the index is loading" do
+      patch(ManagerApi, :search_store_exact, {:error, :loading})
+
+      assert {:ok, "MyApp.Repo", _range} =
+               ~q[
+               defmodule MyApp.|Repo do
+                 use Ecto.Repo,
+                   otp_app: :my_app,
+                   adapter: Ecto.Adapters.Postgres
+               end
+               ]
+               |> prepare()
+    end
+
+    test "prepares a protocol declaration from source while the index is loading" do
+      patch(ManagerApi, :search_store_exact, {:error, :loading})
+
+      assert {:ok, "MyApp.Protocol", _range} =
+               ~q[
+               defprotocol MyApp.|Protocol do
+                 def run(value)
+               end
+               ]
+               |> prepare()
+    end
+
     test "returns nil for module reference" do
       assert {:ok, nil} =
                ~q[
@@ -142,16 +168,8 @@ defmodule Engine.CodeMod.RenameTest do
     end
   end
 
-  test "does not track rename without document changes", %{project: project, store: store} do
-    patch(ManagerApi, :search_store_exact, fn ^project, subject, constraints ->
-      if Keyword.get(constraints, :subtype) == :definition do
-        {:ok, query_entries(store, subject, constraints, :exact)}
-      else
-        {:ok, []}
-      end
-    end)
-
-    patch(ManagerApi, :search_store_prefix, fn _project, _subject, _constraints -> {:ok, []} end)
+  test "does not track rename without document changes" do
+    patch(Rename.Module, :rename, [])
 
     assert {:ok, _result} =
              ~q[
@@ -173,7 +191,7 @@ defmodule Engine.CodeMod.RenameTest do
 
     patch(Engine.Progress, :complete, fn :rename -> send(test, :complete_progress) end)
 
-    patch(Rename.Module, :rename, fn _range, _new_name, _module ->
+    patch(Rename.Module, :rename, fn _analysis, _range, _new_name, _module ->
       send(test, {:calculating_edits, self()})
       receive do: (:continue -> [])
     end)
@@ -260,7 +278,81 @@ defmodule Engine.CodeMod.RenameTest do
     refute_receive :complete_progress
   end
 
+  test "returns an error when exact references are unavailable" do
+    patch(ManagerApi, :search_store_exact, {:error, :loading})
+
+    assert {:error, :loading} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
+  test "returns an error when descendant references are unavailable" do
+    patch(ManagerApi, :search_store_prefix, {:error, :loading})
+
+    assert {:error, :loading} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
+  test "returns an error when exact reference search is unavailable" do
+    patch(ManagerApi, :search_store_exact, [])
+
+    assert {:error, :search_store_unavailable} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
+  test "returns an error when descendant reference search is unavailable" do
+    patch(ManagerApi, :search_store_prefix, [])
+
+    assert {:error, :search_store_unavailable} =
+             ~q[
+             defmodule |MyApp.Users do
+             end
+             ]
+             |> rename("MyApp.Accounts")
+  end
+
   describe "rename/4 basic" do
+    test "renames an Ecto repo declaration when the index has no definition" do
+      patch(ManagerApi, :search_store_exact, {:ok, []})
+
+      assert {:ok, result} =
+               ~q[
+               defmodule MyApp.|Repo do
+                 use Ecto.Repo,
+                   otp_app: :my_app,
+                   adapter: Ecto.Adapters.Postgres
+               end
+               ]
+               |> rename("MyApp.DataRepo")
+
+      assert result =~ ~S[defmodule MyApp.DataRepo do]
+    end
+
+    test "renames a protocol declaration when the index has no definition" do
+      patch(ManagerApi, :search_store_exact, {:ok, []})
+
+      assert {:ok, result} =
+               ~q[
+               defprotocol MyApp.|Protocol do
+                 def run(value)
+               end
+               ]
+               |> rename("MyApp.Runnable")
+
+      assert result =~ ~S[defprotocol MyApp.Runnable do]
+    end
+
     test "renames at definition" do
       {:ok, result} =
         ~q[

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -78,6 +78,32 @@ defmodule Engine.CodeMod.RenameTest do
       assert result == "MyApp.Users"
     end
 
+    test "returns Inner instead of MyApp.Test.Inner for a nested module" do
+      {:ok, result, _} =
+        ~q[
+        defmodule MyApp.Test do
+          defmodule |Inner do
+          end
+        end
+      ]
+        |> prepare()
+
+      assert result == "Inner"
+    end
+
+    test "returns a multi-segment relative module name" do
+      {:ok, result, _} =
+        ~q[
+        defmodule MyApp.Users do
+          defmodule Admin.|Query do
+          end
+        end
+      ]
+        |> prepare()
+
+      assert result == "Admin.Query"
+    end
+
     test "returns nil for module reference" do
       assert {:ok, nil} =
                ~q[
@@ -300,7 +326,64 @@ defmodule Engine.CodeMod.RenameTest do
       assert result =~ ~S[defmodule MyApp.Session do]
     end
 
-    test "renames nested module definition" do
+    test "does not qualify a renamed nested module declaration" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.Test do
+          defmodule |Inner do
+          end
+        end
+
+        defmodule MyApp.TestTest do
+          alias MyApp.Test.Inner
+        end
+      ]
+        |> rename("InnerRenamed")
+
+      assert result == ~q[
+        defmodule MyApp.Test do
+          defmodule InnerRenamed do
+          end
+        end
+
+        defmodule MyApp.TestTest do
+          alias MyApp.Test.InnerRenamed
+        end
+      ]
+
+      refute result =~ "defmodule MyApp.Test.InnerRenamed"
+    end
+
+    test "does not rename the same nested name under another module" do
+      {:ok, result} =
+        ~q[
+        defmodule MyApp.Test do
+          defmodule |Inner do
+          end
+        end
+
+        defmodule OtherApp.Test do
+          defmodule Inner do
+          end
+        end
+
+        defmodule MyApp.Consumer do
+          alias MyApp.Test.Inner
+        end
+
+        defmodule OtherApp.Consumer do
+          alias OtherApp.Test.Inner
+        end
+      ]
+        |> rename("InnerRenamed")
+
+      assert result =~ ~S[alias MyApp.Test.InnerRenamed]
+      assert result =~ ~S[defmodule OtherApp.Test do]
+      assert result =~ ~S[alias OtherApp.Test.Inner]
+      refute result =~ ~S[alias OtherApp.Test.InnerRenamed]
+    end
+
+    test "preserves every segment requested for a relative declaration" do
       {:ok, result} =
         ~q[
         defmodule MyApp.Users do
@@ -312,18 +395,10 @@ defmodule Engine.CodeMod.RenameTest do
           alias MyApp.Users.Query
         end
       ]
-        |> rename("Filter")
+        |> rename("Admin.Filter")
 
-      assert result == ~q[
-        defmodule MyApp.Users do
-          defmodule Filter do
-          end
-        end
-
-        defmodule MyApp.UsersTest do
-          alias MyApp.Users.Filter
-        end
-      ]
+      assert result =~ ~S[defmodule Admin.Filter do]
+      assert result =~ ~S[alias MyApp.Users.Admin.Filter]
     end
 
     test "renames multi-alias syntax" do

--- a/apps/engine/test/engine/code_mod/rename_test.exs
+++ b/apps/engine/test/engine/code_mod/rename_test.exs
@@ -1144,6 +1144,57 @@ defmodule Engine.CodeMod.RenameTest do
       assert %Document.Changes{expected_version: nil} =
                Enum.find(changes, &(&1.document.uri == reference_uri))
     end
+
+    test "uses current entries and skips missing indexed files", %{
+      project: project
+    } do
+      {position, users_source} =
+        pop_cursor(~q[
+        defmodule MyApp.|Users do
+        end
+        ])
+
+      users_uri = subject_uri(project, "lib/users.ex")
+      consumer_uri = subject_uri(project, "lib/consumer.ex")
+      consumer_source = "defmodule Consumer do\n  alias MyApp.Users\nend\n"
+
+      :ok = Document.Store.open(users_uri, users_source, 1)
+      {:ok, users, users_analysis} = Document.Store.fetch(users_uri, :analysis)
+      {:ok, users_entries} = Source.index_document(users)
+
+      :ok = Document.Store.open(consumer_uri, consumer_source, 1)
+      {:ok, consumer} = Document.Store.fetch(consumer_uri)
+      {:ok, consumer_entries} = Source.index_document(consumer)
+
+      missing_path = file_path(project, "lib/missing_consumer.ex")
+      missing_document = Document.new(missing_path, consumer_source, 1)
+      {:ok, missing_entries} = Source.index_document(missing_document)
+
+      :ok =
+        ManagerApi.search_store_replace(
+          project,
+          users_entries ++ consumer_entries ++ missing_entries
+        )
+
+      shifted_source =
+        "# unsaved shift\ndefmodule Consumer do\n  alias MyApp.Users.Report\nend\n"
+
+      :ok =
+        Document.Store.update(consumer_uri, fn document ->
+          Document.apply_content_changes(document, 2, [Document.Edit.new(shifted_source)])
+        end)
+
+      assert {:ok, changes} =
+               Rename.rename(users_analysis, position, "MyApp.Accounts", nil, false)
+
+      assert %Document.Changes{document: document, edits: edits, expected_version: 2} =
+               Enum.find(changes, &(&1.document.uri == consumer_uri))
+
+      assert {:ok, updated} = Document.apply_content_changes(document, 3, edits)
+
+      assert Document.to_string(updated) ==
+               "# unsaved shift\ndefmodule Consumer do\n  alias MyApp.Accounts.Report\nend\n"
+    end
   end
 
   describe "rename/4 standard file convention" do

--- a/apps/engine/test/engine/commands/rename_test.exs
+++ b/apps/engine/test/engine/commands/rename_test.exs
@@ -1,0 +1,152 @@
+defmodule Engine.Commands.RenameTest do
+  alias Engine.Api.Proxy
+  alias Engine.Commands.Rename
+  alias Engine.Commands.RenameSupervisor
+  alias Engine.Search.Store
+
+  import Forge.EngineApi.Messages
+  import Forge.Test.EventualAssertions
+
+  use ExUnit.Case
+  use Patch
+
+  setup do
+    start_supervised!(RenameSupervisor)
+    :ok
+  end
+
+  setup do
+    pid = self()
+
+    on_report_progress = fn delta, message -> update_progress(pid, delta, message) end
+    on_complete = fn -> complete_progress(pid) end
+
+    patch(Proxy, :start_buffering, :ok)
+    %{on_report_progress: on_report_progress, on_complete: on_complete}
+  end
+
+  test "it should start buffering when a rename is in progress", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    uri = "file://file.ex"
+    uri_with_expected_operation = %{uri => file_changed(uri: uri)}
+    paths_to_reindex = [uri]
+
+    {:ok, _pid} =
+      RenameSupervisor.start_renaming(
+        uri_with_expected_operation,
+        paths_to_reindex,
+        [],
+        on_report_progress,
+        on_complete
+      )
+
+    assert_called(Proxy.start_buffering())
+  end
+
+  test "it should complete and shutdown the process when rename is done", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    uri = "file://file.ex"
+    paths_to_reindex = [uri]
+
+    {:ok, _pid} =
+      RenameSupervisor.start_renaming(
+        %{uri => file_saved(uri: uri)},
+        paths_to_reindex,
+        [],
+        on_report_progress,
+        on_complete
+      )
+
+    Rename.update_progress(file_saved(uri: uri))
+
+    assert_receive {:update_progress, 1, ""}
+    assert_receive :complete_progress
+
+    refute_eventually Process.whereis(Rename)
+  end
+
+  test "it should still be in progress if there are files yet to be saved", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    uri1 = "file://file1.ex"
+    old_uri = "file://file2.ex"
+    new_uri = "file://file3.ex"
+
+    uri_with_expected_operation = %{
+      uri1 => file_changed(uri: uri1),
+      new_uri => file_saved(uri: new_uri)
+    }
+
+    paths_to_reindex = [uri1, new_uri]
+    paths_to_delete = [old_uri]
+
+    {:ok, _pid} =
+      RenameSupervisor.start_renaming(
+        uri_with_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_report_progress,
+        on_complete
+      )
+
+    Rename.update_progress(file_changed(uri: uri1))
+    assert_receive {:update_progress, 1, ""}
+    refute_receive :complete_progress
+  end
+
+  test "it should reindex new files and delete old entries when all files are modified", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    patch(Store, :clear, :ok)
+    old_uri = "file://old_file.ex"
+    new_uri = "file://new_file.ex"
+    another_uri = "file://file.ex"
+
+    uri_with_expected_operation = %{
+      old_uri => file_changed(uri: old_uri),
+      new_uri => file_saved(uri: new_uri)
+    }
+
+    paths_to_reindex = [new_uri, another_uri]
+    paths_to_delete = [old_uri]
+
+    {:ok, _pid} =
+      RenameSupervisor.start_renaming(
+        uri_with_expected_operation,
+        paths_to_reindex,
+        paths_to_delete,
+        on_report_progress,
+        on_complete
+      )
+
+    Rename.update_progress(file_changed(uri: old_uri))
+    assert_receive {:update_progress, 1, ""}
+    refute_receive :complete_progress
+
+    Rename.update_progress(file_saved(uri: new_uri))
+    assert_receive {:update_progress, 1, ""}
+
+    assert_receive {:update_progress, 1, "reindexing"}
+    assert_receive {:update_progress, 1, "deleting old index"}
+    assert_receive :complete_progress
+  end
+
+  test "it should return :error when updating progress if no rename is in progress" do
+    assert {:error, :not_in_rename_progress} =
+             Rename.update_progress(file_changed(uri: "file://file.ex"))
+  end
+
+  defp update_progress(pid, delta, message) do
+    send(pid, {:update_progress, delta, message})
+  end
+
+  defp complete_progress(pid) do
+    send(pid, :complete_progress)
+  end
+end

--- a/apps/engine/test/engine/commands/rename_test.exs
+++ b/apps/engine/test/engine/commands/rename_test.exs
@@ -1,14 +1,14 @@
 defmodule Engine.Commands.RenameTest do
-  alias Engine.Api.Proxy
-  alias Engine.Commands.Rename
-  alias Engine.Commands.RenameSupervisor
-  alias Engine.Search.Store
+  use ExUnit.Case
+  use Patch
 
   import Forge.EngineApi.Messages
   import Forge.Test.EventualAssertions
 
-  use ExUnit.Case
-  use Patch
+  alias Engine.Api.Proxy
+  alias Engine.Commands.Rename
+  alias Engine.Commands.RenameSupervisor
+  alias Engine.ManagerApi
 
   setup do
     start_supervised!(RenameSupervisor)
@@ -103,7 +103,7 @@ defmodule Engine.Commands.RenameTest do
     on_report_progress: on_report_progress,
     on_complete: on_complete
   } do
-    patch(Store, :clear, :ok)
+    patch(ManagerApi, :search_store_clear, :ok)
     old_uri = "file://old_file.ex"
     new_uri = "file://new_file.ex"
     another_uri = "file://file.ex"

--- a/apps/engine/test/engine/commands/rename_test.exs
+++ b/apps/engine/test/engine/commands/rename_test.exs
@@ -6,6 +6,7 @@ defmodule Engine.Commands.RenameTest do
   import Forge.Test.EventualAssertions
 
   alias Engine.Api.Proxy
+  alias Engine.Commands.Reindex
   alias Engine.Commands.Rename
   alias Engine.Commands.RenameSupervisor
   alias Engine.ManagerApi
@@ -22,6 +23,7 @@ defmodule Engine.Commands.RenameTest do
     on_complete = fn -> complete_progress(pid) end
 
     patch(Proxy, :start_buffering, :ok)
+    patch(Reindex, :uri, :ok)
     %{on_report_progress: on_report_progress, on_complete: on_complete}
   end
 
@@ -140,6 +142,48 @@ defmodule Engine.Commands.RenameTest do
   test "it should return :error when updating progress if no rename is in progress" do
     assert {:error, :not_in_rename_progress} =
              Rename.update_progress(file_changed(uri: "file://file.ex"))
+  end
+
+  test "it should complete and shutdown when notifications time out", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    uri = "file://file.ex"
+
+    {:ok, pid} =
+      RenameSupervisor.start_renaming(
+        %{uri => file_saved(uri: uri)},
+        [uri],
+        [],
+        on_report_progress,
+        on_complete
+      )
+
+    send(pid, :timeout)
+
+    assert_receive :complete_progress
+    refute_eventually Process.whereis(Rename)
+    refute_called(Reindex.uri(_))
+  end
+
+  test "it should accept file_changed when file_saved is expected", %{
+    on_report_progress: on_report_progress,
+    on_complete: on_complete
+  } do
+    uri = "file://file.ex"
+
+    {:ok, _pid} =
+      RenameSupervisor.start_renaming(
+        %{uri => file_saved(uri: uri)},
+        [],
+        [],
+        on_report_progress,
+        on_complete
+      )
+
+    Rename.update_progress(file_changed(uri: uri))
+
+    assert_receive :complete_progress
   end
 
   defp update_progress(pid, delta, message) do

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -560,6 +560,12 @@ defmodule Expert do
       %GenLSP.Requests.WorkspaceSymbol{} ->
         {:ok, Handlers.WorkspaceSymbol}
 
+      %GenLSP.Requests.TextDocumentPrepareRename{} ->
+        {:ok, Handlers.PrepareRename}
+
+      %GenLSP.Requests.TextDocumentRename{} ->
+        {:ok, Handlers.Rename}
+
       %request_module{} ->
         {:error, {:unhandled, request_module}}
     end

--- a/apps/expert/lib/expert/configuration/support.ex
+++ b/apps/expert/lib/expert/configuration/support.ex
@@ -17,6 +17,11 @@ defmodule Expert.Configuration.Support do
       :code_action,
       :resolve_support
     ],
+    document_changes: [
+      :workspace,
+      :workspace_edit,
+      :document_changes
+    ],
     hierarchical_symbols: [
       :text_document,
       :document_symbol,
@@ -51,18 +56,25 @@ defmodule Expert.Configuration.Support do
     show_message: [
       :window,
       :show_message
+    ],
+    resource_operations: [
+      :workspace,
+      :workspace_edit,
+      :resource_operations
     ]
   ]
 
   defstruct code_action_dynamic_registration: false,
             code_action_resolve: false,
+            document_changes: false,
             hierarchical_symbols: false,
             snippet: false,
             deprecated: false,
             tags: false,
             signature_help: false,
             work_done_progress: false,
-            show_message: false
+            show_message: false,
+            resource_operations: false
 
   @type t :: %__MODULE__{}
 

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -165,10 +165,6 @@ defmodule Expert.EngineApi do
     call(project, Engine, :workspace_symbols, [query])
   end
 
-  def runtime_versions(%Project{} = project) do
-    call(project, Engine, :runtime_versions, [])
-  end
-
   def prepare_rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
     call(project, Engine, :prepare_rename, [analysis, position])
   end
@@ -198,13 +194,15 @@ defmodule Expert.EngineApi do
   the main document change/save flow.
   """
   def maybe_update_rename_progress(%Project{} = project, message) do
-    try do
-      call(project, Engine, :maybe_update_rename_progress, [message])
-    rescue
-      _ -> {:error, :not_in_rename_progress}
-    catch
-      :exit, _ -> {:error, :not_in_rename_progress}
-    end
+    call(project, Engine, :maybe_update_rename_progress, [message])
+  rescue
+    _ -> {:error, :not_in_rename_progress}
+  catch
+    :exit, _ -> {:error, :not_in_rename_progress}
+  end
+
+  def runtime_versions(%Project{} = project) do
+    call(project, Engine, :runtime_versions, [])
   end
 
   defdelegate stop(project), to: EngineNode

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -193,9 +193,18 @@ defmodule Expert.EngineApi do
 
   This should be called when files are changed or saved during a rename operation.
   The message is used to track which file operations have been completed.
+
+  This function is intentionally fire-and-forget - failures don't affect
+  the main document change/save flow.
   """
   def maybe_update_rename_progress(%Project{} = project, message) do
-    call(project, Engine, :maybe_update_rename_progress, [message])
+    try do
+      call(project, Engine, :maybe_update_rename_progress, [message])
+    rescue
+      _ -> {:error, :not_in_rename_progress}
+    catch
+      :exit, _ -> {:error, :not_in_rename_progress}
+    end
   end
 
   defdelegate stop(project), to: EngineNode

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -169,5 +169,24 @@ defmodule Expert.EngineApi do
     call(project, Engine, :runtime_versions, [])
   end
 
+  def prepare_rename(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
+    call(project, Engine, :prepare_rename, [analysis, position])
+  end
+
+  def rename(
+        %Project{} = project,
+        %Analysis{} = analysis,
+        %Position{} = position,
+        new_name,
+        client_name
+      ) do
+    call(project, Engine, :rename, [
+      analysis,
+      position,
+      new_name,
+      client_name
+    ])
+  end
+
   defdelegate stop(project), to: EngineNode
 end

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -188,5 +188,15 @@ defmodule Expert.EngineApi do
     ])
   end
 
+  @doc """
+  Updates the rename progress with a triggered message.
+
+  This should be called when files are changed or saved during a rename operation.
+  The message is used to track which file operations have been completed.
+  """
+  def maybe_update_rename_progress(%Project{} = project, message) do
+    call(project, Engine, :maybe_update_rename_progress, [message])
+  end
+
   defdelegate stop(project), to: EngineNode
 end

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -174,13 +174,15 @@ defmodule Expert.EngineApi do
         %Analysis{} = analysis,
         %Position{} = position,
         new_name,
-        client_name
+        client_name,
+        rename_files?
       ) do
     call(project, Engine, :rename, [
       analysis,
       position,
       new_name,
-      client_name
+      client_name,
+      rename_files?
     ])
   end
 

--- a/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
@@ -1,0 +1,68 @@
+defmodule Expert.Provider.Handlers.PrepareRename do
+  @moduledoc """
+  Handler for textDocument/prepareRename requests.
+
+  This handler determines if the entity at the cursor can be renamed
+  and returns the range and placeholder text for the rename operation.
+  """
+  alias Expert.ActiveProjects
+  alias Expert.EngineApi
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.Project
+  alias GenLSP.Structures
+
+  require Logger
+
+  def handle(%GenLSP.Requests.TextDocumentPrepareRename{
+        params: %Structures.PrepareRenameParams{} = params
+      }) do
+    document = Forge.Document.Container.context_document(params, nil)
+    projects = ActiveProjects.projects()
+    project = Project.project_for_document(projects, document)
+
+    case Document.Store.fetch(document.uri, :analysis) do
+      {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
+        prepare_rename(project, analysis, params.position)
+
+      _ ->
+        {:error, :request_failed, "Document cannot be analyzed"}
+    end
+  end
+
+  defp prepare_rename(project, analysis, position) do
+    case EngineApi.prepare_rename(project, analysis, position) do
+      {:ok, placeholder, range} when is_binary(placeholder) ->
+        # PrepareRenameResult is a type alias in GenLSP, return as map
+        result = %{
+          placeholder: placeholder,
+          range: to_lsp_range(range)
+        }
+
+        {:ok, result}
+
+      {:ok, nil} ->
+        {:ok, nil}
+
+      {:error, error} when is_binary(error) ->
+        {:error, :request_failed, error}
+
+      {:error, error} ->
+        {:error, :request_failed, inspect(error)}
+    end
+  end
+
+  defp to_lsp_range(%Forge.Document.Range{} = range) do
+    %Structures.Range{
+      start: to_lsp_position(range.start),
+      end: to_lsp_position(range.end)
+    }
+  end
+
+  defp to_lsp_position(%Forge.Document.Position{} = position) do
+    %Structures.Position{
+      line: position.line - 1,
+      character: position.character - 1
+    }
+  end
+end

--- a/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
@@ -35,7 +35,7 @@ defmodule Expert.Provider.Handlers.PrepareRename do
         # PrepareRenameResult is a type alias in GenLSP, return as map
         result = %{
           placeholder: placeholder,
-          range: to_lsp_range(range)
+          range: range
         }
 
         {:ok, result}
@@ -49,19 +49,5 @@ defmodule Expert.Provider.Handlers.PrepareRename do
       {:error, error} ->
         {:error, :request_failed, inspect(error)}
     end
-  end
-
-  defp to_lsp_range(%Forge.Document.Range{} = range) do
-    %Structures.Range{
-      start: to_lsp_position(range.start),
-      end: to_lsp_position(range.end)
-    }
-  end
-
-  defp to_lsp_position(%Forge.Document.Position{} = position) do
-    %Structures.Position{
-      line: position.line - 1,
-      character: position.character - 1
-    }
   end
 end

--- a/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/prepare_rename.ex
@@ -5,22 +5,21 @@ defmodule Expert.Provider.Handlers.PrepareRename do
   This handler determines if the entity at the cursor can be renamed
   and returns the range and placeholder text for the rename operation.
   """
-  alias Expert.ActiveProjects
+  @behaviour Expert.Provider.Handler
+
+  alias Expert.Document.Context
   alias Expert.EngineApi
   alias Forge.Ast
   alias Forge.Document
-  alias Forge.Project
   alias GenLSP.Structures
 
-  require Logger
-
-  def handle(%GenLSP.Requests.TextDocumentPrepareRename{
-        params: %Structures.PrepareRenameParams{} = params
-      }) do
-    document = Forge.Document.Container.context_document(params, nil)
-    projects = ActiveProjects.projects()
-    project = Project.project_for_document(projects, document)
-
+  @impl Expert.Provider.Handler
+  def handle(
+        %GenLSP.Requests.TextDocumentPrepareRename{
+          params: %Structures.PrepareRenameParams{} = params
+        },
+        %Context{document: document, project: project}
+      ) do
     case Document.Store.fetch(document.uri, :analysis) do
       {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
         prepare_rename(project, analysis, params.position)

--- a/apps/expert/lib/expert/provider/handlers/rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/rename.ex
@@ -1,0 +1,108 @@
+defmodule Expert.Provider.Handlers.Rename do
+  @moduledoc """
+  Handler for textDocument/rename requests.
+
+  This handler executes the rename operation and returns the workspace edit
+  containing all the text edits and file renames needed.
+  """
+  alias Expert.ActiveProjects
+  alias Expert.Configuration
+  alias Expert.EngineApi
+  alias Forge.Ast
+  alias Forge.Document
+  alias Forge.Document.Changes
+  alias Forge.Project
+  alias GenLSP.Structures
+
+  require Logger
+
+  def handle(%GenLSP.Requests.TextDocumentRename{
+        params: %Structures.RenameParams{} = params
+      }) do
+    document = Forge.Document.Container.context_document(params, nil)
+    projects = ActiveProjects.projects()
+    project = Project.project_for_document(projects, document)
+
+    case Document.Store.fetch(document.uri, :analysis) do
+      {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
+        rename(project, analysis, params.position, params.new_name)
+
+      _ ->
+        {:error, :request_failed, "Document cannot be analyzed"}
+    end
+  end
+
+  defp rename(project, analysis, position, new_name) do
+    %Configuration{client_name: client_name} = Configuration.get()
+
+    case EngineApi.rename(project, analysis, position, new_name, client_name) do
+      {:ok, []} ->
+        {:ok, nil}
+
+      {:ok, results} ->
+        document_changes =
+          Enum.flat_map(results, fn
+            %Changes{rename_file: %Changes.RenameFile{}} = changes ->
+              [to_text_document_edit(changes), to_rename_file(changes.rename_file)]
+
+            %Changes{} = changes ->
+              [to_text_document_edit(changes)]
+          end)
+
+        workspace_edit = %Structures.WorkspaceEdit{document_changes: document_changes}
+        {:ok, workspace_edit}
+
+      {:error, {:unsupported_entity, entity}} ->
+        Logger.info("Cannot rename entity: #{inspect(entity)}")
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, :request_failed, inspect(reason)}
+    end
+  end
+
+  defp to_text_document_edit(%Changes{} = changes) do
+    %Changes{document: document, edits: edits} = changes
+
+    text_document =
+      %Structures.OptionalVersionedTextDocumentIdentifier{
+        uri: document.uri,
+        version: document.version
+      }
+
+    %Structures.TextDocumentEdit{
+      edits: Enum.map(edits, &to_text_edit/1),
+      text_document: text_document
+    }
+  end
+
+  defp to_text_edit(%Document.Edit{} = edit) do
+    %Structures.TextEdit{
+      new_text: edit.text,
+      range: to_lsp_range(edit.range)
+    }
+  end
+
+  defp to_lsp_range(%Document.Range{} = range) do
+    %Structures.Range{
+      start: to_lsp_position(range.start),
+      end: to_lsp_position(range.end)
+    }
+  end
+
+  defp to_lsp_position(%Document.Position{} = position) do
+    %Structures.Position{
+      line: position.line - 1,
+      character: position.character - 1
+    }
+  end
+
+  defp to_rename_file(%Changes.RenameFile{} = rename_file) do
+    %Structures.RenameFile{
+      kind: "rename",
+      new_uri: rename_file.new_uri,
+      old_uri: rename_file.old_uri,
+      options: %Structures.RenameFileOptions{overwrite: true}
+    }
+  end
+end

--- a/apps/expert/lib/expert/provider/handlers/rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/rename.ex
@@ -101,7 +101,7 @@ defmodule Expert.Provider.Handlers.Rename do
       kind: "rename",
       new_uri: rename_file.new_uri,
       old_uri: rename_file.old_uri,
-      options: %Structures.RenameFileOptions{overwrite: true}
+      options: %Structures.RenameFileOptions{overwrite: false}
     }
   end
 end

--- a/apps/expert/lib/expert/provider/handlers/rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/rename.ex
@@ -5,24 +5,23 @@ defmodule Expert.Provider.Handlers.Rename do
   This handler executes the rename operation and returns the workspace edit
   containing all the text edits and file renames needed.
   """
-  alias Expert.ActiveProjects
+  @behaviour Expert.Provider.Handler
+
   alias Expert.Configuration
+  alias Expert.Document.Context
   alias Expert.EngineApi
   alias Forge.Ast
   alias Forge.Document
   alias Forge.Document.Changes
-  alias Forge.Project
   alias GenLSP.Structures
 
   require Logger
 
-  def handle(%GenLSP.Requests.TextDocumentRename{
-        params: %Structures.RenameParams{} = params
-      }) do
-    document = Forge.Document.Container.context_document(params, nil)
-    projects = ActiveProjects.projects()
-    project = Project.project_for_document(projects, document)
-
+  @impl Expert.Provider.Handler
+  def handle(
+        %GenLSP.Requests.TextDocumentRename{params: %Structures.RenameParams{} = params},
+        %Context{document: document, project: project}
+      ) do
     case Document.Store.fetch(document.uri, :analysis) do
       {:ok, _document, %Ast.Analysis{valid?: true} = analysis} ->
         rename(project, analysis, params.position, params.new_name)

--- a/apps/expert/lib/expert/provider/handlers/rename.ex
+++ b/apps/expert/lib/expert/provider/handlers/rename.ex
@@ -33,23 +33,18 @@ defmodule Expert.Provider.Handlers.Rename do
 
   defp rename(project, analysis, position, new_name) do
     %Configuration{client_name: client_name} = Configuration.get()
+    document_changes? = Configuration.client_support(:document_changes)
 
-    case EngineApi.rename(project, analysis, position, new_name, client_name) do
+    rename_files? =
+      document_changes? and
+        "rename" in List.wrap(Configuration.client_support(:resource_operations))
+
+    case EngineApi.rename(project, analysis, position, new_name, client_name, rename_files?) do
       {:ok, []} ->
         {:ok, nil}
 
       {:ok, results} ->
-        document_changes =
-          Enum.flat_map(results, fn
-            %Changes{rename_file: %Changes.RenameFile{}} = changes ->
-              [to_text_document_edit(changes), to_rename_file(changes.rename_file)]
-
-            %Changes{} = changes ->
-              [to_text_document_edit(changes)]
-          end)
-
-        workspace_edit = %Structures.WorkspaceEdit{document_changes: document_changes}
-        {:ok, workspace_edit}
+        {:ok, to_workspace_edit(results, document_changes?)}
 
       {:error, {:unsupported_entity, entity}} ->
         Logger.info("Cannot rename entity: #{inspect(entity)}")
@@ -60,39 +55,36 @@ defmodule Expert.Provider.Handlers.Rename do
     end
   end
 
+  defp to_workspace_edit(results, true) do
+    document_changes =
+      Enum.flat_map(results, fn
+        %Changes{rename_file: %Changes.RenameFile{}} = changes ->
+          [to_text_document_edit(changes), to_rename_file(changes.rename_file)]
+
+        %Changes{} = changes ->
+          [to_text_document_edit(changes)]
+      end)
+
+    %Structures.WorkspaceEdit{document_changes: document_changes}
+  end
+
+  defp to_workspace_edit(results, false) do
+    changes = Map.new(results, &{&1.document.uri, List.wrap(&1.edits)})
+    %Structures.WorkspaceEdit{changes: changes}
+  end
+
   defp to_text_document_edit(%Changes{} = changes) do
-    %Changes{document: document, edits: edits} = changes
+    %Changes{document: document, edits: edits, expected_version: expected_version} = changes
 
     text_document =
       %Structures.OptionalVersionedTextDocumentIdentifier{
         uri: document.uri,
-        version: document.version
+        version: expected_version
       }
 
     %Structures.TextDocumentEdit{
-      edits: Enum.map(edits, &to_text_edit/1),
+      edits: edits,
       text_document: text_document
-    }
-  end
-
-  defp to_text_edit(%Document.Edit{} = edit) do
-    %Structures.TextEdit{
-      new_text: edit.text,
-      range: to_lsp_range(edit.range)
-    }
-  end
-
-  defp to_lsp_range(%Document.Range{} = range) do
-    %Structures.Range{
-      start: to_lsp_position(range.start),
-      end: to_lsp_position(range.end)
-    }
-  end
-
-  defp to_lsp_position(%Document.Position{} = position) do
-    %Structures.Position{
-      line: position.line - 1,
-      character: position.character - 1
     }
   end
 

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -406,6 +406,11 @@ defmodule Expert.State do
         trigger_characters: CodeIntelligence.Completion.trigger_characters()
       }
 
+    rename_options =
+      %Structures.RenameOptions{
+        prepare_provider: true
+      }
+
     server_capabilities =
       %Structures.ServerCapabilities{
         code_action_provider: code_action_options,
@@ -418,6 +423,7 @@ defmodule Expert.State do
         folding_range_provider: true,
         hover_provider: true,
         references_provider: true,
+        rename_provider: rename_options,
         text_document_sync: sync_options,
         workspace_symbol_provider: true,
         workspace: %{

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -195,6 +195,7 @@ defmodule Expert.State do
 
           EngineApi.maybe_update_rename_progress(context.project, updated_message)
         end
+
         {:ok, state}
 
       error ->
@@ -268,7 +269,7 @@ defmodule Expert.State do
         # This can happen during batch renames when didClose and didSave
         # arrive nearly simultaneously. Still update rename progress tracking.
         Logger.debug("Save received for already-closed file: #{uri}")
-        EngineApi.maybe_update_rename_progress(project, file_saved(uri: uri))
+        EngineApi.maybe_update_rename_progress(context.project, file_saved(uri: uri))
         {:ok, state}
     end
   end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -192,8 +192,9 @@ defmodule Expert.State do
           if Configuration.compile_on_type?() do
             EngineApi.compile_document(context.project, updated_source)
           end
-        end
 
+          EngineApi.maybe_update_rename_progress(context.project, updated_message)
+        end
         {:ok, state}
 
       error ->
@@ -254,6 +255,10 @@ defmodule Expert.State do
 
           %Context{project: %Project{kind: :bare}} ->
             :ok
+        end
+
+        if Store.ready?(context.project) do
+          EngineApi.maybe_update_rename_progress(context.project, file_saved(uri: uri))
         end
 
         {:ok, state}

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -263,9 +263,13 @@ defmodule Expert.State do
 
         {:ok, state}
 
-      error ->
-        Logger.error("Save failed for uri #{uri} error was #{inspect(error)}")
-        error
+      {:error, :not_open} ->
+        # File was closed before save notification was processed.
+        # This can happen during batch renames when didClose and didSave
+        # arrive nearly simultaneously. Still update rename progress tracking.
+        Logger.debug("Save received for already-closed file: #{uri}")
+        EngineApi.maybe_update_rename_progress(project, file_saved(uri: uri))
+        {:ok, state}
     end
   end
 

--- a/apps/expert/test/expert/provider/handlers/rename_test.exs
+++ b/apps/expert/test/expert/provider/handlers/rename_test.exs
@@ -4,12 +4,14 @@ defmodule Expert.Provider.Handlers.RenameTest do
 
   import Forge.Test.Fixtures
 
+  alias Expert.Configuration
   alias Expert.Document.Context
   alias Expert.EngineApi
+  alias Expert.Protocol.Convert
   alias Expert.Provider.Handlers
   alias Forge.Document
   alias Forge.Document.Changes
-  alias GenLSP.Requests.TextDocumentRename
+  alias GenLSP.Requests
   alias GenLSP.Structures
 
   setup_all do
@@ -18,34 +20,38 @@ defmodule Expert.Provider.Handlers.RenameTest do
   end
 
   setup do
-    :persistent_term.erase(Expert.Configuration)
-    Expert.Configuration.new() |> Expert.Configuration.set()
+    set_workspace_edit_support(true, ["rename"])
 
     project = project()
     uri = subject_uri(project, "lib/my_app/users.ex")
-    :ok = Document.Store.open(uri, "defmodule MyApp.Users do\nend\n", 1)
+
+    if Document.Store.open?(uri), do: Document.Store.close(uri)
+
+    text = "defmodule MyApp.Users do\n  \"😀\"; MyApp.Users.run()\nend\n"
+    :ok = Document.Store.open(uri, text, 1)
     {:ok, document} = Document.Store.fetch(uri)
+
+    on_exit(fn ->
+      :persistent_term.erase(Configuration)
+      if Document.Store.open?(uri), do: Document.Store.close(uri)
+    end)
 
     {:ok, project: project, document: document}
   end
 
-  test "does not allow a file rename to overwrite its destination", %{
+  test "emits a safe file rename when the client supports it", %{
     project: project,
     document: document
   } do
     new_uri = subject_uri(project, "lib/my_app/accounts.ex")
     rename_file = Changes.RenameFile.new(document.uri, new_uri)
-    changes = Changes.new(document, [], rename_file)
-    patch(EngineApi, :rename, {:ok, [changes]})
+    changes = changes(document, [], document.version, rename_file)
+    test_pid = self()
 
-    request = %TextDocumentRename{
-      id: Expert.Protocol.Id.next(),
-      params: %Structures.RenameParams{
-        text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
-        position: %Structures.Position{line: 0, character: 10},
-        new_name: "MyApp.Accounts"
-      }
-    }
+    patch(EngineApi, :rename, fn _project, _analysis, _position, _name, _client, rename_files? ->
+      send(test_pid, {:rename_files?, rename_files?})
+      {:ok, [changes]}
+    end)
 
     context = Context.new(document.uri, document, project)
 
@@ -57,7 +63,159 @@ defmodule Expert.Provider.Handlers.RenameTest do
                   options: %Structures.RenameFileOptions{overwrite: false}
                 }
               ]
-            }} = Handlers.Rename.handle(request, context)
+            }} = Handlers.Rename.handle(rename_request(document.uri), context)
+
+    assert_receive {:rename_files?, true}
+  end
+
+  test "converts rename edit ranges to UTF-16", %{project: project, document: document} do
+    range = unicode_range(document)
+    edit = Document.Edit.new("MyApp.Accounts", range)
+    patch(EngineApi, :rename, {:ok, [changes(document, [edit], document.version)]})
+
+    context = Context.new(document.uri, document, project)
+    assert {:ok, workspace_edit} = Handlers.Rename.handle(rename_request(document.uri), context)
+    assert {:ok, converted} = Convert.to_lsp(workspace_edit)
+
+    assert [
+             %Structures.TextDocumentEdit{
+               edits: [%Structures.TextEdit{range: converted_range}]
+             }
+           ] = converted.document_changes
+
+    assert converted_range.start.character == 8
+    assert converted_range.end.character == 19
+  end
+
+  test "converts prepare rename ranges to UTF-16", %{project: project, document: document} do
+    patch(EngineApi, :prepare_rename, {:ok, "MyApp.Users", unicode_range(document)})
+    context = Context.new(document.uri, document, project)
+
+    request = %Requests.TextDocumentPrepareRename{
+      id: Expert.Protocol.Id.next(),
+      params: %Structures.PrepareRenameParams{
+        text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+        position: %Structures.Position{line: 1, character: 8}
+      }
+    }
+
+    assert {:ok, result} = Handlers.PrepareRename.handle(request, context)
+    assert {:ok, converted} = Convert.to_lsp(result)
+    assert converted.range.start.character == 8
+    assert converted.range.end.character == 19
+  end
+
+  test "uses the captured version after the open document changes", %{
+    project: project,
+    document: document
+  } do
+    edit = Document.Edit.new("MyApp.Accounts", unicode_range(document))
+    patch(EngineApi, :rename, {:ok, [changes(document, [edit], document.version)]})
+
+    assert :ok =
+             Document.Store.update(document.uri, fn current ->
+               {:ok, %{current | version: current.version + 1}}
+             end)
+
+    context = Context.new(document.uri, document, project)
+    assert {:ok, workspace_edit} = Handlers.Rename.handle(rename_request(document.uri), context)
+
+    assert [%Structures.TextDocumentEdit{text_document: %{version: 1}}] =
+             workspace_edit.document_changes
+  end
+
+  test "omits the synthetic version for a temporary document", %{
+    project: project,
+    document: document
+  } do
+    temporary = Document.new("file:///closed.ex", "defmodule Closed do\nend\n", 0)
+    edit = Document.Edit.new("Accounts", unicode_range(document))
+    patch(EngineApi, :rename, {:ok, [changes(temporary, [edit], nil)]})
+
+    context = Context.new(document.uri, document, project)
+    assert {:ok, workspace_edit} = Handlers.Rename.handle(rename_request(document.uri), context)
+
+    assert [%Structures.TextDocumentEdit{text_document: %{version: nil}}] =
+             workspace_edit.document_changes
+  end
+
+  test "uses plain changes when document changes are unsupported", %{
+    project: project,
+    document: document
+  } do
+    Configuration.new() |> Configuration.set()
+    edit = Document.Edit.new("MyApp.Accounts", unicode_range(document))
+    result = changes(document, [edit], document.version)
+    test_pid = self()
+
+    patch(EngineApi, :rename, fn _project, _analysis, _position, _name, _client, rename_files? ->
+      send(test_pid, {:rename_files?, rename_files?})
+      {:ok, [result]}
+    end)
+
+    context = Context.new(document.uri, document, project)
+    assert {:ok, workspace_edit} = Handlers.Rename.handle(rename_request(document.uri), context)
+    assert {:ok, converted} = Convert.to_lsp(workspace_edit)
+    uri = document.uri
+
+    assert %{^uri => [%Structures.TextEdit{}]} = converted.changes
+    assert is_nil(converted.document_changes)
+    assert_receive {:rename_files?, false}
+  end
+
+  test "does not rename files without rename resource operation support", %{
+    project: project,
+    document: document
+  } do
+    set_workspace_edit_support(true, nil)
+    edit = Document.Edit.new("MyApp.Accounts", unicode_range(document))
+    result = changes(document, [edit], document.version)
+    test_pid = self()
+
+    patch(EngineApi, :rename, fn _project, _analysis, _position, _name, _client, rename_files? ->
+      send(test_pid, {:rename_files?, rename_files?})
+      {:ok, [result]}
+    end)
+
+    context = Context.new(document.uri, document, project)
+    assert {:ok, workspace_edit} = Handlers.Rename.handle(rename_request(document.uri), context)
+    assert [%Structures.TextDocumentEdit{}] = workspace_edit.document_changes
+    assert_receive {:rename_files?, false}
+  end
+
+  defp changes(document, edits, expected_version, rename_file \\ nil) do
+    Changes.new(document, edits, rename_file, expected_version)
+  end
+
+  defp rename_request(uri) do
+    %Requests.TextDocumentRename{
+      id: Expert.Protocol.Id.next(),
+      params: %Structures.RenameParams{
+        text_document: %Structures.TextDocumentIdentifier{uri: uri},
+        position: %Structures.Position{line: 0, character: 10},
+        new_name: "MyApp.Accounts"
+      }
+    }
+  end
+
+  defp set_workspace_edit_support(document_changes, resource_operations) do
+    %Structures.ClientCapabilities{
+      workspace: %Structures.WorkspaceClientCapabilities{
+        workspace_edit: %Structures.WorkspaceEditClientCapabilities{
+          document_changes: document_changes,
+          resource_operations: resource_operations
+        }
+      }
+    }
+    |> Configuration.new(nil)
+    |> Configuration.set()
+  end
+
+  defp unicode_range(document) do
+    Document.Range.new(
+      Document.Position.new(document, 2, 8),
+      Document.Position.new(document, 2, 19)
+    )
   end
 
   defp subject_uri(project, path) do

--- a/apps/expert/test/expert/provider/handlers/rename_test.exs
+++ b/apps/expert/test/expert/provider/handlers/rename_test.exs
@@ -1,0 +1,68 @@
+defmodule Expert.Provider.Handlers.RenameTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.Fixtures
+
+  alias Expert.Document.Context
+  alias Expert.EngineApi
+  alias Expert.Provider.Handlers
+  alias Forge.Document
+  alias Forge.Document.Changes
+  alias GenLSP.Requests.TextDocumentRename
+  alias GenLSP.Structures
+
+  setup_all do
+    start_supervised(Expert.Application.document_store_child_spec())
+    :ok
+  end
+
+  setup do
+    :persistent_term.erase(Expert.Configuration)
+    Expert.Configuration.new() |> Expert.Configuration.set()
+
+    project = project()
+    uri = subject_uri(project, "lib/my_app/users.ex")
+    :ok = Document.Store.open(uri, "defmodule MyApp.Users do\nend\n", 1)
+    {:ok, document} = Document.Store.fetch(uri)
+
+    {:ok, project: project, document: document}
+  end
+
+  test "does not allow a file rename to overwrite its destination", %{
+    project: project,
+    document: document
+  } do
+    new_uri = subject_uri(project, "lib/my_app/accounts.ex")
+    rename_file = Changes.RenameFile.new(document.uri, new_uri)
+    changes = Changes.new(document, [], rename_file)
+    patch(EngineApi, :rename, {:ok, [changes]})
+
+    request = %TextDocumentRename{
+      id: Expert.Protocol.Id.next(),
+      params: %Structures.RenameParams{
+        text_document: %Structures.TextDocumentIdentifier{uri: document.uri},
+        position: %Structures.Position{line: 0, character: 10},
+        new_name: "MyApp.Accounts"
+      }
+    }
+
+    context = Context.new(document.uri, document, project)
+
+    assert {:ok,
+            %Structures.WorkspaceEdit{
+              document_changes: [
+                %Structures.TextDocumentEdit{},
+                %Structures.RenameFile{
+                  options: %Structures.RenameFileOptions{overwrite: false}
+                }
+              ]
+            }} = Handlers.Rename.handle(request, context)
+  end
+
+  defp subject_uri(project, path) do
+    project
+    |> file_path(path)
+    |> Document.Path.ensure_uri()
+  end
+end

--- a/apps/expert/test/expert/state/rename_progress_test.exs
+++ b/apps/expert/test/expert/state/rename_progress_test.exs
@@ -1,0 +1,213 @@
+defmodule Expert.State.RenameProgressTest do
+  @moduledoc """
+  Integration tests for rename progress tracking with different editors.
+
+  Different editors send different events after rename operations:
+  - VSCode: sends both file_changed and file_saved events for renamed files
+  - Neovim: sends only file_changed for non-renamed files, file_saved for renamed files
+
+  These tests verify the full rename flow from State → EngineApi → Engine.
+  """
+
+  alias Expert.Configuration
+  alias Expert.EngineApi
+  alias Expert.State
+  alias Engine.Commands.Rename
+  alias Engine.Commands.RenameSupervisor
+  alias Forge.Document
+
+  import Forge.EngineApi.Messages
+  import Forge.Test.Fixtures
+
+  use ExUnit.Case, async: false
+  use Patch
+
+  setup do
+    start_supervised!(Expert.Application.document_store_child_spec())
+    start_supervised!(RenameSupervisor)
+
+    patch(Engine.Api.Proxy, :start_buffering, :ok)
+    patch(Engine.Commands.Reindex, :uri, fn _uri -> :ok end)
+    patch(Engine.Search.Store, :clear, fn _uri -> :ok end)
+
+    if pid = Process.whereis(Rename) do
+      Process.exit(pid, :kill)
+      Process.sleep(10)
+    end
+
+    :ok
+  end
+
+  describe "VSCode editor - non-file-rename (edits only)" do
+    test "reindex triggers after file_saved (VSCode expects save after edit)" do
+      uri = "file:///test/lib/foo.ex"
+      editor = vscode_editor()
+      open_document(uri, "defmodule Foo do\nend")
+      expect_events_before_reindex(%{uri => file_saved(uri: uri)}, reindex: [uri])
+
+      simulate_did_change(editor, uri)
+      refute_reindex_triggered()
+
+      simulate_did_save(editor, uri)
+      assert_reindex_triggered(reindex: [uri], delete: [])
+    end
+  end
+
+  describe "Neovim editor - non-file-rename (edits only)" do
+    test "reindex triggers after file_changed only (Neovim doesn't auto-save)" do
+      uri = "file:///test/lib/foo.ex"
+      editor = neovim_editor()
+      open_document(uri, "defmodule Foo do\nend")
+      expect_events_before_reindex(%{uri => file_changed(uri: uri)}, reindex: [uri])
+
+      simulate_did_change(editor, uri)
+
+      assert_reindex_triggered(reindex: [uri], delete: [])
+    end
+  end
+
+  describe "VSCode editor - file rename" do
+    test "reindex triggers after receiving file_changed for old + file_saved for new" do
+      old_uri = "file:///test/lib/old_module.ex"
+      new_uri = "file:///test/lib/new_module.ex"
+      editor = vscode_editor()
+
+      open_document(old_uri, "defmodule OldModule do\nend")
+      open_document(new_uri, "defmodule NewModule do\nend")
+
+      expect_events_before_reindex(
+        %{old_uri => file_changed(uri: old_uri), new_uri => file_saved(uri: new_uri)},
+        reindex: [new_uri],
+        delete: [old_uri]
+      )
+
+      simulate_did_change(editor, old_uri)
+      refute_reindex_triggered()
+
+      simulate_did_save(editor, new_uri)
+      assert_reindex_triggered(reindex: [new_uri], delete: [old_uri])
+    end
+  end
+
+  describe "Neovim editor - file rename" do
+    test "reindex triggers after file_saved for new file only" do
+      old_uri = "file:///test/lib/old_neovim.ex"
+      new_uri = "file:///test/lib/new_neovim.ex"
+      editor = neovim_editor()
+
+      open_document(new_uri, "defmodule NewNeovim do\nend")
+
+      expect_events_before_reindex(
+        %{new_uri => file_saved(uri: new_uri)},
+        reindex: [new_uri],
+        delete: [old_uri]
+      )
+
+      simulate_did_save(editor, new_uri)
+
+      assert_reindex_triggered(reindex: [new_uri], delete: [old_uri])
+    end
+  end
+
+  # ============================================================================
+  # Test DSL - Editor simulation
+  # ============================================================================
+
+  defp vscode_editor do
+    build_editor("Visual Studio Code")
+  end
+
+  defp neovim_editor do
+    build_editor("Neovim")
+  end
+
+  defp build_editor(client_name) do
+    project = project()
+    config = Configuration.new(project: project, client_name: client_name)
+    state = %State{configuration: config, initialized?: true}
+
+    patch(EngineApi, :broadcast, fn ^project, _msg -> :ok end)
+    patch(EngineApi, :compile_document, fn ^project, _doc -> :ok end)
+    patch(EngineApi, :schedule_compile, fn ^project, _ -> :ok end)
+
+    patch(EngineApi, :maybe_update_rename_progress, fn ^project, msg ->
+      Rename.update_progress(msg)
+    end)
+
+    %{state: state, version: 1}
+  end
+
+  defp open_document(uri, content) do
+    :ok = Document.Store.open(uri, content, 1)
+  end
+
+  defp simulate_did_change(editor, uri) do
+    new_version = editor.version + 1
+    notification = build_did_change(uri, new_version)
+    {:ok, new_state} = State.apply(editor.state, notification)
+    %{editor | state: new_state, version: new_version}
+  end
+
+  defp simulate_did_save(editor, uri) do
+    notification = build_did_save(uri)
+    {:ok, new_state} = State.apply(editor.state, notification)
+    %{editor | state: new_state}
+  end
+
+  # ============================================================================
+  # Test DSL - Expectations
+  # ============================================================================
+
+  defp expect_events_before_reindex(uri_to_expected, opts) do
+    paths_to_reindex = Keyword.get(opts, :reindex, [])
+    paths_to_delete = Keyword.get(opts, :delete, [])
+    test_pid = self()
+
+    on_complete = fn ->
+      send(test_pid, {:rename_complete, paths_to_reindex, paths_to_delete})
+    end
+
+    {:ok, _} =
+      RenameSupervisor.start_renaming(
+        uri_to_expected,
+        paths_to_reindex,
+        paths_to_delete,
+        fn _delta, _msg -> :ok end,
+        on_complete
+      )
+  end
+
+  defp assert_reindex_triggered(opts) do
+    reindex = Keyword.fetch!(opts, :reindex)
+    delete = Keyword.fetch!(opts, :delete)
+    assert_receive {:rename_complete, ^reindex, ^delete}
+  end
+
+  defp refute_reindex_triggered do
+    refute_receive {:rename_complete, _, _}, 50
+  end
+
+  # ============================================================================
+  # LSP notification builders
+  # ============================================================================
+
+  defp build_did_change(uri, version) do
+    %GenLSP.Notifications.TextDocumentDidChange{
+      params: %GenLSP.Structures.DidChangeTextDocumentParams{
+        text_document: %GenLSP.Structures.VersionedTextDocumentIdentifier{
+          uri: uri,
+          version: version
+        },
+        content_changes: [%{text: "defmodule Renamed do\nend"}]
+      }
+    }
+  end
+
+  defp build_did_save(uri) do
+    %GenLSP.Notifications.TextDocumentDidSave{
+      params: %GenLSP.Structures.DidSaveTextDocumentParams{
+        text_document: %GenLSP.Structures.TextDocumentIdentifier{uri: uri}
+      }
+    }
+  end
+end

--- a/apps/expert/test/expert/state/rename_progress_test.exs
+++ b/apps/expert/test/expert/state/rename_progress_test.exs
@@ -9,26 +9,28 @@ defmodule Expert.State.RenameProgressTest do
   These tests verify the full rename flow from State → EngineApi → Engine.
   """
 
-  alias Expert.Configuration
-  alias Expert.EngineApi
-  alias Expert.State
-  alias Engine.Commands.Rename
-  alias Engine.Commands.RenameSupervisor
-  alias Forge.Document
+  use ExUnit.Case, async: false
+  use Patch
 
   import Forge.EngineApi.Messages
   import Forge.Test.Fixtures
 
-  use ExUnit.Case, async: false
-  use Patch
+  alias Engine.Commands.Rename
+  alias Engine.Commands.RenameSupervisor
+  alias Expert.Configuration
+  alias Expert.EngineApi
+  alias Expert.Project.Store
+  alias Expert.State
+  alias Forge.Document
 
   setup do
     start_supervised!(Expert.Application.document_store_child_spec())
+    start_supervised!({Store, []})
     start_supervised!(RenameSupervisor)
 
     patch(Engine.Api.Proxy, :start_buffering, :ok)
     patch(Engine.Commands.Reindex, :uri, fn _uri -> :ok end)
-    patch(Engine.Search.Store, :clear, fn _uri -> :ok end)
+    patch(Engine.ManagerApi, :search_store_clear, fn _project, _path -> :ok end)
 
     if pid = Process.whereis(Rename) do
       Process.exit(pid, :kill)
@@ -40,8 +42,8 @@ defmodule Expert.State.RenameProgressTest do
 
   describe "VSCode editor - non-file-rename (edits only)" do
     test "reindex triggers after file_saved (VSCode expects save after edit)" do
-      uri = "file:///test/lib/foo.ex"
       editor = vscode_editor()
+      uri = subject_uri(editor.project, "lib/foo.ex")
       open_document(uri, "defmodule Foo do\nend")
       expect_events_before_reindex(%{uri => file_saved(uri: uri)}, reindex: [uri])
 
@@ -57,8 +59,8 @@ defmodule Expert.State.RenameProgressTest do
     test "rename progress is updated even when file is already closed" do
       # This can happen during batch renames when didClose and didSave
       # arrive nearly simultaneously and didClose is processed first
-      uri = "file:///test/lib/race.ex"
       editor = vscode_editor()
+      uri = subject_uri(editor.project, "lib/race.ex")
       open_document(uri, "defmodule Race do\nend")
       expect_events_before_reindex(%{uri => file_saved(uri: uri)}, reindex: [uri])
 
@@ -73,8 +75,8 @@ defmodule Expert.State.RenameProgressTest do
 
   describe "Neovim editor - non-file-rename (edits only)" do
     test "reindex triggers after file_changed only (Neovim doesn't auto-save)" do
-      uri = "file:///test/lib/foo.ex"
       editor = neovim_editor()
+      uri = subject_uri(editor.project, "lib/foo.ex")
       open_document(uri, "defmodule Foo do\nend")
       expect_events_before_reindex(%{uri => file_changed(uri: uri)}, reindex: [uri])
 
@@ -86,9 +88,9 @@ defmodule Expert.State.RenameProgressTest do
 
   describe "VSCode editor - file rename" do
     test "reindex triggers after receiving file_changed for old + file_saved for new" do
-      old_uri = "file:///test/lib/old_module.ex"
-      new_uri = "file:///test/lib/new_module.ex"
       editor = vscode_editor()
+      old_uri = subject_uri(editor.project, "lib/old_module.ex")
+      new_uri = subject_uri(editor.project, "lib/new_module.ex")
 
       open_document(old_uri, "defmodule OldModule do\nend")
       open_document(new_uri, "defmodule NewModule do\nend")
@@ -109,9 +111,9 @@ defmodule Expert.State.RenameProgressTest do
 
   describe "Neovim editor - file rename" do
     test "reindex triggers after file_saved for new file only" do
-      old_uri = "file:///test/lib/old_neovim.ex"
-      new_uri = "file:///test/lib/new_neovim.ex"
       editor = neovim_editor()
+      old_uri = subject_uri(editor.project, "lib/old_neovim.ex")
+      new_uri = subject_uri(editor.project, "lib/new_neovim.ex")
 
       open_document(new_uri, "defmodule NewNeovim do\nend")
 
@@ -141,8 +143,10 @@ defmodule Expert.State.RenameProgressTest do
 
   defp build_editor(client_name) do
     project = project()
-    config = Configuration.new(project: project, client_name: client_name)
-    state = %State{configuration: config, initialized?: true}
+    project |> List.wrap() |> Store.set_projects()
+    Store.transition(project, :ready)
+    [client_name: client_name] |> Configuration.new() |> Configuration.set()
+    state = %State{initialized?: true}
 
     patch(EngineApi, :broadcast, fn ^project, _msg -> :ok end)
     patch(EngineApi, :compile_document, fn ^project, _doc -> :ok end)
@@ -152,7 +156,13 @@ defmodule Expert.State.RenameProgressTest do
       Rename.update_progress(msg)
     end)
 
-    %{state: state, version: 1}
+    %{state: state, version: 1, project: project}
+  end
+
+  defp subject_uri(project, path) do
+    project
+    |> file_path(path)
+    |> Document.Path.ensure_uri()
   end
 
   defp open_document(uri, content) do

--- a/apps/expert/test/expert/state/rename_progress_test.exs
+++ b/apps/expert/test/expert/state/rename_progress_test.exs
@@ -41,16 +41,13 @@ defmodule Expert.State.RenameProgressTest do
   end
 
   describe "VSCode editor - non-file-rename (edits only)" do
-    test "reindex triggers after file_saved (VSCode expects save after edit)" do
+    test "reindex triggers after file_changed" do
       editor = vscode_editor()
       uri = subject_uri(editor.project, "lib/foo.ex")
       open_document(uri, "defmodule Foo do\nend")
       expect_events_before_reindex(%{uri => file_saved(uri: uri)}, reindex: [uri])
 
       simulate_did_change(editor, uri)
-      refute_reindex_triggered()
-
-      simulate_did_save(editor, uri)
       assert_reindex_triggered(reindex: [uri], delete: [])
     end
   end
@@ -96,7 +93,7 @@ defmodule Expert.State.RenameProgressTest do
       open_document(new_uri, "defmodule NewModule do\nend")
 
       expect_events_before_reindex(
-        %{old_uri => file_changed(uri: old_uri), new_uri => file_saved(uri: new_uri)},
+        %{new_uri => file_saved(uri: new_uri)},
         reindex: [new_uri],
         delete: [old_uri]
       )

--- a/apps/forge/lib/forge/ast/analysis.ex
+++ b/apps/forge/lib/forge/ast/analysis.ex
@@ -374,7 +374,7 @@ defmodule Forge.Ast.Analysis do
   defp analyze_node({:alias, meta, [aliases, options]} = quoted, state) do
     with {:ok, alias_as} <- fetch_alias_as(options),
          [_ | _] = segments <- expand_alias(aliases, state) do
-      alias = Alias.explicit(state.document, quoted, segments, alias_as)
+      alias = Alias.explicit(state.document, quoted, segments, alias_as, true)
       State.push_alias(state, alias)
     else
       _ ->

--- a/apps/forge/lib/forge/ast/analysis/alias.ex
+++ b/apps/forge/lib/forge/ast/analysis/alias.ex
@@ -4,18 +4,20 @@ defmodule Forge.Ast.Analysis.Alias do
   alias Forge.Document.Position
   alias Forge.Document.Range
 
-  defstruct [:module, :as, :range, explicit?: true]
+  defstruct [:module, :as, :range, explicit?: true, explicit_as?: false]
 
   @type t :: %__MODULE__{
           module: [atom],
           as: [module()],
-          range: Range.t() | nil
+          range: Range.t() | nil,
+          explicit_as?: boolean()
         }
 
-  def explicit(%Document{} = document, ast, module, as) when is_list(module) do
+  def explicit(%Document{} = document, ast, module, as, explicit_as? \\ false)
+      when is_list(module) do
     as = List.wrap(as)
     range = range_for_ast(document, ast, module, as)
-    %__MODULE__{module: module, as: as, range: range}
+    %__MODULE__{module: module, as: as, range: range, explicit_as?: explicit_as?}
   end
 
   def implicit(%Document{} = document, ast, module, as) when is_list(module) do

--- a/apps/forge/lib/forge/document/changes.ex
+++ b/apps/forge/lib/forge/document/changes.ex
@@ -6,6 +6,9 @@ defmodule Forge.Document.Changes do
   It will convert cleanly into either a single `TextEdit` or a list of `TextEdit`s depending on
   whether you passed a single edit or a list of edits.
 
+  `expected_version` is the optional client document version against which the edits were planned.
+  A `nil` value leaves the edits unversioned, as required for documents read from disk.
+
   Using this struct allows efficient conversions at the language server border, as the document
   doesn't have to be looked up (and possibly read off the filesystem) by the language server.
   """
@@ -13,7 +16,7 @@ defmodule Forge.Document.Changes do
 
   alias Forge.Document
 
-  defstruct [:document, :edits, :rename_file]
+  defstruct [:document, :edits, :rename_file, :expected_version]
 
   defmodule RenameFile do
     @moduledoc """
@@ -34,18 +37,25 @@ defmodule Forge.Document.Changes do
 
   @type edits :: Document.Edit.t() | [Document.Edit.t()]
   @type rename_file :: RenameFile.t() | nil
+  @type expected_version :: Document.version() | nil
   @type t :: %__MODULE__{
           document: Document.t(),
           edits: edits,
-          rename_file: rename_file
+          rename_file: rename_file,
+          expected_version: expected_version
         }
 
   @doc """
   Creates a new Changes struct given a document and edits.
 
   """
-  @spec new(Document.t(), edits(), rename_file()) :: t()
-  def new(document, edits, rename_file \\ nil) do
-    %__MODULE__{document: document, edits: edits, rename_file: rename_file}
+  @spec new(Document.t(), edits(), rename_file(), expected_version()) :: t()
+  def new(document, edits, rename_file \\ nil, expected_version \\ nil) do
+    %__MODULE__{
+      document: document,
+      edits: edits,
+      rename_file: rename_file,
+      expected_version: expected_version
+    }
   end
 end

--- a/apps/forge/lib/forge/document/changes.ex
+++ b/apps/forge/lib/forge/document/changes.ex
@@ -13,19 +13,39 @@ defmodule Forge.Document.Changes do
 
   alias Forge.Document
 
-  defstruct [:document, :edits]
+  defstruct [:document, :edits, :rename_file]
+
+  defmodule RenameFile do
+    @moduledoc """
+    Represents a file rename operation during module renaming.
+    """
+    defstruct [:old_uri, :new_uri]
+
+    @type t :: %__MODULE__{
+            old_uri: Forge.uri(),
+            new_uri: Forge.uri()
+          }
+
+    @spec new(Forge.uri(), Forge.uri()) :: t()
+    def new(old_uri, new_uri) do
+      %__MODULE__{old_uri: old_uri, new_uri: new_uri}
+    end
+  end
+
   @type edits :: Document.Edit.t() | [Document.Edit.t()]
+  @type rename_file :: RenameFile.t() | nil
   @type t :: %__MODULE__{
           document: Document.t(),
-          edits: edits
+          edits: edits,
+          rename_file: rename_file
         }
 
   @doc """
   Creates a new Changes struct given a document and edits.
 
   """
-  @spec new(Document.t(), edits()) :: t()
-  def new(document, edits) do
-    %__MODULE__{document: document, edits: edits}
+  @spec new(Document.t(), edits(), rename_file()) :: t()
+  def new(document, edits, rename_file \\ nil) do
+    %__MODULE__{document: document, edits: edits, rename_file: rename_file}
   end
 end

--- a/apps/forge/lib/forge/document/store.ex
+++ b/apps/forge/lib/forge/document/store.ex
@@ -15,6 +15,7 @@ defmodule Forge.Document.Store do
   @type derivation_key :: atom()
   @type derivation_fun :: (Document.t() -> derived_value)
   @type derived_value :: any()
+  @type origin :: :open | :temporary
 
   @type start_opts :: [start_opt]
   @type start_opt :: {:derive, derivations}
@@ -117,6 +118,12 @@ defmodule Forge.Document.Store do
     def open?(%__MODULE__{} = store, uri) do
       Map.has_key?(store.open, uri)
     end
+
+    @spec origin(t, Forge.uri()) :: Store.origin()
+    def origin(%__MODULE__{temporary_open_refs: refs}, uri) when is_map_key(refs, uri),
+      do: :temporary
+
+    def origin(%__MODULE__{}, _uri), do: :open
 
     @spec close(t, Forge.uri()) :: {:ok, t} | {:error, :not_open}
     def close(%__MODULE__{} = store, uri) do
@@ -245,6 +252,18 @@ defmodule Forge.Document.Store do
     GenServer.call(name(), {:fetch, uri, key})
   end
 
+  @spec fetch_with_origin(Forge.uri()) ::
+          {:ok, Document.t(), origin()} | {:error, :not_open}
+  def fetch_with_origin(uri) do
+    GenServer.call(name(), {:fetch_with_origin, uri})
+  end
+
+  @spec fetch_with_origin(Forge.uri(), derivation_key) ::
+          {:ok, Document.t(), derived_value, origin()} | {:error, :not_open}
+  def fetch_with_origin(uri, key) do
+    GenServer.call(name(), {:fetch_with_origin, uri, key})
+  end
+
   @spec save(Forge.uri()) :: :ok | {:error, :not_open}
   def save(uri) do
     GenServer.call(name(), {:save, uri})
@@ -354,6 +373,32 @@ defmodule Forge.Document.Store do
       case State.fetch(state, uri, key) do
         {:ok, value, derived_value, new_state} -> {{:ok, value, derived_value}, new_state}
         error -> {error, state}
+      end
+
+    {:reply, reply, new_state}
+  end
+
+  def handle_call({:fetch_with_origin, uri}, _from, %State{} = state) do
+    {reply, new_state} =
+      case State.fetch(state, uri) do
+        {:ok, document, new_state} ->
+          {{:ok, document, State.origin(state, uri)}, new_state}
+
+        error ->
+          {error, state}
+      end
+
+    {:reply, reply, new_state}
+  end
+
+  def handle_call({:fetch_with_origin, uri, key}, _from, %State{} = state) do
+    {reply, new_state} =
+      case State.fetch(state, uri, key) do
+        {:ok, document, derived_value, new_state} ->
+          {{:ok, document, derived_value, State.origin(state, uri)}, new_state}
+
+        error ->
+          {error, state}
       end
 
     {:reply, reply, new_state}

--- a/apps/forge/lib/forge/engine_api/messages.ex
+++ b/apps/forge/lib/forge/engine_api/messages.ex
@@ -28,6 +28,8 @@ defmodule Forge.EngineApi.Messages do
 
   defrecord :file_deleted, project: nil, uri: nil
 
+  defrecord :file_saved, uri: nil
+
   defrecord :module_updated, file: nil, name: nil, functions: [], macros: [], struct: nil
 
   defrecord :project_diagnostics, project: nil, build_number: 0, diagnostics: []
@@ -93,6 +95,8 @@ defmodule Forge.EngineApi.Messages do
             status: compile_status,
             elapsed_ms: non_neg_integer
           )
+
+  @type file_saved :: record(:file_saved, uri: Forge.uri())
 
   @type module_updated ::
           record(:module_updated,

--- a/apps/forge/lib/forge/engine_api/messages.ex
+++ b/apps/forge/lib/forge/engine_api/messages.ex
@@ -46,6 +46,9 @@ defmodule Forge.EngineApi.Messages do
 
   defrecord :search_store_loading, project: nil
 
+  defrecord :project_progress, label: nil, stage: :begin
+
+  defrecord :percent_progress, label: nil, message: nil, delta: 0, max: 0, stage: :begin
   @type compile_status :: :successful | :error
   @type name_and_arity :: {atom, non_neg_integer}
   @type field_list :: Keyword.t() | [atom]
@@ -135,4 +138,21 @@ defmodule Forge.EngineApi.Messages do
 
   @type search_store_loading ::
           record(:search_store_loading, project: Forge.Project.t())
+
+  @type progress_stage :: :begin | :report | :complete
+
+  @type project_progress ::
+          record(:project_progress,
+            label: String.t(),
+            stage: progress_stage()
+          )
+
+  @type percent_progress ::
+          record(:percent_progress,
+            label: String.t(),
+            message: String.t() | nil,
+            delta: non_neg_integer(),
+            max: non_neg_integer(),
+            stage: progress_stage()
+          )
 end

--- a/apps/forge/lib/forge/engine_api/messages.ex
+++ b/apps/forge/lib/forge/engine_api/messages.ex
@@ -46,9 +46,6 @@ defmodule Forge.EngineApi.Messages do
 
   defrecord :search_store_loading, project: nil
 
-  defrecord :project_progress, label: nil, stage: :begin
-
-  defrecord :percent_progress, label: nil, message: nil, delta: 0, max: 0, stage: :begin
   @type compile_status :: :successful | :error
   @type name_and_arity :: {atom, non_neg_integer}
   @type field_list :: Keyword.t() | [atom]
@@ -138,21 +135,4 @@ defmodule Forge.EngineApi.Messages do
 
   @type search_store_loading ::
           record(:search_store_loading, project: Forge.Project.t())
-
-  @type progress_stage :: :begin | :report | :complete
-
-  @type project_progress ::
-          record(:project_progress,
-            label: String.t(),
-            stage: progress_stage()
-          )
-
-  @type percent_progress ::
-          record(:percent_progress,
-            label: String.t(),
-            message: String.t() | nil,
-            delta: non_neg_integer(),
-            max: non_neg_integer(),
-            stage: progress_stage()
-          )
 end

--- a/apps/forge/test/forge/document/store_test.exs
+++ b/apps/forge/test/forge/document/store_test.exs
@@ -104,6 +104,10 @@ defmodule Forge.Document.StoreTest do
       assert Document.to_string(doc) == "hello"
     end
 
+    test "is identified as open when fetched with its origin" do
+      assert {:ok, %Document{version: 1}, :open} = Document.Store.fetch_with_origin(uri())
+    end
+
     test "can be closed" do
       assert :ok = Document.Store.close(uri())
       assert {:error, :not_open} = Document.Store.fetch(uri())
@@ -181,6 +185,13 @@ defmodule Forge.Document.StoreTest do
       assert Document.to_string(doc) == ctx.contents
     end
 
+    test "is identified as temporary when fetched with its origin", ctx do
+      assert {:ok, _doc} = Document.Store.open_temporary(ctx.uri, 100)
+
+      assert {:ok, %Document{version: 0}, :temporary} =
+               Document.Store.fetch_with_origin(ctx.uri)
+    end
+
     test "closes after a timeout", ctx do
       assert {:ok, _} = Document.Store.open_temporary(ctx.uri, 100)
       Process.sleep(101)
@@ -225,6 +236,11 @@ defmodule Forge.Document.StoreTest do
     test "can be fetched with the document by key" do
       assert {:ok, doc, 5} = Document.Store.fetch(uri(), :length)
       assert Document.to_string(doc) == "hello"
+    end
+
+    test "can be fetched with a derived value and its origin" do
+      assert {:ok, %Document{version: 1}, 5, :open} =
+               Document.Store.fetch_with_origin(uri(), :length)
     end
 
     test "update when the document changes" do


### PR DESCRIPTION
### Context

While AI-assisted renaming is convenient, it's still slower than a native Language Server implementation. This PR ports the module rename feature from [Lexical PR #636](https://github.com/lexical-lsp/lexical/pull/636), which I've been using reliably for almost two years. Given that the Lexical repository is now archived, I wanted to bring this practical and well-tested feature to Expert.

### Changes

**Core Implementation (engine)**
- Add `Engine.CodeMod.Rename` module with submodules: `Prepare`, `Module`, `Entry`, `File`, and `Diff`
- Add `Engine.Commands.Rename` GenServer for tracking rename progress and triggering reindex
- Add `Engine.Commands.RenameSupervisor` for managing rename command lifecycle

**LSP Integration (expert)**
- Add `PrepareRename` and `Rename` handlers for LSP protocol
- Extend `Expert.EngineApi` with `prepare_rename/3` and `rename/5` APIs
- Register `rename_provider` with `prepare_provider: true` in server capabilities

**Infrastructure (forge)**
- Add `RenameFile` struct to `Forge.Document.Changes` for file rename operations
- Add `file_changed` and `file_saved` message types to `Forge.EngineApi.Messages`

**Key Differences from Lexical**
- Uses `:erpc.call` via `Expert.EngineApi.call/4` instead of `RemoteControl.call`
- Added reindexing mechanism after rename to keep search index consistent (see "Why These Changes")
- Namespace mapping: `Lexical.RemoteControl.*` → `Engine.*`, `Lexical.Server.*` → `Expert.*`

### Why These Changes

- **Progress tracking & reindex** (`59953157`): Without reindexing after rename, the search index retains old module names. This causes subsequent renames to fail - e.g., renaming `Accounts` → `Accounts2` works, but renaming back fails because the index doesn't reflect the new names.

- **Temporary document opening** (`f08fd155`): After a file rename, the new URI may not exist in `Document.Store`, causing "not_open" errors during reindex. Added `ensure_open/1` to temporarily open files from disk when needed.

- **Expanded test coverage** (`a38652ef`): Added comprehensive tests covering references, descendants, structs, edge cases, and file renaming with realistic module names.

### Extra

A demo video is attached showing the smooth rename workflow - renaming a module and then renaming it back. Tested successfully in both VSCode and Neovim.


https://github.com/user-attachments/assets/7f7bd67b-8cef-47b3-90f2-93146e534a90

