### PR TITLE
fix(engine): download Hex and Rebar only if missing

### DIFF
--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -17,8 +17,8 @@ expert_data_path = :filename.basedir(:user_data, "Expert", %{version: expert_vsn
 
 System.put_env("MIX_INSTALL_DIR", expert_data_path)
 
-Mix.Task.run("local.hex", ["--force"])
-Mix.Task.run("local.rebar", ["--force"])
+Mix.Task.run("local.hex", ["--force", "--if-missing"])
+Mix.Task.run("local.rebar", ["--force", "--if-missing"])
 
 Mix.install([{:engine, path: engine_source_path, env: :dev}],
   start_applications: false,


### PR DESCRIPTION
Closes: https://github.com/elixir-lang/expert/issues/336 by downloading Hex and Rebar only if missing before building the engine. This should also make the startup of the extension faster and allow offline mode. I tested it locally and I can use Expert now without an internet connection just fine!