### PR TITLE
fix(expert_credo): prevent infinite hang in with_stdin/2

### DIFF
--- a/apps/expert_credo/lib/expert_credo.ex
+++ b/apps/expert_credo/lib/expert_credo.ex
@@ -64,15 +64,25 @@ defmodule ExpertCredo do
     {:ok, stdio} = StringIO.open(stdin_contents)
     caller = self()
 
-    spawn(fn ->
-      Process.group_leader(self(), stdio)
-      result = function.()
-      send(caller, {:result, result})
-    end)
+    {pid, ref} =
+      spawn_monitor(fn ->
+        Process.group_leader(self(), stdio)
+        result = function.()
+        send(caller, {:result, result})
+      end)
 
     receive do
       {:result, result} ->
+        Process.demonitor(ref, [:flush])
         {:ok, result}
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        {:error, reason}
+    after
+      30_000 ->
+        Process.demonitor(ref, [:flush])
+        Process.exit(pid, :kill)
+        {:error, :timeout}
     end
   end
 

--- a/apps/expert_credo/test/expert_credo_test.exs
+++ b/apps/expert_credo/test/expert_credo_test.exs
@@ -15,6 +15,15 @@ defmodule ExpertCredoTest do
     Document.new("file:///file.ex", contents, 1)
   end
 
+  test "with_stdin returns result on success" do
+    assert {:ok, :hello} = ExpertCredo.with_stdin("input", fn -> :hello end)
+  end
+
+  test "with_stdin returns error when function raises" do
+    assert {:error, {%RuntimeError{message: "boom"}, _stacktrace}} =
+             ExpertCredo.with_stdin("input", fn -> raise "boom" end)
+  end
+
   test "reports errors on documents" do
     has_inspect =
       """


### PR DESCRIPTION
This is part of a set of 4 PRs that arose out of some static analysis tooling I'm working on:
- https://github.com/elixir-lang/expert/pull/369
- https://github.com/elixir-lang/expert/pull/370
- https://github.com/elixir-lang/expert/pull/371
- https://github.com/elixir-lang/expert/pull/372

That means that these aren't crashes or issues that I've observed in practice, however based on my reading of the code, they do represent issues worth addressing.

## Problem:
This is effectively the same issue as in https://github.com/elixir-lang/expert/pull/370, where the use of a bare `spawn/2` causes the spawning process to hang indefinitely while waiting for a message from the spawned process, and preventing `Credo` diagnostics from being updated.

## Solution
Replace `spawn/1` with `spawn_monitor/1`, and add a `receive` clause to handle the spawned process unexpectedly terminating before sending a result.

In the successful case, the monitor is flushed to avoid `:DOWN` messages building up and causing a mailbox leak.

A 30 second timeout is also added, to prevent buggy or broken `Credo` modules from causing the entire system to hang.