### PR TITLE
fix(engine): isolate search store from async load crashes

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -17,6 +17,7 @@ defmodule Engine.Application do
           Engine.Build.CaptureServer,
           Engine.Plugin.Runner.Supervisor,
           Engine.Plugin.Runner.Coordinator,
+          {Task.Supervisor, name: Engine.TaskSupervisor},
           Engine.Search.Store.Backends.Ets,
           {Engine.Search.Store,
            [

--- a/apps/engine/lib/engine/search/store/state.ex
+++ b/apps/engine/lib/engine/search/store/state.ex
@@ -234,7 +234,7 @@ defmodule Engine.Search.Store.State do
 
   defp prepare_backend_async(%__MODULE__{async_load_ref: nil} = state, backend_result) do
     task =
-      Task.async(fn ->
+      Task.Supervisor.async_nolink(Engine.TaskSupervisor, fn ->
         case state.backend.prepare(backend_result) do
           {:ok, :empty} ->
             Logger.info("backend reports empty")

--- a/apps/engine/test/engine/code_intelligence/references_test.exs
+++ b/apps/engine/test/engine/code_intelligence/references_test.exs
@@ -20,6 +20,7 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
     Backends.Ets.destroy_all(project)
     Engine.set_project(project)
 
+    start_supervised!({Task.Supervisor, name: Engine.TaskSupervisor})
     start_supervised!(Document.Store)
     start_supervised!(Engine.Dispatch)
     start_supervised!(Backends.Ets)

--- a/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
+++ b/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
@@ -28,6 +28,7 @@ defmodule Engine.Dispatch.Handlers.IndexingTest do
 
     patch(Engine.Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
+    start_supervised!({Task.Supervisor, name: Engine.TaskSupervisor})
     start_supervised!(Engine.Dispatch)
     start_supervised!(Commands.Reindex)
     start_supervised!(Search.Store.Backends.Ets)

--- a/apps/engine/test/engine/search/store/backends/ets_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets_test.exs
@@ -61,6 +61,7 @@ defmodule Engine.Search.Store.Backend.EtsTest do
   end
 
   defp start_supervised_store(%Project{} = project, create_fn, update_fn, backend) do
+    start_supervised!({Task.Supervisor, name: Engine.TaskSupervisor})
     start_supervised!(Dispatch)
     start_supervised!(Backends.Ets)
     start_supervised!({Store, [project, create_fn, update_fn, backend]})


### PR DESCRIPTION
This is part of a set of 4 PRs that arose out of some static analysis tooling I'm working on:
- https://github.com/elixir-lang/expert/pull/369
- https://github.com/elixir-lang/expert/pull/370
- https://github.com/elixir-lang/expert/pull/371
- https://github.com/elixir-lang/expert/pull/372

That means that these aren't crashes or issues that I've observed in practice, however based on my reading of the code, they do represent issues worth addressing.

## Problem:
`State.prepare_backend_async/2` uses `Task.async/1` to build the search index. If this task raises, the `Store` crashes, and the task silently fails. The store is supervised under a `:one_for_one` strategy, and as far as I can tell, no indexed data is permanently lost, however:

1) During the restart window, callers of the `Store` will be returned `:noproc` instead of  `{:error, :loading}`, and the crash will cascade
2) If any `project_compiled` events are dispatched between the crash and the restart, these will be missed by the `Store`. Since these events are never replayed, the event will be lost, and the server will remain unloaded until the next compilation

## Solution
By using `Task.Supervisor.async_nolink/2` to start the search index task under a dedicated `Engine.TaskSupervisor`, we can instead handle a crash in the task by logging the error, and clearing `async_load_ref`, so that the server is immediately ready to process further requests.

During this time, the server remains available, callers are isolated from the crash, no `project_compiled` events are lost while waiting for the restart, and previously loaded indexes remain loaded.

In the successful case, the monitor is flushed to avoid `:DOWN` messages building up and causing a mailbox leak.