### PR TITLE
fix: ensure `MIX_BUILD_PATH` is set for child processes

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -194,7 +194,7 @@ defmodule Expert do
 
             start_result = Expert.Project.Supervisor.ensure_node_started(project)
 
-            send(Expert, {:engine_initialized, project, start_result})
+            send(lsp.pid, {:engine_initialized, project, start_result})
           end)
 
         case started do


### PR DESCRIPTION
Fix #435 

I think that issue is caused by a bug on elixir 1.19.1 where `MIX_BUILD_PATH` is not inherited by the deps compiler partition processes leading to issues, there is a report in the elixir repo with the same kind of stacktraces: https://github.com/elixir-lang/elixir/issues/14885 fixed in this commit: https://github.com/elixir-lang/elixir/commit/6440fb90a335af2570713e68a6702a9ddb668327 which although it's not explicitly about `MIX_BUILD_PATH`, it does fix that too by passing the build path via `Mix.ProjectStack.peek() |> :erlang.term_to_binary() |> Base.url_encode64()`

This PR ensures `MIX_BUILD_PATH` is always set. At some point when testing this I got it to fail with `1.19.1`, but cleaning the engine for that version solved that. I'm not sure what happened there since I wasn't able to reproduce the issue afterwards.