### PR TITLE
fix(engine): correctly match any-struct references

### DIFF
--- a/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
@@ -81,11 +81,8 @@ defmodule Engine.Search.Indexer.Extractors.StructReference do
     Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
   end
 
-  # Any-struct pattern: %_{}
-  defp expand_alias(:_, _reducer), do: :ignored
-
-  # Struct pattern with variable binding: %struct_name{}
-  defp expand_alias(atom, _reducer) when is_atom(atom), do: :ignored
+  # We ignore struct references with variable names, e.g. %_{}, %var_name{}
+  defp expand_alias({atom, _, ctx}, _reducer) when is_atom(atom) and is_atom(ctx), do: :ignored
 
   defp expand_alias(alias, %Reducer{} = reducer) do
     {line, column} = reducer.position


### PR DESCRIPTION
I noticed that after upgrading to the current newest version ([375391c](https://github.com/elixir-lang/expert/commit/375391c92c8027e06e0c293325384e6c58310a6f)) I still see a lot of the following log
```
Could not expand alias: {:mod, [], MyModule}
```

The should be resolved after #343, but there is a small typo in one of the heads of `expand_alias(ast_node, reducer)`.
I've hopefully fixed the issue for good by pattern matching against the AST representation of a variable in the appropriate head clause and adding tests for the log.

I've specifically avoided against matching patterns like `%my_macro(){}`, since they may actually contain a reference to a struct.