### PR TITLE
fix(expert): always log PATH on start

### DIFF
--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -233,6 +233,7 @@ defmodule Expert.EngineNode do
       with {:ok, elixir, env} <- Expert.Port.project_executable(project, "elixir"),
            {:ok, erl, _env} <- Expert.Port.project_executable(project, "erl") do
         lsp = Expert.get_lsp()
+        Expert.log_info(lsp, project, "Using path: #{System.get_env("PATH")}")
         Expert.log_info(lsp, project, "Found elixir executable at #{elixir}")
         Expert.log_info(lsp, project, "Found erl executable at #{erl}")
 

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -114,7 +114,7 @@ defmodule Expert.Port do
 
     case :os.find_executable(to_charlist(name), to_charlist(path)) do
       false ->
-        {:error, name, "Couldn't find an #{name} executable. Using PATH=#{path}"}
+        {:error, name, "Couldn't find an #{name} executable"}
 
       elixir ->
         env =
@@ -148,8 +148,7 @@ defmodule Expert.Port do
 
     case :os.find_executable(to_charlist(name), to_charlist(path)) do
       false ->
-        {:error, name,
-         "Couldn't find an #{name} executable for project at #{root_path}. Using PATH=#{path}"}
+        {:error, name, "Couldn't find an #{name} executable for project at #{root_path}"}
 
       elixir ->
         env =


### PR DESCRIPTION
Before we were only logging PATH when executable could not be found. However, it might happen (and happened) that the wrong executable is found. We are then left with no information about the PATH to debug, which is why it's useful to always log it.

Discussed in #365, could help with debugging #385 (and #275 in the past).