### PR TITLE
fix: fetch `hex` and `rebar` in all places

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -91,8 +91,7 @@ defmodule Engine do
       :error ->
         {:ok, deps_paths} =
           Engine.Mix.in_project(fn _ ->
-            Mix.Task.run("local.hex", ~w(--force --if-missing))
-            Mix.Task.run("local.rebar", ~w(--force --if-missing))
+            Project.ensure_hex_and_rebar()
             Mix.Task.run("loadpaths")
             Mix.Project.deps_paths()
           end)

--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -3,6 +3,7 @@ defmodule Engine.Build.Project do
   alias Engine.Build.Isolation
   alias Engine.Plugin
   alias Engine.Progress
+  alias Forge.Internet
   alias Forge.Project
   alias Mix.Task.Compiler.Diagnostic
 
@@ -53,6 +54,7 @@ defmodule Engine.Build.Project do
       Mix.Task.clear()
       Progress.report(token, message: "Compiling #{Project.display_name(project)}")
       result = compile_in_isolation()
+      Project.ensure_hex_and_rebar()
       Mix.Task.run(:loadpaths)
       result
     end
@@ -78,7 +80,10 @@ defmodule Engine.Build.Project do
   end
 
   defp compile_in_isolation do
-    compile_fun = fn -> Mix.Task.run(:compile, mix_compile_opts()) end
+    compile_fun = fn ->
+      Project.ensure_hex_and_rebar()
+      Mix.Task.run(:compile, mix_compile_opts())
+    end
 
     case Isolation.invoke(compile_fun) do
       {:ok, result} ->
@@ -98,7 +103,7 @@ defmodule Engine.Build.Project do
   end
 
   defp prepare_for_project_build(token) do
-    if connected_to_internet?() do
+    if Internet.connected_to_internet?() do
       Progress.report(token, message: "mix local.hex")
       Mix.Task.run("local.hex", ~w(--force --if-missing))
 
@@ -121,17 +126,6 @@ defmodule Engine.Build.Project do
 
     Progress.report(token, message: "Loading plugins")
     Plugin.Discovery.run()
-  end
-
-  defp connected_to_internet? do
-    # While there's no perfect way to check if a computer is connected to the internet,
-    # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
-    # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
-    # but that's an edge case, and the build will just time out anyways.
-    case :inet_res.getbyname(~c"hex.pm", :a, 250) do
-      {:ok, _} -> true
-      _ -> false
-    end
   end
 
   defp mix_compile_opts do

--- a/apps/engine/lib/engine/mix.tasks.deps.safe_compile.ex
+++ b/apps/engine/lib/engine/mix.tasks.deps.safe_compile.ex
@@ -1,5 +1,7 @@
 unless Elixir.Features.compile_keeps_current_directory?() do
   defmodule Mix.Tasks.Deps.SafeCompile do
+    alias Forge.Project
+
     use Mix.Task
 
     @shortdoc "Compiles dependencies"
@@ -53,6 +55,7 @@ unless Elixir.Features.compile_keeps_current_directory?() do
         Mix.Tasks.Deps.Compile.run(args)
       else
         unless "--no-archives-check" in args do
+          Project.ensure_hex_and_rebar()
           Mix.Task.run("archive.check", args)
         end
 
@@ -176,6 +179,7 @@ unless Elixir.Features.compile_keeps_current_directory?() do
             "--no-warnings-as-errors"
           ]
 
+          Project.ensure_hex_and_rebar()
           res = Mix.Task.run("compile", options)
           match?({:ok, _}, res)
         catch

--- a/apps/forge/lib/forge/internet.ex
+++ b/apps/forge/lib/forge/internet.ex
@@ -1,0 +1,12 @@
+defmodule Forge.Internet do
+  def connected_to_internet? do
+    # While there's no perfect way to check if a computer is connected to the internet,
+    # it seems reasonable to gate pulling dependencies on a resolution check for hex.pm.
+    # Yes, it's entirely possible that the DNS server is local, and that the entry is in cache,
+    # but that's an edge case, and the build will just time out anyways.
+    case :inet_res.getbyname(~c"hex.pm", :a, 250) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+end

--- a/apps/forge/lib/forge/project.ex
+++ b/apps/forge/lib/forge/project.ex
@@ -6,6 +6,9 @@ defmodule Forge.Project do
   as well as business logic for how to change its attributes.
   """
   alias Forge.Document
+  alias Forge.Internet
+
+  require Logger
 
   defstruct root_uri: nil,
             mix_exs_uri: nil,
@@ -430,6 +433,17 @@ defmodule Forge.Project do
     else
       {_, rest} = List.pop_at(segments, -1)
       traverse_path(rest)
+    end
+  end
+
+  def ensure_hex_and_rebar do
+    if Internet.connected_to_internet?() do
+      Mix.Task.run("local.hex", ~w(--force --if-missing))
+      Mix.Task.run("local.rebar", ~w(--force --if-missing))
+      :ok
+    else
+      Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
+      :ok
     end
   end
 end


### PR DESCRIPTION
Close #484

I'm not sure which call it came from, but simply fetching `hex` and `rebar`, as was done before, with a few calls already in all the necessary places, should do the trick.