### PR TITLE
fix(engine): avoid duplicate spec annotation when falling back to ElixirSense

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/hover.ex
+++ b/apps/engine/lib/engine/code_intelligence/hover.ex
@@ -60,7 +60,7 @@ defmodule Engine.CodeIntelligence.Hover do
     specs_text =
       case specs do
         [] -> ""
-        _ -> Enum.map_join(specs, "\n", &("@spec " <> &1))
+        _ -> Enum.join(specs, "\n")
       end
 
     header =

--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -491,11 +491,19 @@ defmodule Expert.Provider.Handlers.HoverTest do
 
       hovered = "CallHover.|my_fun(1)"
 
+      expected =
+        """
+        ```elixir
+        CallHover.my_fun(integer)
+        @spec my_fun(integer()) :: integer()
+        ```
+        """
+        |> String.trim_trailing()
+
       with_compiled_in(project, code, fn ->
         assert {:ok, %Structures.Hover{} = result} = hover(project, hovered)
         assert result.contents.kind == "markdown"
-        assert result.contents.value =~ "CallHover.my_fun(integer)"
-        assert result.contents.value =~ "@spec my_fun(integer()) :: integer()"
+        assert result.contents.value == expected
       end)
     end
 


### PR DESCRIPTION
ElixirSense already returns the type spec with `@spec` annotation in it, so concatenating it with `"@spec"` causes duplication. Fixes #409.