### PR TITLE
fix(engine): skip unquoted aliases

### DIFF
--- a/apps/engine/lib/engine/analyzer/aliases.ex
+++ b/apps/engine/lib/engine/analyzer/aliases.ex
@@ -10,8 +10,14 @@ defmodule Engine.Analyzer.Aliases do
       [%Scope{} = scope | _] ->
         scope
         |> Scope.alias_map(position)
-        |> Map.new(fn {as, %Alias{} = alias} ->
-          {as, Alias.to_module(alias)}
+        |> Enum.reduce(%{}, fn {as, %Alias{} = alias}, acc ->
+          segments = alias.module
+
+          if is_list(segments) and Enum.all?(segments, &is_atom/1) do
+            Map.put(acc, as, Alias.to_module(alias))
+          else
+            acc
+          end
         end)
 
       [] ->

--- a/apps/engine/test/engine/analyzer/aliases_test.exs
+++ b/apps/engine/test/engine/analyzer/aliases_test.exs
@@ -260,6 +260,23 @@ defmodule Engine.Analyzer.AliasesTest do
       assert aliases[:"@protocol"] == MyProtocol
       assert aliases[:"@for"] == Atom
     end
+
+    test "skips unquote-based aliases in quoted blocks" do
+      aliases =
+        ~q<
+          defmodule TopLevel do
+            defmacro __using__(module) do
+              quote do
+                alias unquote(module).Helpers|
+              end
+            end
+          end
+        >
+        |> aliases_at_cursor()
+
+      assert is_map(aliases)
+      refute Map.has_key?(aliases, :Helpers)
+    end
   end
 
   describe "alias ranges" do


### PR DESCRIPTION
Ran into an issue with our code base where aliases inside macros cause expert to crash.

Resolves https://github.com/elixir-lang/expert/issues/349

I was able to finagle this situation into a test which crashes the same as my company's code base:
```
> just test engine -- test/engine/analyzer/aliases_test.exs

  1) test top level aliases skips unquote-based aliases in quoted blocks (Engine.Analyzer.AliasesTest)
     test/engine/analyzer/aliases_test.exs:264
     ** (FunctionClauseError) no function clause matching in :elixir_aliases.do_concat/2

     The following arguments were given to :elixir_aliases.do_concat/2:

         # 1
         [{:unquote, [_scope_id: 7432131986015121426, closing: [line: 4, column: 27], line: 4, column: 13], [{:module, [_scope_id: 7432131986015121427, line: 4, column: 21], nil}]}, :Helpers]

         # 2
         "Elixir"

     code: |> aliases_at_cursor()
     stacktrace:
       (elixir 1.18.3) src/elixir_aliases.erl:183: :elixir_aliases.do_concat/2
       (elixir 1.18.3) src/elixir_aliases.erl:171: :elixir_aliases.concat/1
       (engine 0.1.0-rc.2) lib/engine/analyzer/aliases.ex:14: anonymous fn/1 in Engine.Analyzer.Aliases.at/2
       (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
       (elixir 1.18.3) lib/map.ex:257: Map.do_map/2
       (elixir 1.18.3) lib/map.ex:251: Map.new_from_map/2
       test/engine/analyzer/aliases_test.exs:275: (test)
```

PR includes a proposal to skip aliases when they aren't made of atoms, which prevents the crash and allows expert to keep running. 

