### PR TITLE
fix(engine): handle matches against any struct

### DIFF
--- a/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
@@ -81,6 +81,12 @@ defmodule Engine.Search.Indexer.Extractors.StructReference do
     Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
   end
 
+  # Any-struct pattern: %_{}
+  defp expand_alias(:_, _reducer), do: :ignored
+
+  # Struct pattern with variable binding: %struct_name{}
+  defp expand_alias(atom, _reducer) when is_atom(atom), do: :ignored
+
   defp expand_alias(alias, %Reducer{} = reducer) do
     {line, column} = reducer.position
 


### PR DESCRIPTION
Using an "any struct match" (I don't know the proper term, sorry) causes errors being logged during indexing:

```
14:58:09.984 [debug] Node port message: 
14:58:09.984 [error] Could not expand alias: {:_, [line: 1590, column: 35], nil} at /path/to/file.ex 1590:34
```

The code causing it is, for example:

```elixir
  defp normalize_suggestion_data(%_{} = struct) do
    Map.from_struct(struct)
  end
```

This change adds proper handling to this kind of matches (ignoring them, as they are not useful, but without emitting an error).