### PR TITLE
feat(expert): support projectDir in `initializationOptions`

### DIFF
--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -47,7 +47,10 @@ defmodule Expert.State do
         _ -> nil
       end
 
-    config = Configuration.new(event.root_uri, event.capabilities, client_name)
+    init_options = event.initialization_options || %{}
+
+    config =
+      Configuration.new(event.root_uri, event.capabilities, client_name, init_options)
 
     response = initialize_result()
     new_state = %__MODULE__{state | configuration: config, initialized?: true}

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -1,0 +1,78 @@
+defmodule Expert.ConfigurationTest do
+  use ExUnit.Case, async: true
+
+  alias Expert.Configuration
+  alias Forge.Document
+  alias Forge.Project
+  alias GenLSP.Structures.ClientCapabilities
+
+  describe "new/4 with projectDir initialization option" do
+    setup do
+      tmp_dir = System.tmp_dir!()
+      root_path = Path.join(tmp_dir, "test_root_#{System.unique_integer([:positive])}")
+      sub_project_path = Path.join(root_path, "apps/my_app")
+
+      File.mkdir_p!(sub_project_path)
+
+      on_exit(fn ->
+        File.rm_rf!(root_path)
+      end)
+
+      root_uri = Document.Path.to_uri(root_path)
+
+      {:ok,
+       root_uri: root_uri,
+       root_path: root_path,
+       sub_project_path: sub_project_path,
+       client_capabilities: %ClientCapabilities{}}
+    end
+
+    test "uses root_uri when projectDir is not provided", ctx do
+      config = Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", %{})
+
+      assert Project.root_path(config.project) == ctx.root_path
+    end
+
+    test "uses root_uri when init_options is empty map", ctx do
+      config = Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", %{})
+
+      assert Project.root_path(config.project) == ctx.root_path
+    end
+
+    test "appends projectDir to root_uri when provided", ctx do
+      init_options = %{"projectDir" => "apps/my_app"}
+
+      config =
+        Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", init_options)
+
+      assert Project.root_path(config.project) == ctx.sub_project_path
+    end
+
+    test "treats projectDir with leading slash as absolute path", ctx do
+      init_options = %{"projectDir" => ctx.sub_project_path}
+
+      config =
+        Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", init_options)
+
+      assert Project.root_path(config.project) == ctx.sub_project_path
+    end
+
+    test "ignores empty projectDir string", ctx do
+      init_options = %{"projectDir" => ""}
+
+      config =
+        Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", init_options)
+
+      assert Project.root_path(config.project) == ctx.root_path
+    end
+
+    test "ignores nil projectDir", ctx do
+      init_options = %{"projectDir" => nil}
+
+      config =
+        Configuration.new(ctx.root_uri, ctx.client_capabilities, "test-client", init_options)
+
+      assert Project.root_path(config.project) == ctx.root_path
+    end
+  end
+end


### PR DESCRIPTION
I am struggling to make Expert work with a "monorepo" setup, where actual Elixir code is in a subdirectory (`api` in my case), while the parent directory is open. This works in VSCode, but not in other editors, in my experience.

By checking the VSCode extensions in seems that both Lexical and Expert extensions achieve that by [directly setting the path](https://github.com/expert-lsp/vscode-expert/blob/e59ade26c7e99110b56927da4c41319ae0e278cb/src/configuration.ts#L29-L34) based on the first workspace path and the extension's `projectDir` setting. This is then used to [build `workspaceFolders`](https://github.com/expert-lsp/vscode-expert/blob/e59ade26c7e99110b56927da4c41319ae0e278cb/src/extension.ts#L81-L85) and as I understand VSCode sets `rootUri` in `initialize` based on that, which is then used by Expert.

However, this method does not work well with other clients. For example, in Emacs/eglot attempt to overwrite `rootUri` is ignored (eglot seems to always set it on its own). Other editors don't even expose a theoretical possibility to do so. And even if, this should be an absolute path, which is not always easy to set.

As a resolution, I propose supporting `projectDir` in `initializationOptions`, which is a standard way for configuring LSPs during `initialize` request.

I tested this approach successfully in Emacs and NeoVim with following configurations:

```elisp
((elixir-ts-mode
 . ((eglot-server-programs
     . ((elixir-ts-mode . ("start_expert.sh" :initializationOptions
                           (:projectDir "api"))))))))
```

```lua
vim.lsp.config('expert', {
  cmd = { 'expert_darwin_arm64', '--stdio' },
  root_markers = { 'mix.exs', '.git' },
  filetypes = { 'elixir', 'eelixir', 'heex' },
  settings = {
    projectDir = 'api'
  }
})
```

In the future, I think this could also be supported in `workspace/didChangeConfiguration`, if possible, which I think is required for Zed (although I might have missed something and doing `initializationOptions` is possible there too.