### PR TITLE
fix(cli): don't crash when there is no CLI arg provided

### DIFF
--- a/apps/expert/lib/expert/application.ex
+++ b/apps/expert/lib/expert/application.ex
@@ -31,6 +31,9 @@ defmodule Expert.Application do
 
           System.halt(1)
         end
+
+      _ ->
+        :noop
     end
 
     {opts, _argv, _invalid} =


### PR DESCRIPTION
Currently when no argument is passed to Expert's binary, it crashes:

```
❯ ./expert_darwin_arm64 
Kernel pid terminated (application_controller) ("{application_start_failure,xp_expert,{bad_return,{{'Elixir.XPExpert.Application',start,[normal,[]]},{'EXIT',{{case_clause,[]},[{'Elixir.XPExpert.Application',start,2,[{file,\"lib/expert/application.ex\"},{line,18}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,295}]}]}}}}}")

Crash dump is being written to: erl_crash.dump...done
```

This brings back previous behaviour, with "FATAL" message explaining that you need to provide transport or use `engine` subcommand.