### PR TITLE
feat: configure lsp log level

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -10,16 +10,22 @@ defmodule Expert.Configuration do
   alias GenLSP.Requests
   alias GenLSP.Structures
 
+  @default_lsp_log_level :info
+
+  @type lsp_level :: :error | :warning | :info | :log
+
   defstruct support: nil,
             client_name: nil,
             additional_watched_extensions: nil,
-            workspace_symbols: %WorkspaceSymbols{}
+            workspace_symbols: %WorkspaceSymbols{},
+            log_level: @default_lsp_log_level
 
   @type t :: %__MODULE__{
           support: support | nil,
           client_name: String.t() | nil,
           additional_watched_extensions: [String.t()] | nil,
-          workspace_symbols: WorkspaceSymbols.t()
+          workspace_symbols: WorkspaceSymbols.t(),
+          log_level: lsp_level()
         }
 
   @opaque support :: Support.t()
@@ -50,6 +56,11 @@ defmodule Expert.Configuration do
   @spec client_support(atom()) :: term()
   def client_support(key) when is_atom(key) do
     client_support(get().support, key)
+  end
+
+  @spec log_level() :: lsp_level()
+  def log_level do
+    get().log_level
   end
 
   @spec window_log_message_enabled?() :: boolean()
@@ -94,11 +105,22 @@ defmodule Expert.Configuration do
   defp apply_config_change(%__MODULE__{} = old_config, %{} = settings) do
     new_config =
       old_config
+      |> set_lsp_log_level(settings)
       |> set_workspace_symbols(settings)
       |> set()
 
     maybe_watched_extensions_request(new_config, settings)
   end
+
+  defp set_lsp_log_level(%__MODULE__{} = config, settings) do
+    %__MODULE__{config | log_level: parse_lsp_log_level(settings)}
+  end
+
+  defp parse_lsp_log_level(%{"logLevel" => "error"}), do: :error
+  defp parse_lsp_log_level(%{"logLevel" => "warning"}), do: :warning
+  defp parse_lsp_log_level(%{"logLevel" => "info"}), do: :info
+  defp parse_lsp_log_level(%{"logLevel" => "log"}), do: :log
+  defp parse_lsp_log_level(_), do: @default_lsp_log_level
 
   defp set_workspace_symbols(%__MODULE__{} = config, settings) do
     %__MODULE__{config | workspace_symbols: WorkspaceSymbols.new(settings)}

--- a/apps/expert/lib/expert/logging/window_log_handler.ex
+++ b/apps/expert/lib/expert/logging/window_log_handler.ex
@@ -63,10 +63,11 @@ defmodule Expert.Logging.WindowLogHandler do
 
   defp maybe_notify(log_event) do
     with false <- ignore_event?(log_event),
+         true <- above_log_level?(log_event.level),
          true <- Expert.Configuration.window_log_message_enabled?(),
          %GenLSP.LSP{} = lsp <- Expert.get_lsp(),
          {:ok, message} <- extract_message(log_event) do
-      params = %LogMessageParams{type: to_lsp_message_type(log_event.level), message: message}
+      params = %LogMessageParams{type: to_message_type(log_event.level), message: message}
 
       with_recursion_metadata(fn ->
         GenLSP.notify(lsp, %WindowLogMessage{params: params})
@@ -74,6 +75,10 @@ defmodule Expert.Logging.WindowLogHandler do
     else
       _ -> :ok
     end
+  end
+
+  defp above_log_level?(otp_level) do
+    to_message_type(otp_level) <= to_message_type(Expert.Configuration.log_level())
   end
 
   defp ignore_event?(%{msg: {:report, _}}), do: true
@@ -150,11 +155,9 @@ defmodule Expert.Logging.WindowLogHandler do
   defp ensure_binary(string) when is_binary(string), do: string
   defp ensure_binary(other), do: inspect(other)
 
-  defp to_lsp_message_type(level) when level in [:debug], do: Enumerations.MessageType.log()
-
-  defp to_lsp_message_type(level) when level in [:info, :notice],
-    do: Enumerations.MessageType.info()
-
-  defp to_lsp_message_type(:warning), do: Enumerations.MessageType.warning()
-  defp to_lsp_message_type(_), do: Enumerations.MessageType.error()
+  defp to_message_type(:debug), do: Enumerations.MessageType.log()
+  defp to_message_type(level) when level in [:info, :notice], do: Enumerations.MessageType.info()
+  defp to_message_type(:warning), do: Enumerations.MessageType.warning()
+  defp to_message_type(:log), do: Enumerations.MessageType.log()
+  defp to_message_type(_), do: Enumerations.MessageType.error()
 end

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -59,6 +59,51 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
+  describe "log_level/0" do
+    test "defaults to :info" do
+      assert Configuration.log_level() == :info
+    end
+
+    test "can be set via new/1" do
+      [log_level: :warning]
+      |> Configuration.new()
+      |> Configuration.set()
+
+      assert Configuration.log_level() == :warning
+    end
+  end
+
+  describe "on_change/1 with logLevel" do
+    test "parses the 4 valid LSP log level strings" do
+      for {string, atom} <- [
+            {"error", :error},
+            {"warning", :warning},
+            {"info", :info},
+            {"log", :log}
+          ] do
+        change = build_change(%{"logLevel" => string})
+
+        {:ok, updated} = Configuration.on_change(change)
+
+        assert updated.log_level == atom
+      end
+    end
+
+    test "defaults to :info when setting is missing" do
+      change = build_change(%{})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.log_level == :info
+    end
+
+    test "defaults to :info for invalid string values" do
+      change = build_change(%{"logLevel" => "verbose"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.log_level == :info
+    end
+  end
+
   describe "on_change/1 with workspace_symbols.min_query_length" do
     test "parses nested setting correctly" do
       settings = %{"workspaceSymbols" => %{"minQueryLength" => 0}}

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -8,7 +8,8 @@ Expert supports the following configuration options.
 {
   "workspaceSymbols": {
     "minQueryLength": 2
-  }
+  },
+  "logLevel": "info"
 }
 ```
 
@@ -17,3 +18,4 @@ Expert supports the following configuration options.
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `workspaceSymbols.minQueryLength` | integer | `2` | Minimum characters required before workspace symbol search returns results. Set to `0` to return all symbols with an empty query. |
+| `logLevel` | string | `"info"` | Minimum severity of log messages forwarded to the editor. Valid values: `"error"`, `"warning"`, `"info"`, `"log"`. |


### PR DESCRIPTION
Adds a new `logLevel` configuration option to filter logs.
I will update the VSCode extension after this is merged