### PR TITLE
fix: add Project.unique_name to allow multiple project with same root folder name

### DIFF
--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -476,7 +476,7 @@ defmodule Expert.EngineNode do
   end
 
   def name(%Project{} = project) do
-    :"#{Project.name(project)}::node_process"
+    :"#{Project.unique_name(project)}::node_process"
   end
 
   @deps_apps Mix.Project.deps_apps()

--- a/apps/expert/lib/expert/engine_supervisor.ex
+++ b/apps/expert/lib/expert/engine_supervisor.ex
@@ -8,7 +8,7 @@ defmodule Expert.EngineSupervisor do
 
   def child_spec(%Project{} = project) do
     %{
-      id: {__MODULE__, Project.name(project)},
+      id: {__MODULE__, Project.unique_name(project)},
       start: {__MODULE__, :start_link, [project]}
     }
   end
@@ -18,7 +18,7 @@ defmodule Expert.EngineSupervisor do
   end
 
   defp name(%Project{} = project) do
-    :"#{Project.name(project)}::project_node_supervisor"
+    :"#{Project.unique_name(project)}::project_node_supervisor"
   end
 
   def start_project_node(%Project{} = project) do

--- a/apps/expert/lib/expert/project/diagnostics.ex
+++ b/apps/expert/lib/expert/project/diagnostics.ex
@@ -17,7 +17,7 @@ defmodule Expert.Project.Diagnostics do
 
   def child_spec(%Project{} = project) do
     %{
-      id: {__MODULE__, Project.name(project)},
+      id: {__MODULE__, Project.unique_name(project)},
       start: {__MODULE__, :start_link, [project]}
     }
   end
@@ -104,6 +104,6 @@ defmodule Expert.Project.Diagnostics do
   end
 
   defp name(%Project{} = project) do
-    :"#{Project.name(project)}::diagnostics"
+    :"#{Project.unique_name(project)}::diagnostics"
   end
 end

--- a/apps/expert/lib/expert/project/intelligence.ex
+++ b/apps/expert/lib/expert/project/intelligence.ex
@@ -158,7 +158,7 @@ defmodule Expert.Project.Intelligence do
 
   def child_spec(%Project{} = project) do
     %{
-      id: {__MODULE__, Project.name(project)},
+      id: {__MODULE__, Project.unique_name(project)},
       start: {__MODULE__, :start_link, [project]}
     }
   end
@@ -226,7 +226,7 @@ defmodule Expert.Project.Intelligence do
   # Private
 
   def name(%Project{} = project) do
-    :"#{Project.name(project)}::intelligence"
+    :"#{Project.unique_name(project)}::intelligence"
   end
 
   defp extract_range(to: :infinity) do

--- a/apps/expert/lib/expert/project/node.ex
+++ b/apps/expert/lib/expert/project/node.ex
@@ -27,13 +27,13 @@ defmodule Expert.Project.Node do
 
   def child_spec(%Project{} = project) do
     %{
-      id: {__MODULE__, Project.name(project)},
+      id: {__MODULE__, Project.unique_name(project)},
       start: {__MODULE__, :start_link, [project]}
     }
   end
 
   def name(%Project{} = project) do
-    :"#{Project.name(project)}::node"
+    :"#{Project.unique_name(project)}::node"
   end
 
   def node_name(%Project{} = project) do

--- a/apps/expert/lib/expert/project/search_listener.ex
+++ b/apps/expert/lib/expert/project/search_listener.ex
@@ -15,7 +15,7 @@ defmodule Expert.Project.SearchListener do
   end
 
   defp name(%Project{} = project) do
-    :"#{Project.name(project)}::search_listener"
+    :"#{Project.unique_name(project)}::search_listener"
   end
 
   @impl GenServer

--- a/apps/expert/lib/expert/project/supervisor.ex
+++ b/apps/expert/lib/expert/project/supervisor.ex
@@ -41,7 +41,7 @@ defmodule Expert.Project.Supervisor do
   end
 
   def name(%Project{} = project) do
-    :"#{Project.name(project)}::supervisor"
+    :"#{Project.unique_name(project)}::supervisor"
   end
 
   def ensure_node_started(%Project{} = project) do

--- a/apps/forge/lib/forge/project.ex
+++ b/apps/forge/lib/forge/project.ex
@@ -58,6 +58,18 @@ defmodule Forge.Project do
   end
 
   @doc """
+  Returns a unique name for the project, suitable for process registration.
+
+  Appends a hash of the full root path to disambiguate projects that share
+  the same folder name (e.g. an umbrella root and a sub-app within it).
+  """
+  @spec unique_name(t) :: String.t()
+  def unique_name(%__MODULE__{} = project) do
+    hash = :erlang.phash2(root_path(project))
+    "#{name(project)}::#{hash}"
+  end
+
+  @doc """
   The project node's name
   """
   def node_name(%__MODULE__{} = project) do


### PR DESCRIPTION
This attempts to fix #450 by introducing `Project.unique_name`, including a hash of the absolute path of the project.

When two or more mix projects with the same containing folder are present, Expert attempts to start two supervisors with the same name. Upon failing to start the second one, it assumes it was already started. This leads to LSP partially not working (the second project was not indexed, for example).

Here we add `Project.unique_name`, which is a name of the containing folder + a hash of the full absolute path.

The situation where this issue was detected was an umbrella app inside `my_app` directory with `apps/my_app` inside. Now, since these two mix projects have different absolute paths, they will have different `unique_name` and two supervisors will correctly be started.