### PR TITLE
fix: make Refactorex available on all trigger kinds

### DIFF
--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -33,7 +33,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   def kinds, do: [Enumerations.CodeActionKind.refactor()]
 
   @impl CodeAction.Handler
-  def trigger_kind, do: Enumerations.CodeActionTriggerKind.invoked()
+  def trigger_kind, do: :all
 
   defp line_or_selection(_, %{start: start, end: start}), do: {:ok, start.line}
 


### PR DESCRIPTION
Fix #437 

Some editors(Zed) don't provide a trigger kind but rather a filtering list of code action kinds. This was making Refactorex code actions unavailable because it was restricted to the `invoked` trigger kind.

This makes Refactorex available regardless of trigger kind like the rest of our code actions.