### PR TITLE
fix(expert): don't crash on missing root_uri

### DIFF
--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -47,11 +47,13 @@ defmodule Expert.State do
         _ -> nil
       end
 
-    root_path = Document.Path.from_uri(event.root_uri)
+    if event.root_uri do
+      root_path = Document.Path.from_uri(event.root_uri)
 
-    root_path
-    |> Forge.Workspace.new()
-    |> Forge.Workspace.set_workspace()
+      root_path
+      |> Forge.Workspace.new()
+      |> Forge.Workspace.set_workspace()
+    end
 
     event.capabilities
     |> Configuration.new(client_name)


### PR DESCRIPTION
Opening an `.exs` file outside of a mix project results in a crash as described in #397. As described in `GenLSP.Structures.InitializeParams`, the root_uri is allowed to be nil and must be handled accordingly. To avoid crashing on start up in such a case, this PR drops setting the workspace URI in this case. While this doesn't make `expert` fully functional in single-file mode, with this change allows debugging further problems in the case of `root_uri` not being set.

Fix #397.