### PR TITLE
fix(forge): progress message ordering

### DIFF
--- a/apps/engine/lib/engine/progress.ex
+++ b/apps/engine/lib/engine/progress.ex
@@ -16,8 +16,7 @@ defmodule Engine.Progress do
   def report(@noop_token, _opts), do: :ok
 
   def report(token, [_ | _] = opts) when is_token(token) do
-    Dispatch.erpc_cast(Expert.Progress, :report, [token, opts])
-    :ok
+    Dispatch.erpc_call(Expert.Progress, :report, [token, opts])
   end
 
   @impl true

--- a/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
+++ b/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
@@ -22,8 +22,12 @@ defmodule Engine.Dispatch.Handlers.IndexingTest do
     # Mock the broadcast so progress reporting doesn't fail
     patch(Engine.Api.Proxy, :broadcast, fn _ -> :ok end)
     # Mock erpc calls for progress reporting
-    patch(Engine.Dispatch, :erpc_call, fn Expert.Progress, :begin, [_title, _opts] ->
-      {:ok, System.unique_integer([:positive])}
+    patch(Engine.Dispatch, :erpc_call, fn
+      Expert.Progress, :begin, [_title, _opts] ->
+        {:ok, System.unique_integer([:positive])}
+
+      Expert.Progress, :report, _args ->
+        :ok
     end)
 
     patch(Engine.Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)

--- a/apps/engine/test/engine/progress_test.exs
+++ b/apps/engine/test/engine/progress_test.exs
@@ -8,14 +8,19 @@ defmodule Engine.ProgressTest do
   setup do
     test_pid = self()
 
-    # Mock erpc_call for begin - returns {:ok, token}
-    patch(Dispatch, :erpc_call, fn Expert.Progress, :begin, [title, opts] ->
-      token = System.unique_integer([:positive])
-      send(test_pid, {:begin, token, title, opts})
-      {:ok, token}
+    # Mock erpc_call for begin and report
+    patch(Dispatch, :erpc_call, fn
+      Expert.Progress, :begin, [title, opts] ->
+        token = System.unique_integer([:positive])
+        send(test_pid, {:begin, token, title, opts})
+        {:ok, token}
+
+      Expert.Progress, :report, args ->
+        send(test_pid, {:report, args})
+        :ok
     end)
 
-    # Mock erpc_cast for report and complete
+    # Mock erpc_cast for complete
     patch(Dispatch, :erpc_cast, fn Expert.Progress, function, args ->
       send(test_pid, {function, args})
       true

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -29,8 +29,12 @@ defmodule Engine.Search.IndexerTest do
     # Mock the broadcast so progress reporting doesn't fail
     patch(Engine.Api.Proxy, :broadcast, fn _ -> :ok end)
     # Mock erpc calls for progress reporting
-    patch(Dispatch, :erpc_call, fn Expert.Progress, :begin, [_title, _opts] ->
-      {:ok, System.unique_integer([:positive])}
+    patch(Dispatch, :erpc_call, fn
+      Expert.Progress, :begin, [_title, _opts] ->
+        {:ok, System.unique_integer([:positive])}
+
+      Expert.Progress, :report, _args ->
+        :ok
     end)
 
     patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)


### PR DESCRIPTION
Due to the use of erpc_cast, it was possible that the completion message could arrive before a progress message. When this would happen (which would happen very often during expert's app startup process), emacs would not clear the current minibuffer's progress message. This would leave `buidling xp-<something>` in the minibuffer for the existing session, and no other messages would appear.

The fix is to use erpc_call, though this would have been easy to accomplish if progress had state, and could cancel any outstanding messages.