### PR TITLE
fix: correctly handle port lines when building the engine

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -12,6 +12,7 @@ defmodule Expert.Port do
           | {:cd, String.t() | charlist()}
           | {:env, [{:os.env_var_name(), :os.env_var_value()}]}
           | {:args, list()}
+          | {:line, non_neg_integer()}
 
   @type open_opts :: [open_opt]
 

--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -53,5 +53,10 @@ ns_build_path = Path.join([install_path, "_build", "dev_ns"])
 
 Mix.Task.run("namespace", [dev_build_path, ns_build_path, "--cwd", install_path, "--no-progress"])
 
-IO.puts("mix_home:" <> Path.join(tooling_path, "mix_home"))
-IO.puts("engine_path:" <> ns_build_path)
+mix_home = Path.join(tooling_path, "mix_home")
+
+engine_meta =
+  "engine_meta:" <>
+    Base.encode64(:erlang.term_to_binary(%{mix_home: mix_home, engine_path: ns_build_path}))
+
+IO.puts(engine_meta)


### PR DESCRIPTION
Fix #459 

I think the most likely issue there is that we are not properly parsing the mix_home and engine build paths from the build script, probably because we are not explicitly using the Port's line mode.

This PR changes two things:
- It sends the paths as `engine_meta` in a single line
- It uses the `:line` option from Port to ensure we're getting proper lines back. This needed a buffer in case we receive `:noeol` chunks