### PR TITLE
fix(engine): stuck on format request

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -89,6 +89,8 @@ defmodule Engine do
       :error ->
         {:ok, deps_paths} =
           Engine.Mix.in_project(fn _ ->
+            Mix.Task.run("local.hex", ~w(--force --if-missing))
+            Mix.Task.run("local.rebar", ~w(--force --if-missing))
             Mix.Task.run("loadpaths")
             Mix.Project.deps_paths()
           end)


### PR DESCRIPTION
I encountered my editor (Emacs) freezing after making a change to Forge's code in Expert. After debugging, I found it's hanging on a format request to a language server. Then in the logs I found that it's waiting for confirmation whether or not to install Hex.

```
12:57:24.674 [debug] Node port message: Mix requires the Hex package manager to fetch dependencies

12:57:24.675 [debug] Node port message: Shall I install Hex? (if running non-interactively, use "mix local.hex --force") [Yn] 
12:57:24.677 [debug] Node port message: 
```

I traced it to calling `mix loadpaths`. Added enforced installation of Hex and Rebar before it.  This runs only when persistent term is not found for deps paths, so it should be run only once during the server session.

After this change I no longer encounter this issue so far. But I also have seen this on a subsequent run, which suggested that it moved one step further:

```
14:50:08.245 [error] Process #PID<0.453.0> on node :"expert-project-forge-555@127.0.0.1" raised an exception
** (Mix.Error) Can't continue due to errors on dependencies
    (mix 1.18.4) lib/mix.ex:618: Mix.raise/2
    (mix 1.18.4) lib/mix/tasks/deps.loadpaths.ex:100: Mix.Tasks.Deps.Loadpaths.deps_check/3
    (mix 1.18.4) lib/mix/tasks/deps.loadpaths.ex:68: Mix.Tasks.Deps.Loadpaths.run/1
    (mix 1.18.4) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.4) lib/mix/tasks/loadpaths.ex:37: Mix.Tasks.Loadpaths.run/1
    (mix 1.18.4) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.4) lib/mix/tasks/compile.ex:136: Mix.Tasks.Compile.run/1
    (mix 1.18.4) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
```

(the latter issue was fixed by `expert engine clean --force`)