### PR TITLE
feat(engine): indicate progress when loading checkpoint

### DIFF
--- a/apps/engine/test/engine/search/store/backends/ets/schema_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets/schema_test.exs
@@ -1,4 +1,5 @@
 defmodule Engine.Search.Store.Backends.Ets.SchemaTest do
+  alias Engine.Dispatch
   alias Engine.Search.Store.Backends.Ets.Schema
   alias Engine.Search.Store.Backends.Ets.Wal
   alias Forge.Project
@@ -7,11 +8,18 @@ defmodule Engine.Search.Store.Backends.Ets.SchemaTest do
   import Wal, only: :macros
 
   use ExUnit.Case
+  use Patch
 
   setup do
     project = project()
 
     destroy_index_path(project)
+
+    patch(Dispatch, :erpc_call, fn Expert.Progress, :begin, [_title, _opts] ->
+      {:ok, System.unique_integer([:positive])}
+    end)
+
+    patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
     on_exit(fn ->
       destroy_index_path(project)

--- a/apps/engine/test/engine/search/store/backends/ets/wal_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets/wal_test.exs
@@ -1,4 +1,5 @@
 defmodule Engine.Search.Store.Backends.Ets.WalTest do
+  alias Engine.Dispatch
   alias Engine.Search.Store.Backends.Ets.Wal
 
   import Forge.Test.Fixtures
@@ -14,6 +15,12 @@ defmodule Engine.Search.Store.Backends.Ets.WalTest do
   setup do
     project = project()
     new_table()
+
+    patch(Dispatch, :erpc_call, fn Expert.Progress, :begin, [_title, _opts] ->
+      {:ok, System.unique_integer([:positive])}
+    end)
+
+    patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
     on_exit(fn ->
       Wal.destroy(project, @schema_version)

--- a/apps/engine/test/engine/search/store/backends/ets_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets_test.exs
@@ -8,6 +8,7 @@ defmodule Engine.Search.Store.Backend.EtsTest do
   alias Forge.Test.Fixtures
 
   use ExUnit.Case, async: false
+  use Patch
 
   import EventualAssertions
   import Entry.Builder
@@ -23,6 +24,12 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     # start with a clean slate.
 
     Engine.set_project(project)
+
+    patch(Dispatch, :erpc_call, fn Expert.Progress, :begin, [_title, _opts] ->
+      {:ok, System.unique_integer([:positive])}
+    end)
+
+    patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
     delete_indexes(project, backend)
 


### PR DESCRIPTION
This implements the idea from #308 to add progress notification while the ets checkpoint is loading.

<img width="905" height="484" alt="Screenshot 2026-01-19 at 11 03 29" src="https://github.com/user-attachments/assets/0955e29d-0bc7-4ca4-9c6e-2f70efe14f96" />
