### PR TITLE
chore(forge): ignore test fixtures via :test_ignore_filters

### DIFF
--- a/apps/forge/mix.exs
+++ b/apps/forge/mix.exs
@@ -11,7 +11,8 @@ defmodule Forge.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       compilers: [:yecc] ++ Mix.compilers(),
-      dialyzer: Mix.Dialyzer.config()
+      dialyzer: Mix.Dialyzer.config(),
+      test_ignore_filters: [&String.starts_with?(&1, "test/fixtures")]
     ]
   end
 


### PR DESCRIPTION
Fixes #374 

This is a new thing in Elixir 1.19. It by default takes all files in `test` directory and if they don't match inclusion filter (ends with `_test.exs` by default), nor end with `_helper.ex` nor are present in `elixirc_paths` - it raises a warning. See https://github.com/elixir-lang/elixir/commit/a4cb71c0cd4fe58f2ff0ca67254f1cc2ac88096f.

In case of Expert, we don't want to add fixtures to `elixirc_paths`, so we ignore them by settings `:test_ignore_filters`.