### PR TITLE
fix(forge): monitor beam rewriting worker process

### DIFF
--- a/apps/forge/test/forge/namespace/transform/beams_test.exs
+++ b/apps/forge/test/forge/namespace/transform/beams_test.exs
@@ -1,0 +1,30 @@
+defmodule Forge.Namespace.Transform.BeamsTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Forge.Namespace.Transform.Beams
+
+  @moduletag tmp_dir: true
+
+  describe "apply_to_all/2 crash handling" do
+    test "raises when worker process crashes", %{tmp_dir: tmp_dir} do
+      # We need total_files to be > 0 in block_until_done to enter the
+      # receive loop
+      File.mkdir_p!(Path.join([tmp_dir, "lib", "fake"]))
+      File.write!(Path.join([tmp_dir, "lib", "fake", "Elixir.Fake.beam"]), "")
+
+      patch(Mix.Tasks.Namespace, :app_names, [:fake])
+
+      # Force a crash inside the worker. :beam_lib.chunks is the first
+      # remote call in apply/1, so patching it sidesteps the with clause that
+      # would otherwise handle a graceful error return.
+      patch(:beam_lib, :chunks, fn _path, _chunks ->
+        raise "simulated beam_lib crash"
+      end)
+
+      assert_raise RuntimeError, ~r/Beam rewriting worker crashed/, fn ->
+        Beams.apply_to_all(tmp_dir, no_progress: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is part of a set of 4 PRs that arose out of some static analysis tooling I'm working on:
- https://github.com/elixir-lang/expert/pull/369
- https://github.com/elixir-lang/expert/pull/370
- https://github.com/elixir-lang/expert/pull/371
- https://github.com/elixir-lang/expert/pull/372

That means that these aren't crashes or issues that I've observed in practice, however based on my reading of the code, they do represent issues worth addressing.

## Problem:
`Beams.apply_to_all/2` spawns its worker process using a bare `spawn/1`, and then blocks in `block_until_done/3` until it receives a `:progress` message from it. If the worker crashes, this message will never arrive, and the caller will block indefinitely.

## Solution
Replace `spawn/1` with `spawn_monitor/1`, and add a `receive` clause in `block_until_done/3` to handle the worker unexpectedly terminating before a `:progress` message is sent, so that we're able to immediately raise instead of blocking forever.

In the successful case, the monitor is flushed to avoid `:DOWN` messages building up and causing a mailbox leak.