### PR TITLE
fix(forge): handle interpolation when it starts with a special token

### DIFF
--- a/apps/forge/lib/forge/ast/tokens.ex
+++ b/apps/forge/lib/forge/ast/tokens.ex
@@ -171,6 +171,11 @@ defmodule Forge.Ast.Tokens do
     {start_line, start_column}
   end
 
+  defp get_start_pos([{token, {start_line, start_column, _}} | _])
+       when token in [:"(", :"[", :"{", :%, :%{}] do
+    {start_line, start_column}
+  end
+
   defp get_start_pos([{_, {start_line, start_column, _}, _} | _]) do
     {start_line, start_column}
   end


### PR DESCRIPTION
We identified few situations when `Forge.Ast.Tokens` fails on string interpolation. They all share these two characteristics:
* The string does not start with interpolation
* The expression in interpolation begins with a "special" character, such as a bracket or percent sign