### PR TITLE
fix: rotate expert.log files

### DIFF
--- a/apps/expert/config/runtime.exs
+++ b/apps/expert/config/runtime.exs
@@ -16,6 +16,6 @@ config :logger, :default_handler,
   level: :debug,
   config: [
     file: String.to_charlist(log_file_name),
-    max_no_bytes: :infinity,
-    max_no_files: 0
+    max_no_bytes: 10_485_760,
+    max_no_files: 3
   ]


### PR DESCRIPTION
Rotates expert.log every 10mb

project.log files already rotate every 1mb(and they produce way fewer logs)