### PR TITLE
docs: ai policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -2,54 +2,49 @@
 
 The Expert project has strict rules for AI usage:
 
-- **All AI usage in any form must be disclosed.** You must state
-  the tool you used (e.g. Claude Code, Cursor, Amp) along with
-  the extent that the work was AI-assisted.
+- **All AI usage in any form must be disclosed.** You must state the tool you
+  used (e.g. Claude Code, Cursor, Amp) along with the extent that the work was
+  AI-assisted.
 
 - **Pull requests created in any way by AI can only be for accepted issues.**
-  Drive-by pull requests that do not reference an accepted issue will be
-  closed. If AI isn't disclosed but a maintainer suspects its use, the
-  PR will be closed. If you want to share code for a non-accepted issue,
-  open a discussion or attach it to an existing discussion.
+  Drive-by pull requests that do not reference an accepted issue will be closed.
+  If AI isn't disclosed but a maintainer suspects its use, the PR will be closed.
+  If you want to share code for a non-accepted issue, open a discussion or attach
+  it to an existing discussion.
 
-- **Pull requests created by AI must have been fully verified with
-  human use.** AI must not create hypothetically correct code that
-  hasn't been tested. Importantly, you must not allow AI to write
-  code for platforms or environments you don't have access to manually
-  test on.
+- **Pull requests created by AI must have been fully verified with human use.**
+  AI must not create hypothetically correct code that hasn't been tested.
+  Importantly, you must not allow AI to write code for platforms or environments
+  you don't have access to manually test on.
 
 - **Issues and discussions can use AI assistance but must have a full
-  human-in-the-loop.** This means that any content generated with AI
-  must have been reviewed _and edited_ by a human before submission.
-  AI is very good at being overly verbose and including noise that
-  distracts from the main point. Humans must do their research and
-  trim this down.
+  human-in-the-loop.** This means that any content generated with AI must have
+  been reviewed _and edited_ by a human before submission. AI is very good at
+  being overly verbose and including noise that distracts from the main point.
+  Humans must do their research and trim this down.
 
-- **No AI-generated media is allowed (art, images, videos, audio, etc.).**
-  Text and code are the only acceptable AI-generated content, per the
-  other rules in this policy.
+- **No AI-generated media is allowed (art, images, videos, audio, etc.).** Text
+  and code are the only acceptable AI-generated content, per the other rules in
+  this policy.
 
-- **Bad AI drivers will be banned.** You've been warned. We love to help
-  junior developers learn and grow, but if you're interested in that then
-  don't use AI, and we'll help you. I'm sorry that bad AI drivers have
-  ruined this for you.
+- **Bad AI drivers will be banned.** You've been warned. We love to help junior
+  developers learn and grow, but if you're interested in that then don't use AI,
+  and we'll help you. I'm sorry that bad AI drivers have ruined this for you.
 
-These rules apply only to outside contributions to Expert. Maintainers
-are exempt from these rules and may use AI tools at their discretion;
-they've proven themselves trustworthy to apply good judgment.
+These rules apply only to outside contributions to Expert. Maintainers are
+exempt from these rules and may use AI tools at their discretion; they've proven
+themselves trustworthy to apply good judgment.
 
 ## There are Humans Here
 
 Please remember that Expert is maintained by humans.
 
-Every discussion, issue, and pull request is read and reviewed by
-humans (and sometimes machines, too). It is a boundary point at which
-people interact with each other and the work done. It is rude and
-disrespectful to approach this boundary with low-effort, unqualified
+Every discussion, issue, and pull request is read and reviewed by humans. It is
+a boundary point at which people interact with each other and the work done. It
+is rude and disrespectful to approach this boundary with low-effort, unqualified
 work, since it puts the burden of validation on the maintainer.
 
-In a perfect world, AI would produce high-quality, accurate work
-every time. But today, that reality depends on the driver of the AI.
-And today, most drivers of AI are just not good enough. So, until either
-the people get better, the AI gets better, or both, we have to have
-strict rules to protect maintainers.
+In a perfect world, AI would produce high-quality, accurate work every time. But
+today, that reality depends on the driver of the AI. And today, most drivers of
+AI are just not good enough. So, until either the people get better, the AI gets
+better, or both, we have to have strict rules to protect maintainers.


### PR DESCRIPTION
## Proposal

Adopts a modified version of the Ghostty AI Policy from
https://github.com/ghostty-org/ghostty/blob/960b181df7b3d98a66034bc96138961db0b00c7e/AI_POLICY.md

- Changes the name to Expert from Ghostty
- Removes some language about ridiculing bad actors
- Removes last paragraph "AI is Welcome", just not necessary
- Reflows the document to 80 characters
- Changes some wording

Let me know your thoughts.
