### PR TITLE
fix: build expert on latest nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763144771,
-        "narHash": "sha256-VWF3RK2lNPX5tz14LnJM7DXkP1YwgrTuu3RqeVEymCk=",
+        "lastModified": 1771594669,
+        "narHash": "sha256-bjqfo3IobpY0se/LOL6U7J0AodvMTZjZad1x3XLc7HY=",
         "owner": "elixir-tools",
         "repo": "nix-beam-flakes",
-        "rev": "0927b7964669ff9301e90ec5753ac81885a4b1bf",
+        "rev": "da950d6652b5b4bc43ee7c440a39097b4d96e448",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1762980239,
-        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -34,13 +34,12 @@ beamPackages.mixRelease rec {
   preConfigure = ''
     # copy the logic from mixRelease to build a deps dir for engine
     mkdir -p apps/engine/deps
-    ${lib.concatMapStringsSep "\n" (dep: ''
-      dep_name=$(basename ${dep} | cut -d '-' -f2)
-      dep_path="apps/engine/deps/$dep_name"
+    ${lib.concatMapAttrsStringSep "\n" (name: dep: ''
+      dep_path="apps/engine/deps/${name}"
       if [ -d "${dep}/src" ]; then
-        ln -s ${dep}/src $dep_path
+        ln -sv ${dep}/src $dep_path
       fi
-    '') (builtins.attrValues engineDeps)}
+    '') engineDeps}
 
     cd apps/expert
   '';


### PR DESCRIPTION
Fixes #403
Picking up on the changes from [NixOS/nixpkgs#475224](https://github.com/NixOS/nixpkgs/pull/475224)

I don't know if there are more changes that @adamcstephens wants to
include. But at least it now builds on latest nixpkgs.

I've refrained from updating the `flake.lock` to avoid any unforeseen
changes though. Let me know if I should bump it. 