### PR TITLE
fix(expert): spec completions for functions with guards

### DIFF
--- a/apps/expert/test/expert/code_intelligence/completion/translations/module_attribute_test.exs
+++ b/apps/expert/test/expert/code_intelligence/completion/translations/module_attribute_test.exs
@@ -255,6 +255,47 @@ defmodule Expert.CodeIntelligence.Completion.Translations.ModuleAttributeTest do
       ]
     end
 
+    test "with a function with guards after it", %{project: project} do
+      source = ~q[
+        defmodule MyModule do
+          @spe|
+          def my_function(arg1, arg2, arg3) when is_binary(arg1) do
+            :ok
+          end
+        end
+      ]
+
+      assert {:ok, [spec_my_function, spec]} =
+               project
+               |> complete(source)
+               |> fetch_completion(kind: CompletionItemKind.property())
+
+      assert spec_my_function.label == "@spec my_function"
+
+      assert apply_completion(spec_my_function) == ~q[
+        defmodule MyModule do
+          @spec my_function(${1:term()}, ${2:term()}, ${3:term()}) :: ${0:term()}
+          def my_function(arg1, arg2, arg3) when is_binary(arg1) do
+            :ok
+          end
+        end
+      ]
+
+      assert spec.label == "@spec"
+
+      assert apply_completion(spec) == ~q[
+        defmodule MyModule do
+          @spec ${1:function}(${2:term()}) :: ${3:term()}
+        def ${1:function}(${4:args}) do
+          $0
+        end
+          def my_function(arg1, arg2, arg3) when is_binary(arg1) do
+            :ok
+          end
+        end
+      ]
+    end
+
     test "with a private function after it", %{project: project} do
       source = ~q[
         defmodule MyModule do


### PR DESCRIPTION
Completions for `@spec` module attribues would incorrectly suggest the function name as `when`.

This change adds detection for AST when a function has guards. Added unit test to cover the case.