### PR TITLE
fix: inherited PATH pollutes project environment

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -89,8 +89,12 @@ defmodule Expert.Port do
     # or we get an incomplete PATH not including erl or any other version manager
     # managed programs.
 
-    # Disable shell session history to reduce noise
-    env = [{"SHELL_SESSIONS_DISABLE", "1"}]
+    env = [
+      # Disable shell session history to reduce noise
+      {"SHELL_SESSIONS_DISABLE", "1"},
+      # Start with a clean PATH to get the correct new value
+      {"PATH", nil}
+    ]
 
     args =
       case Path.basename(shell) do


### PR DESCRIPTION
This is a followup to the discussion in #295.

To determine the correct value for PATH to start the engine build and project node with, `Expert.Port.path_env_at_directory` starts a new shell in the project directory. When doing so the server's own PATH variable is inherited by that shell.

In the context of an Expert release built using `just release`, this variable contains paths pointing to the release, including one containing an `erl` executable. The surrounding directory structure does not contain a `start.boot` file in the location `erl` expects.

On some systems (e.g. Debian) the new shell will set PATH to a completely new value or prefix it with paths containing a complete Erlang environment. On others (e.g. Arch, Fedora) the new shell will only append defaults to the value, leaving the unwanted paths in place.

In the latter case Expert will launch `elixir`, which in turn launches `erl`, which won't be able to find a `start.boot`-file and therefore crash.

By providing the new shell an unset PATH it is fully responsible for determining an appropriate value without being affected by the environment of Expert.