### PR TITLE
fix(forge): don't crash on analysis of code with incorrect aliases

### DIFF
--- a/apps/engine/test/engine/code_intelligence/symbols_test.exs
+++ b/apps/engine/test/engine/code_intelligence/symbols_test.exs
@@ -641,6 +641,32 @@ defmodule Engine.CodeIntelligence.SymbolsTest do
       assert is_list(symbols)
       assert symbols == []
     end
+
+    test "returns some symbols for syntactically incorrect code with incomplete grouped aliases" do
+      {symbols, _doc} =
+        ~q[
+        defmodule MyModule do
+          alias Foo.{Bar
+        end
+        ]
+        |> document_symbols()
+
+      assert [%Document{} = module] = symbols
+      assert module.name == "MyModule"
+      assert module.type == :module
+
+      {symbols, _doc} =
+        ~q[
+        defmodule MyModule do
+          alias Foo.{Bar,
+        end
+        ]
+        |> document_symbols()
+
+      assert [%Document{} = module] = symbols
+      assert module.name == "MyModule"
+      assert module.type == :module
+    end
   end
 
   describe "workspace symbols" do


### PR DESCRIPTION
This should address #386. The first test case reproduces the error with `:__cursor__` from that issue. The other was found accidentally while trying to reproduce.

This tries to be conservative, without a catch-all, in case we find other cases, in which we would want to do something different than just skip the node.