### PR TITLE
fix: resolve function delegates on hover docs

### DIFF
--- a/apps/forge/lib/forge/code.ex
+++ b/apps/forge/lib/forge/code.ex
@@ -1,0 +1,48 @@
+defmodule Forge.Code do
+  @moduledoc false
+
+  @doc """
+  Parses an MFA string into a {module, function, arity} tuple.
+
+  Returns `nil` if the string cannot be parsed or if the module doesn't exist.
+  """
+  @spec parse_mfa(String.t()) :: {module(), atom(), non_neg_integer()} | nil
+  def parse_mfa(mfa_string) when is_binary(mfa_string) do
+    case Regex.run(~r/^(.+)\.([^.\/]+)\/(\d+)$/, mfa_string) do
+      [_, module_str, fun_str, arity_str] ->
+        with {:ok, module} <- parse_module(module_str),
+             {:ok, fun} <- parse_function(fun_str),
+             {:ok, arity} <- parse_arity(arity_str) do
+          {module, fun, arity}
+        else
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_module(":" <> module_string) do
+    {:ok, String.to_existing_atom(module_string)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp parse_module(module_string) do
+    {:ok, String.to_existing_atom("Elixir." <> module_string)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp parse_function(fun_str) do
+    {:ok, String.to_atom(fun_str)}
+  end
+
+  defp parse_arity(arity_str) do
+    case Integer.parse(arity_str) do
+      {arity, ""} when arity >= 0 -> {:ok, arity}
+      _ -> :error
+    end
+  end
+end

--- a/apps/forge/test/forge/code_test.exs
+++ b/apps/forge/test/forge/code_test.exs
@@ -1,0 +1,34 @@
+defmodule Forge.CodeTest do
+  use ExUnit.Case, async: true
+
+  alias Forge.Code
+
+  describe "parse_mfa/1" do
+    test "parses Elixir module MFA strings" do
+      result = Code.parse_mfa("Enum.map/2")
+      assert {Enum, :map, 2} = result
+    end
+
+    test "parses Erlang module MFA strings" do
+      result = Code.parse_mfa(":lists.reverse/1")
+      assert {:lists, :reverse, 1} = result
+    end
+
+    test "returns nil for non-existent Elixir modules" do
+      result = Code.parse_mfa("NonExistentModule.some_function/1")
+      assert result == nil
+    end
+
+    test "returns nil for non-existent Erlang modules" do
+      result = Code.parse_mfa(":non_existent_erlang_module.some_function/1")
+      assert result == nil
+    end
+
+    test "returns nil for invalid MFA format" do
+      assert Code.parse_mfa("invalid") == nil
+      assert Code.parse_mfa("Module.without.arity") == nil
+      assert Code.parse_mfa("Module.function/") == nil
+      assert Code.parse_mfa("/function/1") == nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes #392 

We were trying to resolve module/function/arity for a user function in the expert node instead of the engine. Parsing those requires us to produce an atom(for the module and for the function), so we use `String.to_existing_atom` to not exhaust the atoms limit. The problem is that it's almost guaranteed for the module/functions to not exist in the expert node too, which causes crashes due to non existing atoms.

This issue could be reproduced by trying to get hover docs for a delegated function, like in this reproduction example provided by @katafrakt:

```elixir
defmodule ModA do
  def test do
    ModB.func1()      # hover here
  end
end

defmodule ModB do
  defdelegate func1, to: ModC
end

defmodule ModC do     # this is defines under `test/support`, which is in elixirc path only in test env
  def func1, do: nil
end
```

The solution is to resolve mfa for user code in the engine node instead, where the chance of those atoms already existing is way higher.

There was also a related bug in which after this fix we would be able to resolve the delegate, but sometimes not be able to resolve the original function docs, so if the above example was defined all in the same file and `def func1` had a `@doc` tag, the docs would not show when hovering on the `ModB.func1()` call. This fixes that too.