### PR TITLE
fix: don't discard new configuration

### DIFF
--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -91,8 +91,6 @@ defmodule Expert.State do
         GenLSP.request(Expert.get_lsp(), request)
         {:ok, %__MODULE__{state | configuration: config}}
     end
-
-    {:ok, state}
   end
 
   def apply(%__MODULE__{} = state, %Notifications.WorkspaceDidChangeWorkspaceFolders{


### PR DESCRIPTION
#18 introduced an issue in VSCode that I didn't catch because I was testing on Zed:

```
09:13:36.297 [debug] sent request server -> client window/workDoneProgress/create
09:13:36.301 [error] ** (XPGenLSP.InvalidRequest) Invalid request from the client

Received: %{"error" => %{"code" => -32601, "message" => "Unhandled method window/workDoneProgress/create"}, "id" => 1, "jsonrpc" => "2.0"}
Errors: "unexpected request payload"

09:13:36.319 [debug] handled request client -> server initialize in 85ms
09:13:36.324 [info] Server initialized, registering capabilities
```

