### PR TITLE
fix: do not crash when `Expert.Protocol.Conversions.to_elixir/2` receives `nil` as document

### DIFF
--- a/apps/expert/lib/expert/protocol/conversions.ex
+++ b/apps/expert/lib/expert/protocol/conversions.ex
@@ -29,6 +29,10 @@ defmodule Expert.Protocol.Conversions do
     end
   end
 
+  def to_elixir(%LSRange{}, nil) do
+    {:error, {:invalid_document, nil}}
+  end
+
   def to_elixir(%ElixirPosition{} = position, _) do
     {:ok, position}
   end
@@ -39,6 +43,10 @@ defmodule Expert.Protocol.Conversions do
 
   def to_elixir(%LSPosition{line: line} = position, _) when line < 0 do
     {:error, {:invalid_position, position}}
+  end
+
+  def to_elixir(%LSPosition{}, nil) do
+    {:error, {:invalid_document, nil}}
   end
 
   def to_elixir(%LSPosition{} = position, %Lines{} = lines) do
@@ -68,7 +76,7 @@ defmodule Expert.Protocol.Conversions do
     end
   end
 
-  def to_elixir(%{range: %{start: start_pos, end: end_pos}}, document) do
+  def to_elixir(%{range: %{start: start_pos, end: end_pos}}, %Document{} = document) do
     # this is actually an elixir sense range... note that it's a bare map with
     # column keys rather than character keys.
     %{line: start_line, column: start_col} = start_pos
@@ -81,6 +89,10 @@ defmodule Expert.Protocol.Conversions do
       )
 
     {:ok, range}
+  end
+
+  def to_elixir(%{range: %{start: _start_pos, end: _end_pos}}, nil) do
+    {:error, {:invalid_document, nil}}
   end
 
   def to_lsp(%LSRange{start: %LSPosition{}, end: %LSPosition{}} = ls_range) do

--- a/apps/expert/lib/expert/protocol/conversions.ex
+++ b/apps/expert/lib/expert/protocol/conversions.ex
@@ -29,12 +29,12 @@ defmodule Expert.Protocol.Conversions do
     end
   end
 
-  def to_elixir(%LSPosition{} = position, %Document{} = document) do
-    to_elixir(position, document.lines)
-  end
-
   def to_elixir(%ElixirPosition{} = position, _) do
     {:ok, position}
+  end
+
+  def to_elixir(%LSPosition{} = position, %Document{} = document) do
+    to_elixir(position, document.lines)
   end
 
   def to_elixir(%LSPosition{line: line} = position, _) when line < 0 do

--- a/apps/expert/test/conversions_test.exs
+++ b/apps/expert/test/conversions_test.exs
@@ -64,6 +64,18 @@ defmodule Expert.Protocol.ConversionsTest do
       assert {:ok, pos} = Conversions.to_elixir(lsp_position(8, 2), doc("abcde\n1234"))
       assert %ExPosition{line: 3, character: 1} = pos
     end
+
+    test "document is nil" do
+      assert Conversions.to_elixir(
+               %GenLSP.Structures.Range{end: lsp_position(0, 0), start: lsp_position(0, 0)},
+               nil
+             ) == {:error, {:invalid_document, nil}}
+
+      assert Conversions.to_elixir(lsp_position(0, 0), nil) == {:error, {:invalid_document, nil}}
+
+      assert Conversions.to_elixir(%{range: %{start: 0, end: 0}}, nil) ==
+               {:error, {:invalid_document, nil}}
+    end
   end
 
   describe "to_lsp/2 for positions" do


### PR DESCRIPTION
I was experiencing this error on VS Code.

```log
[info]   Message: ** (FunctionClauseError) no function clause matching in XPExpert.Protocol.Conversions.to_elixir/2
    (xp_expert 0.1.0-399b2a0) lib/expert/protocol/conversions.ex:22: XPExpert.Protocol.Conversions.to_elixir(%XPGenLSP.Structures.Range{end: %XPGenLSP.Structures.Position{character: 0, line: 0}, start: %XPGenLSP.Structures.Position{character: 0, line: 0}}, nil)
    (xp_forge 0.1.0-399b2a0) lib/forge/protocol/convertible.ex:52: anonymous fn/4 in XPForge.Protocol.Convertible.Helpers.apply/3
    (elixir 1.17.3) lib/enum.ex:4858: Enumerable.List.reduce/3
    (elixir 1.17.3) lib/enum.ex:2585: Enum.reduce_while/3
    (xp_forge 0.1.0-399b2a0) lib/forge/protocol/convertible.ex:182: XPForge.Protocol.Convertible.Any.to_native/2
    (xp_expert 0.1.0-399b2a0) lib/expert/protocol/convert.ex:26: XPExpert.Protocol.Convert.to_native/1
    (xp_expert 0.1.0-399b2a0) lib/expert.ex:119: XPExpert.handle_request/2
    (xp_gen_lsp 0.11.2) lib/gen_lsp.ex:369: anonymous fn/2 in XPGenLSP.loop/3

  Code: -32603 
 ```