### PR TITLE
fix: properly setup logger

### DIFF
--- a/apps/expert/config/runtime.exs
+++ b/apps/expert/config/runtime.exs
@@ -12,11 +12,12 @@ config :logger,
   handle_sasl_reports: true,
   handle_otp_reports: true
 
+config :logger, :default_formatter, metadata: [:instance_id]
+
 config :logger, :default_handler,
   level: :debug,
   config: [
     file: String.to_charlist(log_file_name),
     max_no_bytes: :infinity,
-    max_no_files: 0,
-    formatter: Logger.Formatter.new(metadata: [:instance_id])
+    max_no_files: 0
   ]

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -57,10 +57,14 @@ defmodule ExpertTest do
 
     # window/logMessage is emitted by a Logger handler; keep :info enabled
     # so integration assertions can observe those notifications.
+    # The :default console handler is suppressed to avoid polluting test output.
+    Expert.Logging.WindowLogHandler.attach()
     Logger.configure(level: :info)
+    :logger.update_handler_config(:default, :level, :none)
 
     on_exit(fn ->
       Logger.configure(level: :none)
+      :logger.update_handler_config(:default, :level, :all)
     end)
 
     # NOTE(doorgan): repeatedly starting and stopping nodes in tests produces some

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -18,10 +18,14 @@ defmodule Expert.ExpertTest do
 
     # window/logMessage comes from Logger via WindowLogHandler,
     # so tests that assert on log notifications must allow :info events through.
+    # The :default console handler is suppressed to avoid polluting test output.
+    Expert.Logging.WindowLogHandler.attach()
     Logger.configure(level: :info)
+    :logger.update_handler_config(:default, :level, :none)
 
     on_exit(fn ->
       Logger.configure(level: :none)
+      :logger.update_handler_config(:default, :level, :all)
     end)
 
     :ok

--- a/apps/expert/test/test_helper.exs
+++ b/apps/expert/test/test_helper.exs
@@ -14,7 +14,6 @@ Engine.Module.Loader.start_link(nil)
 ExUnit.configure(timeout: :infinity, assert_receive_timeout: 1000)
 
 ExUnit.start(exclude: [:skip])
-Expert.Logging.WindowLogHandler.attach()
 
 if Version.match?(System.version(), ">= 1.15.0") do
   Logger.configure(level: :none)


### PR DESCRIPTION
FIxes two problems we have with logs right now:

- We're getting our tests **spammed** by logs
- When running the expert cli, we get a `Could not attach default Logger handler` warning because we're not using the right log format