### PR TITLE
fix: build engines to `:user_cache` instead of `:user_data`

### DIFF
--- a/apps/expert/lib/expert/engine.ex
+++ b/apps/expert/lib/expert/engine.ex
@@ -94,15 +94,9 @@ defmodule Expert.Engine do
     end
   end
 
-  @spec base_dir() :: String.t()
-  defp base_dir do
-    base = :filename.basedir(:user_cache, ~c"Expert")
-    to_string(base)
-  end
-
   @spec get_engine_dirs() :: [String.t()]
   defp get_engine_dirs do
-    base = base_dir()
+    base = Forge.Path.expert_cache_dir()
 
     if File.exists?(base) do
       for expert_ver_dir <- File.ls!(base),
@@ -187,7 +181,7 @@ defmodule Expert.Engine do
   @spec print_no_engines_found() :: non_neg_integer()
   defp print_no_engines_found do
     IO.puts("No engine builds found.")
-    IO.puts("\nEngine builds are stored in: #{base_dir()}")
+    IO.puts("\nEngine builds are stored in: #{Forge.Path.expert_cache_dir()}")
 
     @success_code
   end

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -162,13 +162,16 @@ defmodule Expert.EngineNode.Builder do
       |> Path.expand()
 
     build_engine_script = Path.join(expert_priv, "build_engine.exs")
+    cache_dir = Forge.Path.expert_cache_dir()
 
     args = [
       build_engine_script,
       "--source-path",
       engine_source,
       "--vsn",
-      Expert.vsn()
+      Expert.vsn(),
+      "--cache-dir",
+      cache_dir
     ]
 
     args =

--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -4,15 +4,17 @@
     strict: [
       vsn: :string,
       source_path: :string,
-      force: :boolean
+      force: :boolean,
+      cache_dir: :string
     ]
   )
 
 expert_vsn = Keyword.fetch!(args, :vsn)
 engine_source_path = Keyword.fetch!(args, :source_path)
 force? = Keyword.get(args, :force, false)
+cache_dir = Keyword.fetch!(args, :cache_dir)
 
-expert_data_path = :filename.basedir(:user_cache, "Expert", %{version: expert_vsn})
+expert_data_path = Path.join(cache_dir, expert_vsn)
 
 elixir_erts_vsn = "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
 tooling_path = Path.join([expert_data_path, "tooling", elixir_erts_vsn])

--- a/apps/expert/test/expert/engine_test.exs
+++ b/apps/expert/test/expert/engine_test.exs
@@ -8,7 +8,7 @@ defmodule Expert.EngineTest do
 
   @moduletag :tmp_dir
   setup %{tmp_dir: tmp_dir} do
-    patch(Engine, :base_dir, tmp_dir)
+    patch(Forge.Path, :expert_cache_dir, tmp_dir)
 
     :ok
   end

--- a/apps/forge/lib/forge/path.ex
+++ b/apps/forge/lib/forge/path.ex
@@ -61,4 +61,11 @@ defmodule Forge.Path do
 
     String.starts_with?(normalized_child, normalized_parent)
   end
+
+  @spec expert_cache_dir() :: String.t()
+  def expert_cache_dir do
+    :user_cache
+    |> :filename.basedir("expert")
+    |> to_string()
+  end
 end

--- a/justfile
+++ b/justfile
@@ -130,7 +130,6 @@ install: burrito-local
   chmod +x ~/.local/bin/expert
 
 clean-engine:
-  elixir -e ':filename.basedir(:user_cache, "Expert") |> File.rm_rf!() |> IO.inspect()'
+  elixir -e ':filename.basedir(:user_cache, "expert") |> File.rm_rf!() |> IO.inspect()'
 
 default: burrito-local
-


### PR DESCRIPTION
`:user_data` produces a path like `/Users/dorgan/Library/Application Support/Expert/...`, that path has a space in it which causes the issue in #465:

```
2026-02-26 12:03:19.142 [info] [super] Engine build output: /bin/sh: /Users/stephenbussey/Library/Application: No such file or directory
```

While I can't reproduce it on my macbook, the issue there is that the path is being split on the space, so it tries to execute `/Users/stephenbussey/Library/Application`.

This PR changes the build path to `:user_cache` instead, which is something like `/Users/dorgan/Library/Caches/Expert/...`, which doesn't have a space in it.

The `/bin/sh` call is coming from elixir's `Mix.Tasks.Deps.Compile` on elixir 1.15.7, so not something we can easily patch.
Reconsidering my previous choices, having this be a cache makes more sense than it being user data, as it's really a cache of engines, not really "user data" per se, so it makes sense to change it regardless of the issue.