### PR TITLE
fix(expert): send correct version in server_info

### DIFF
--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -314,7 +314,7 @@ defmodule Expert.State do
       capabilities: server_capabilities,
       server_info: %{
         name: "Expert",
-        version: "0.0.1"
+        version: Expert.vsn()
       }
     }
   end


### PR DESCRIPTION
In rc.2 Expert is sending hardcoded "0.0.1" version string in `server_info` part of initialization reply. This information is used by some editors to show LSP info. Example from Zed:

<img width="661" height="178" alt="Screenshot 2026-02-25 at 11 34 34" src="https://github.com/user-attachments/assets/b5be6051-d04c-4a45-81ad-985444436e29" />

Instead, it should send `Expert.vsn()`:

<img width="499" height="226" alt="Screenshot 2026-02-25 at 12 05 08" src="https://github.com/user-attachments/assets/b9838ce7-09d9-438e-9deb-9ca3659b0409" />

