### PR TITLE
test: set test using Patch to be async: false

### DIFF
--- a/apps/forge/test/forge/ast_test.exs
+++ b/apps/forge/test/forge/ast_test.exs
@@ -12,7 +12,7 @@ defmodule Forge.AstTest do
   import Forge.Test.PositionSupport
   import Forge.Test.RangeSupport
 
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Patch
 
   describe "cursor_path/2" do


### PR DESCRIPTION
There is a failing test on main, I think it's because we're using Patch on a test with `async: true`, while Patch is incompatible with async tests

```elixir
1) test in_context?/2 can detect behaviours (Forge.Ast.EnvTest)
Error:      test/forge/ast/env_test.exs:181
     ** (UndefinedFunctionError) function Patch.Mock.Delegate.For.Forge.Ast.Parser.Spitfire.string_to_quoted/1 is undefined (module Patch.Mock.Delegate.For.Forge.Ast.Parser.Spitfire is not available)
     code: env = new_env("@behaviour Modul|e")
     stacktrace:
       Patch.Mock.Delegate.For.Forge.Ast.Parser.Spitfire.string_to_quoted("@behaviour Module")
       (forge 0.1.0) lib/forge/ast.ex:173: Forge.Ast.from/1
       (forge 0.1.0) lib/forge/ast.ex:123: Forge.Ast.analyze/1
       test/forge/ast/env_test.exs:14: Forge.Ast.EnvTest.new_env/2
       test/forge/ast/env_test.exs:182: (test)
```