### PR TITLE
fix: avoid crashing when calling `ActiveProjects.active?/1`

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -158,7 +158,7 @@ defmodule Expert do
           projects = ActiveProjects.projects()
           project = Project.project_for_document(projects, document)
 
-          if ActiveProjects.active?(project) do
+          if project && ActiveProjects.active?(project) do
             :ok
           else
             {:error, :engine_not_initialized, project}


### PR DESCRIPTION
`Project.project_for_document/2` can return `nil` when `projects` is an empty list, and then is passed to `ActiveProjects.active?/1` raising with `FunctionClauseError`.

The error:
```
2026-01-12 11:47:22.881 [info]   Message: ** (FunctionClauseError) no function clause matching in XPExpert.ActiveProjects.active?/1
    (xp_expert 0.1.0-76d6cd5) lib/expert/active_projects.ex:72: XPExpert.ActiveProjects.active?(nil)
    (xp_expert 0.1.0-76d6cd5) lib/expert.ex:161: XPExpert.check_engine_initialized/1
    (xp_expert 0.1.0-76d6cd5) lib/expert.ex:120: XPExpert.handle_request/2
    (xp_gen_lsp 0.11.2) lib/gen_lsp.ex:369: anonymous fn/2 in XPGenLSP.loop/3
    (xp_telemetry 1.3.0) /home/runner/work/expert/expert/apps/expert/deps/telemetry/src/telemetry.erl:324: :xp_telemetry.span/3
    (xp_gen_lsp 0.11.2) lib/gen_lsp.ex:368: anonymous fn/5 in XPGenLSP.loop/3
    (xp_gen_lsp 0.11.2) lib/gen_lsp.ex:592: anonymous fn/4 in XPGenLSP.attempt/4
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
```