### PR TITLE
fix(engine): add missing rescue for `:ets.lookup_element`

### DIFF
--- a/apps/engine/lib/engine/search/store/backends/ets/state.ex
+++ b/apps/engine/lib/engine/search/store/backends/ets/state.ex
@@ -96,10 +96,9 @@ defmodule Engine.Search.Store.Backends.Ets.State do
       id_keys
     end)
     |> MapSet.new()
-    |> Enum.flat_map(&:ets.lookup_element(state.table_name, &1, 2))
-  rescue
-    ArgumentError ->
-      []
+    |> Enum.map(&lookup_element(state.table_name, &1, 2))
+    |> Enum.reject(&(&1 == :error))
+    |> List.flatten()
   end
 
   def find_by_prefix(%__MODULE__{} = state, subject, type, subtype) do
@@ -114,10 +113,9 @@ defmodule Engine.Search.Store.Backends.Ets.State do
     |> :ets.select([{{match_pattern, :_}, [], [:"$_"]}])
     |> Stream.flat_map(fn {_, id_keys} -> id_keys end)
     |> Stream.uniq()
-    |> Enum.flat_map(&:ets.lookup_element(state.table_name, &1, 2))
-  rescue
-    ArgumentError ->
-      []
+    |> Enum.map(&lookup_element(state.table_name, &1, 2))
+    |> Enum.reject(&(&1 == :error))
+    |> List.flatten()
   end
 
   @dialyzer {:nowarn_function, to_prefix: 1}
@@ -133,24 +131,20 @@ defmodule Engine.Search.Store.Backends.Ets.State do
   def siblings(%__MODULE__{} = state, %Entry{} = entry) do
     key = by_block_id(block_id: entry.block_id, path: entry.path)
 
-    siblings =
-      state.table_name
-      |> :ets.lookup_element(key, 2)
-      |> Enum.map(&:ets.lookup_element(state.table_name, &1, 2))
-      |> List.flatten()
-      |> Enum.filter(fn sibling ->
-        case {is_block(entry), is_block(sibling)} do
-          {same, same} -> true
-          _ -> false
-        end
-      end)
-      |> Enum.sort_by(& &1.id)
-      |> Enum.uniq()
+    case lookup_element(state.table_name, key, 2) do
+      :error ->
+        :error
 
-    {:ok, siblings}
-  rescue
-    ArgumentError ->
-      :error
+      elements ->
+        elements
+        |> Enum.map(&lookup_element(state.table_name, &1, 2))
+        |> Enum.reject(&(&1 == :error))
+        |> List.flatten()
+        |> Enum.filter(&same_block_type?(entry, &1))
+        |> Enum.sort_by(& &1.id)
+        |> Enum.uniq()
+        |> then(&{:ok, &1})
+    end
   end
 
   def parent(%__MODULE__{} = state, %Entry{} = entry) do
@@ -284,14 +278,20 @@ defmodule Engine.Search.Store.Backends.Ets.State do
   def structure_for_path(%__MODULE__{} = state, path) do
     key = structure(path: path)
 
-    case :ets.lookup_element(state.table_name, key, 2) do
+    case lookup_element(state.table_name, key, 2) do
       [structure] -> {:ok, structure}
       _ -> :error
     end
+  end
+
+  defp lookup_element(table_name, key, pos) do
+    :ets.lookup_element(table_name, key, pos)
   rescue
     ArgumentError ->
       :error
   end
+
+  defp same_block_type?(a, b), do: is_block(a) == is_block(b)
 
   defp match_id_key(id, type, subtype) do
     {query_by_id(id: id, type: type, subtype: subtype), :_}

--- a/apps/engine/test/engine/search/store/backends/ets/state_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets/state_test.exs
@@ -1,0 +1,49 @@
+defmodule Engine.Search.Store.Backends.Ets.StateTest do
+  alias Engine.Search.Store.Backends.Ets.Schema
+  alias Engine.Search.Store.Backends.Ets.Schemas.V3
+  alias Engine.Search.Store.Backends.Ets.State
+
+  use ExUnit.Case, async: true
+
+  import Engine.Test.Entry.Builder
+  import V3, only: [by_id: 1]
+
+  describe "resilience to stale index references" do
+    setup do
+      table = :ets.new(:stale_ref_test, [:ordered_set])
+      state = %State{table_name: table}
+
+      {:ok, state: state}
+    end
+
+    test "find_by_subject skips entries whose id key was deleted", %{state: state} do
+      entry1 = definition(id: 1, subject: Foo.Bar)
+      entry2 = definition(id: 2, subject: Foo.Bar)
+
+      rows = Schema.entries_to_rows([entry1, entry2], V3)
+      :ets.insert(state.table_name, rows)
+
+      :ets.delete(state.table_name, by_id(id: 2, type: :module, subtype: :definition))
+
+      results = State.find_by_subject(state, "Foo.Bar", :module, :definition)
+
+      assert [entry] = results
+      assert entry.id == 1
+    end
+
+    test "find_by_prefix skips entries whose id key was deleted", %{state: state} do
+      entry1 = definition(id: 1, subject: Foo.Bar)
+      entry2 = definition(id: 2, subject: Foo.Baz)
+
+      rows = Schema.entries_to_rows([entry1, entry2], V3)
+      :ets.insert(state.table_name, rows)
+
+      :ets.delete(state.table_name, by_id(id: 2, type: :module, subtype: :definition))
+
+      results = State.find_by_prefix(state, "Foo", :module, :definition)
+
+      assert [entry] = results
+      assert entry.id == 1
+    end
+  end
+end


### PR DESCRIPTION
All other cases where `:ets.lookup_element` is used have rescue on `ArgumentError` to provide fallback. We need it here as well.

This addressed #493, although probably the full recovery step here involves dropping the search index and letting Expert to create it anew. I wonder if we should add it to release notes somehow. The other option is to add new schema version (although schema was not changed, just the mechanism to build IDs).