### PR TITLE
fix: interpolation_ranges/1 should work for empty interpolations

### DIFF
--- a/apps/forge/lib/forge/ast/tokens.ex
+++ b/apps/forge/lib/forge/ast/tokens.ex
@@ -154,6 +154,10 @@ defmodule Forge.Ast.Tokens do
           range = {{line, column}, end_pos}
           {end_pos, [{:literal, literal, range} | acc]}
 
+        {_, {end_line, end_column, _}, []}, {_, acc} ->
+          range = {{end_line, end_column}, {end_line, end_column}}
+          {{end_line, end_column}, [{:interpolation, [], range} | acc]}
+
         {_, {end_line, end_column, _}, interp}, {_, acc} ->
           start_pos = get_start_pos(interp)
           range = {start_pos, {end_line, end_column}}

--- a/apps/forge/test/forge/ast/tokens_test.exs
+++ b/apps/forge/test/forge/ast/tokens_test.exs
@@ -48,6 +48,26 @@ defmodule Forge.Ast.TokensTest do
       assert Enum.to_list(tokens) == []
     end
 
+    test "works on empty interpolations" do
+      text = ~S|"foo#{}bar"|
+
+      {position, document} = pop_cursor(text <> "|", as: :document)
+
+      tokens = Tokens.prefix_stream(document, position)
+
+      assert Enum.to_list(tokens) == [
+               {
+                 :interpolated_string,
+                 [
+                   {:literal, "foo", {{1, 1}, {1, 4}}},
+                   {:interpolation, [], {{1, 7}, {1, 7}}},
+                   {:literal, "bar", {{1, 7}, {1, 10}}}
+                 ],
+                 {1, 1}
+               }
+             ]
+    end
+
     test "works on interpolations with newlines" do
       text = ~S[
           ~S"""


### PR DESCRIPTION
With Spitfire we now parse things like `"foo#{}bar"`. The previous code wasn't able to calculate ranges for empty interpolations and crashed.
