### PR TITLE
ci: use dializer `--force-check` to fix stale plt for local dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           PROJECT: ${{ matrix.project }}
         run: |
           just mix "${PROJECT}" compile.protocols --warnings-as-errors
-          just mix "${PROJECT}" dialyzer
+          just mix "${PROJECT}" dialyzer --force-check
 
   release-test:
     runs-on: ${{matrix.os.name}}


### PR DESCRIPTION
We have CI failures in projects that update the Forge app because dialyzer is using stale PLTs for local dependencies