### PR TITLE
feat(engine): hover for module attributes

### DIFF
--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -1,4 +1,5 @@
 defmodule Expert.Provider.Handlers.HoverTest do
+  alias Engine.Search
   alias Expert.EngineApi
   alias Expert.Protocol.Convert
   alias Expert.Provider.Handlers
@@ -725,6 +726,115 @@ defmodule Expert.Provider.Handlers.HoverTest do
         assert result.contents.value == expected
       end)
     end
+  end
+
+  describe "module attribute hover" do
+    test "shows attribute definition", %{project: project} do
+      code = ~q[
+        defmodule AttrHover do
+          @my_attr "hello"
+
+          def foo, do: @my_attr
+        end
+      ]
+
+      hovered = ~q[
+        defmodule AttrHover do
+          @my_attr "hello"
+
+          def foo, do: |@my_attr
+        end
+      ]
+
+      with_indexed(project, code, fn ->
+        assert {:ok, %Structures.Hover{} = result} = hover(project, hovered)
+        assert result.contents.kind == "markdown"
+        assert String.contains?(result.contents.value, "@my_attr")
+        assert String.contains?(result.contents.value, ~s[@my_attr "hello"])
+      end)
+    end
+
+    test "shows multiline attribute definition", %{project: project} do
+      code = """
+      defmodule AttrHover do
+        @config [
+          name: "test",
+          value: 42
+        ]
+
+        def get_config, do: @config
+      end
+      """
+
+      hovered = """
+      defmodule AttrHover do
+        @config [
+          name: "test",
+          value: 42
+        ]
+
+        def get_config, do: |@config
+      end
+      """
+
+      with_indexed(project, code, fn ->
+        assert {:ok, %Structures.Hover{} = result} = hover(project, hovered)
+        assert result.contents.kind == "markdown"
+        assert String.contains?(result.contents.value, "@config")
+        assert String.contains?(result.contents.value, "name:")
+      end)
+    end
+
+    test "shows fallback when no definition found", %{project: project} do
+      hovered = ~q[
+        defmodule AttrHoverFallback do
+          def foo, do: |@unknown_attr
+        end
+      ]
+
+      assert {:ok, %Structures.Hover{} = result} = hover(project, hovered)
+      assert result.contents.kind == "markdown"
+      assert String.contains?(result.contents.value, "@unknown_attr")
+    end
+  end
+
+  defp with_indexed(project, code, fun) do
+    tmp_dir = Fixtures.file_path(project, "lib/tmp")
+
+    tmp_path =
+      tmp_dir
+      |> Path.join("tmp_indexed_#{rand_hex(10)}.ex")
+
+    File.mkdir_p!(tmp_dir)
+
+    with_tmp_file(tmp_path, code, fn ->
+      wait_for_store_ready(project)
+
+      uri = Document.Path.ensure_uri(tmp_path)
+      {:ok, _document} = Document.Store.open_temporary(uri)
+
+      {:ok, entries} = Search.Indexer.Source.index(tmp_path, code)
+      :ok = EngineApi.call(project, Search.Store, :replace, [entries])
+
+      try do
+        fun.()
+      after
+        Document.Store.close(uri)
+      end
+    end)
+  end
+
+  defp wait_for_store_ready(project) do
+    Enum.reduce_while(1..50, :not_ready, fn _, _ ->
+      case EngineApi.call(project, Search.Store, :loaded?, []) do
+        true ->
+          {:halt, :ok}
+
+        _ ->
+          Process.sleep(100)
+          {:cont, :not_ready}
+      end
+    end)
   end
 
   defp hover(project, hovered) do


### PR DESCRIPTION
Something I've been missing is the ability to quickly look up how the module attribute is defined. It just shows the definition, does not try to evaluate it, which is sufficient in my opinion for most cases.

Go to definition already worked for module attributes.

<img width="634" height="250" alt="Screenshot 2026-01-22 at 17 31 43" src="https://github.com/user-attachments/assets/8c4a7fc1-1c72-4dfd-bbd8-7b112c69a345" />
