### PR TITLE
fix: correctly order aliases

### DIFF
--- a/apps/engine/test/engine/code_action/handlers/organize_aliases_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/organize_aliases_test.exs
@@ -132,6 +132,29 @@ defmodule Engine.CodeAction.Handlers.OrganizeAliasesTest do
       assert expected == organized
     end
 
+    test "aliases are sorted alphabetically" do
+      {:ok, organized} =
+        ~q[
+          defmodule SortAliases do
+            alias A|
+            alias C
+            alias D
+            alias B
+          end
+        ]
+        |> organize_aliases()
+
+      expected = ~q[
+      defmodule SortAliases do
+        alias A
+        alias B
+        alias C
+        alias D
+      end
+    ]t
+      assert expected == organized
+    end
+
     test "aliases are removed duplicate aliases" do
       {:ok, organized} =
         ~q[

--- a/apps/engine/test/engine/code_mod/directives_test.exs
+++ b/apps/engine/test/engine/code_mod/directives_test.exs
@@ -92,11 +92,11 @@ defmodule Engine.CodeMod.DirectivesTest do
           range: &range_of/1
         )
 
-      # expect old ranges removed (replaced/emptied) and new block inserted
-      assert length(edits) == 3
-      assert Enum.any?(edits, &(&1.text == "\n"))
-      assert Enum.any?(edits, &String.contains?(&1.text, "decl a"))
-      assert Enum.any?(edits, &String.contains?(&1.text, "decl b"))
+      assert length(edits) >= 2
+      [insert_edit | delete_edits] = edits
+      assert String.contains?(insert_edit.text, "decl a")
+      assert String.contains?(insert_edit.text, "decl b")
+      assert Enum.all?(delete_edits, &(&1.text == ""))
     end
   end
 end


### PR DESCRIPTION
Lines were being mangled due to deletes being incorrectly applied after inserts, and newlines being messed up.
