### PR TITLE
fix: sanitize node names

### DIFF
--- a/apps/forge/lib/forge/node.ex
+++ b/apps/forge/lib/forge/node.ex
@@ -1,0 +1,36 @@
+defmodule Forge.Node do
+  @moduledoc false
+
+  @problematic_chars [?., ?@, ?:, ?-, ?\s]
+
+  @doc """
+  Sanitizes a string to be safe for use in Erlang node names.
+
+  Replaces problematic characters (`.`, `@`, `:`, `-`, space) with underscores.
+  These characters either break the `name@host` format or cause issues in atoms.
+
+  ## Examples
+
+      iex> Forge.Node.sanitize("my-project")
+      "my_project"
+
+      iex> Forge.Node.sanitize("expert-lsp.org")
+      "expert_lsp_org"
+
+      iex> Forge.Node.sanitize("MyProject")
+      "MyProject"
+
+      iex> Forge.Node.sanitize("プロジェクト")
+      "プロジェクト"
+
+  """
+  @spec sanitize(String.t()) :: String.t()
+  def sanitize(name) when is_binary(name) do
+    name
+    |> String.to_charlist()
+    |> Enum.map(fn char ->
+      if char in @problematic_chars, do: ?_, else: char
+    end)
+    |> List.to_string()
+  end
+end

--- a/apps/forge/lib/forge/project.ex
+++ b/apps/forge/lib/forge/project.ex
@@ -54,29 +54,15 @@ defmodule Forge.Project do
   @spec name(t) :: String.t()
 
   def name(%__MODULE__{} = project) do
-    sanitized =
-      project
-      |> folder_name()
-      |> String.replace(~r/[^a-zA-Z0-9_]/, "_")
-
-    # This might be a little verbose, but this code is hot.
-    case sanitized do
-      <<c::utf8, _rest::binary>> when c in ?a..?z ->
-        sanitized
-
-      <<c::utf8, rest::binary>> when c in ?A..?Z ->
-        String.downcase("#{[c]}") <> rest
-
-      other ->
-        "p_#{other}"
-    end
+    folder_name(project)
   end
 
   @doc """
   The project node's name
   """
   def node_name(%__MODULE__{} = project) do
-    :"expert-project-#{name(project)}-#{entropy(project)}@127.0.0.1"
+    sanitized = Forge.Node.sanitize(name(project))
+    :"expert-project-#{sanitized}-#{entropy(project)}@127.0.0.1"
   end
 
   def entropy(%__MODULE__{} = project) do
@@ -172,7 +158,8 @@ defmodule Forge.Project do
         _ -> Forge.Workspace.name(workspace)
       end
 
-    :"expert-manager-#{workspace_name}-#{entropy(project)}@127.0.0.1"
+    sanitized = Forge.Node.sanitize(workspace_name)
+    :"expert-manager-#{sanitized}-#{entropy(project)}@127.0.0.1"
   end
 
   @doc """

--- a/apps/forge/test/forge/node_test.exs
+++ b/apps/forge/test/forge/node_test.exs
@@ -1,0 +1,73 @@
+defmodule Forge.NodeTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Forge.Node
+
+  describe "sanitize/1" do
+    test "sanitized names do not contain problematic characters" do
+      check all(name <- string(:utf8, min_length: 1)) do
+        sanitized = Node.sanitize(name)
+
+        # Should not contain characters that break node name format
+        refute String.contains?(sanitized, [".", "@", ":", "-"]),
+               "Expected #{inspect(sanitized)} not to contain problematic characters"
+      end
+    end
+
+    test "periods are replaced with underscores" do
+      assert Node.sanitize("expert-lsp.org") == "expert_lsp_org"
+      assert Node.sanitize("foo.bar.baz") == "foo_bar_baz"
+    end
+
+    test "dashes are replaced with underscores" do
+      assert Node.sanitize("my-project") == "my_project"
+      assert Node.sanitize("my-cool-project") == "my_cool_project"
+    end
+
+    test "at signs are replaced with underscores" do
+      assert Node.sanitize("project@name") == "project_name"
+    end
+
+    test "colons are replaced with underscores" do
+      assert Node.sanitize("project:name") == "project_name"
+    end
+
+    test "spaces are replaced with underscores" do
+      assert Node.sanitize("my project") == "my_project"
+    end
+
+    test "preserves letters and case" do
+      assert Node.sanitize("MyProject") == "MyProject"
+      assert Node.sanitize("fooBar") == "fooBar"
+    end
+
+    test "preserves numbers" do
+      assert Node.sanitize("project123") == "project123"
+      assert Node.sanitize("123project") == "123project"
+    end
+
+    test "preserves underscores" do
+      assert Node.sanitize("my_project") == "my_project"
+    end
+
+    test "preserves UTF-8 characters" do
+      # Japanese katakana
+      assert Node.sanitize("プロジェクト") == "プロジェクト"
+      # Chinese
+      assert Node.sanitize("项目") == "项目"
+      # Latin with diacritics
+      assert Node.sanitize("proyecto_código") == "proyecto_código"
+    end
+
+    test "handles empty string" do
+      assert Node.sanitize("") == ""
+    end
+
+    test "handles string with only problematic characters" do
+      assert Node.sanitize("...") == "___"
+      assert Node.sanitize("@@@") == "___"
+      assert Node.sanitize(".-:@") == "____"
+    end
+  end
+end

--- a/apps/forge/test/forge/workspace_test.exs
+++ b/apps/forge/test/forge/workspace_test.exs
@@ -1,0 +1,37 @@
+defmodule Forge.WorkspaceTest do
+  alias Forge.Workspace
+
+  use ExUnit.Case, async: true
+
+  describe "name/1" do
+    test "returns the folder basename" do
+      workspace = Workspace.new("/path/to/my-project")
+      assert Workspace.name(workspace) == "my-project"
+    end
+
+    test "returns folder name with periods" do
+      workspace = Workspace.new("/path/to/expert-lsp.org")
+      assert Workspace.name(workspace) == "expert-lsp.org"
+    end
+
+    test "returns folder name with special characters" do
+      workspace = Workspace.new("/path/to/project@name:test")
+      assert Workspace.name(workspace) == "project@name:test"
+    end
+
+    test "returns folder name with spaces" do
+      workspace = Workspace.new("/path/to/my project")
+      assert Workspace.name(workspace) == "my project"
+    end
+
+    test "returns folder name with UTF-8 characters" do
+      workspace = Workspace.new("/path/to/プロジェクト")
+      assert Workspace.name(workspace) == "プロジェクト"
+    end
+
+    test "returns folder name with uppercase letters unchanged" do
+      workspace = Workspace.new("/path/to/MyProject")
+      assert Workspace.name(workspace) == "MyProject"
+    end
+  end
+end


### PR DESCRIPTION
Fix #316

Special characters can cause clustering issues, this PR adds sanitization to ensure node names are safe and valid.

There was a comment about the sanitization being a hot path, which is true, so I benchmarked it. The new sanitization happens to actually be about 2-20x faster depending on the input size, I think mostly because I'm not using a Regex, so this should not introduce any performance regressions.
