### PR TITLE
test: correctly expect lexicographic sorting

### DIFF
--- a/apps/expert/test/expert/engine_test.exs
+++ b/apps/expert/test/expert/engine_test.exs
@@ -111,7 +111,7 @@ defmodule Expert.EngineTest do
       assert output =~ "Error deleting"
       assert output =~ dir3
 
-      # Should only attempt dir1 and dir2, not dir3
+      # Sorted order is dir1, dir3, dir2; should only attempt dir1 and dir3
       attempted_dirs =
         agent_pid
         |> Agent.get(& &1)
@@ -119,7 +119,7 @@ defmodule Expert.EngineTest do
 
       assert length(attempted_dirs) == 2
       assert Enum.at(attempted_dirs, 0) =~ "0.1.0/foobar"
-      assert Enum.at(attempted_dirs, 1) =~ "0.2.0/foobar"
+      assert Enum.at(attempted_dirs, 1) =~ "0.2.0/bazbeau"
     end
   end
 
@@ -174,15 +174,15 @@ defmodule Expert.EngineTest do
       File.mkdir_p!(dir2)
       File.mkdir_p!(dir3)
 
-      # Answer yes to first, no to second, yes to third
+      # Answer yes to first, no to second, yes to third (sorted order)
       capture_io([input: "y\nn\nyes\n"], fn ->
         exit_code = Engine.run(["clean"])
         assert exit_code == 0
       end)
 
       refute File.exists?(dir1)
-      assert File.exists?(dir2)
-      refute File.exists?(dir3)
+      refute File.exists?(dir2)
+      assert File.exists?(dir3)
     end
 
     test "prints message when no engine builds exist" do
@@ -227,7 +227,7 @@ defmodule Expert.EngineTest do
 
       assert output =~ "Error deleting"
 
-      # Should only attempt dir1 and dir2, not dir3
+      # Sorted order is dir1, dir3, dir2; should only attempt dir1 and dir3
       attempted_dirs =
         agent_pid
         |> Agent.get(& &1)


### PR DESCRIPTION
**I'm a bit confused as I can't find any reference to this failing for others and CI seems to pass.**
But on my machine, `just test expert --warnings-as-errors` reliably fails 2 test assertions on `main` and is _very_ timeout-flaky for some others. This fixes the 2 reliably failing assertions not matching the expectations of lexicographic ordering of `apps/expert/lib/expert/engine.ex:103-114`.

My machine:
- macOS 26.2
- Erlang/OTP 28.3.1
- Elixir 1.19.5
- nushell 0.110.0

---
Reproducible test failures:
```elixir
  1) test run/1 - clean subcommand with --force stops deleting after first error and returns error code 1 (Expert.EngineTest)
     test/expert/engine_test.exs:81
     Assertion with =~ failed
     code:  assert Enum.at(attempted_dirs, 1) =~ "0.2.0/foobar"
     left:  "/path/to/repo/expert/apps/expert/tmp/Expert.EngineTest/test-run-1---clean-subcommand-with---force-stops-deleting-after-first-error-and-returns-error-code-1-052d261f/0.2.0/bazbeau"
     right: "0.2.0/foobar"
     stacktrace:
       test/expert/engine_test.exs:122: (test)

  2) test run/1 - clean subcommand interactive mode handles multiple directories with mixed responses (Expert.EngineTest)
     test/expert/engine_test.exs:169
     Expected truthy, got false
     code: assert File.exists?(dir2)
     arguments:

         # 1
         "/path/to/repo/expert/apps/expert/tmp/Expert.EngineTest/test-run-1---clean-subcommand-interactive-mode-handles-multiple-directories-with-mixed-responses-adb406df/0.2.0/foobar"

     stacktrace:
       test/expert/engine_test.exs:184: (test)
```