### PR TITLE
fix(engine): don't crash when calling references on an atom

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/references.ex
+++ b/apps/engine/lib/engine/code_intelligence/references.ex
@@ -13,10 +13,14 @@ defmodule Engine.CodeIntelligence.References do
   require Logger
 
   def references(%Analysis{} = analysis, %Position{} = position, include_definitions?) do
-    with {:ok, resolved, _range} <- Entity.resolve(analysis, position) do
-      resolved
-      |> maybe_rewrite_resolution(analysis, position)
-      |> find_references(analysis, position, include_definitions?)
+    case Entity.resolve(analysis, position) do
+      {:ok, resolved, _range} ->
+        resolved
+        |> maybe_rewrite_resolution(analysis, position)
+        |> find_references(analysis, position, include_definitions?)
+
+      {:error, _} ->
+        []
     end
   end
 

--- a/apps/engine/test/engine/code_intelligence/references_test.exs
+++ b/apps/engine/test/engine/code_intelligence/references_test.exs
@@ -311,6 +311,22 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
     end
   end
 
+  describe "unsupported entities" do
+    test "returns an empty list for plain atoms", %{project: project} do
+      query = ~S[
+        defmodule MyModule do
+          def my_fun do
+            :stub_create_consent|
+          end
+        end
+      ]
+
+      {_, code} = pop_cursor(query)
+
+      assert [] == references(project, query, code)
+    end
+  end
+
   defp references(project, referenced, code, include_definitions? \\ false) do
     with {position, referenced} <- pop_cursor(referenced, as: :document),
          {:ok, document} <- project_module(project, code),


### PR DESCRIPTION
Fixes #393 for only reproduction case I was able to find (calling "references" when cursor is over an atom).