### PR TITLE
feat: add `instance_id` metadata to logs

### DIFF
--- a/apps/engine/lib/engine/bootstrap.ex
+++ b/apps/engine/lib/engine/bootstrap.ex
@@ -11,7 +11,15 @@ defmodule Engine.Bootstrap do
 
   require Logger
 
-  def init(%Project{} = project, document_store_entropy, app_configs, manager_node) do
+  def init(
+        %Project{} = project,
+        document_store_entropy,
+        app_configs,
+        manager_node,
+        logger_global_metadata
+      ) do
+    :logger.update_primary_config(%{metadata: logger_global_metadata})
+
     Forge.Document.Store.set_entropy(document_store_entropy)
 
     Application.put_all_env(app_configs)
@@ -64,6 +72,7 @@ defmodule Engine.Bootstrap do
         max_no_bytes: 1_000_000,
         max_no_files: 1
       },
+      formatter: Logger.Formatter.new(metadata: [:instance_id]),
       level: :info
     }
 

--- a/apps/expert/config/runtime.exs
+++ b/apps/expert/config/runtime.exs
@@ -17,5 +17,6 @@ config :logger, :default_handler,
   config: [
     file: String.to_charlist(log_file_name),
     max_no_bytes: :infinity,
-    max_no_files: 0
+    max_no_files: 0,
+    formatter: Logger.Formatter.new(metadata: [:instance_id])
   ]

--- a/apps/expert/lib/expert/application.ex
+++ b/apps/expert/lib/expert/application.ex
@@ -13,6 +13,10 @@ defmodule Expert.Application do
   @impl true
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def start(_type, _args) do
+    :logger.update_primary_config(%{
+      metadata: %{instance_id: Integer.to_string(System.os_time(:millisecond), 16)}
+    })
+
     argv = Burrito.Util.Args.argv()
 
     # Handle engine subcommand first (before starting the LSP server)

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -204,7 +204,16 @@ defmodule Expert.EngineNode do
     start_net_kernel(project)
 
     node_name = Project.node_name(project)
-    bootstrap_args = [project, Document.Store.entropy(), all_app_configs(), Node.self()]
+
+    bootstrap_args = [
+      project,
+      Document.Store.entropy(),
+      all_app_configs(),
+      Node.self(),
+      # Copy logger global metadata to engine instances.
+      # Everything spawned from single expert instance will use same `instance_id`
+      :logger.get_primary_config().metadata
+    ]
 
     with {:ok, node_pid} <- EngineSupervisor.start_project_node(project),
          {:ok, glob_paths} <- glob_paths(project),


### PR DESCRIPTION
This allows us to easily grab logs from a single expert run.

Also, make logs single-line where possible for future ease of parsing