### PR TITLE
fix: prevent recursive alias generation for nested modules

### DIFF
--- a/apps/engine/lib/engine/analyzer.ex
+++ b/apps/engine/lib/engine/analyzer.ex
@@ -49,7 +49,7 @@ defmodule Engine.Analyzer do
 
     if is_nil(maybe_imported_mfa) do
       aliases = aliases_at(analysis, position)
-      current_module = aliases[:__MODULE__]
+      current_module = aliases[[:__MODULE__]]
       {current_module, function_name, arity}
     else
       maybe_imported_mfa
@@ -156,7 +156,7 @@ defmodule Engine.Analyzer do
   end
 
   defp resolve_alias([{:@, _, [{:protocol, _, _}]} | rest], alias_mapping) do
-    with {:ok, protocol} <- Map.fetch(alias_mapping, :"@protocol") do
+    with {:ok, protocol} <- Map.fetch(alias_mapping, [:"@protocol"]) do
       Ast.reify_alias(protocol, rest)
     end
   end
@@ -169,7 +169,7 @@ defmodule Engine.Analyzer do
   end
 
   defp resolve_alias([{:@, _, [{:for, _, _} | _]} | rest], alias_mapping) do
-    with {:ok, protocol_for} <- Map.fetch(alias_mapping, :"@for") do
+    with {:ok, protocol_for} <- Map.fetch(alias_mapping, [:"@for"]) do
       Ast.reify_alias(protocol_for, rest)
     end
   end
@@ -182,7 +182,7 @@ defmodule Engine.Analyzer do
   end
 
   defp resolve_alias([first | _] = segments, aliases_mapping) when is_tuple(first) do
-    with {:ok, current_module} <- Map.fetch(aliases_mapping, :__MODULE__) do
+    with {:ok, current_module} <- Map.fetch(aliases_mapping, [:__MODULE__]) do
       Ast.reify_alias(current_module, segments)
     end
   end
@@ -196,7 +196,7 @@ defmodule Engine.Analyzer do
   defp resolve_alias(_, _), do: :error
 
   defp fetch_leading_alias([first | rest], aliases_mapping) do
-    with {:ok, resolved} <- Map.fetch(aliases_mapping, first) do
+    with {:ok, resolved} <- Map.fetch(aliases_mapping, [first]) do
       {:ok, [resolved | rest]}
     end
   end
@@ -206,7 +206,7 @@ defmodule Engine.Analyzer do
     # in one go, like Foo.{First, Second.Third, Fourth}
     # Our alias mapping will have Third mapped to Foo.Second.Third, so we need to look
     # for Third, whereas the leading alias will look for Second in the mappings.
-    with {:ok, resolved} <- Map.fetch(aliases_mapping, List.last(segments)) do
+    with {:ok, resolved} <- Map.fetch(aliases_mapping, [List.last(segments)]) do
       {:ok, List.wrap(resolved)}
     end
   end

--- a/apps/engine/lib/engine/analyzer/aliases.ex
+++ b/apps/engine/lib/engine/analyzer/aliases.ex
@@ -42,7 +42,7 @@ defmodule Engine.Analyzer.Aliases do
 
       [prefix | suffix] ->
         case aliases do
-          %{^prefix => _} ->
+          %{[^prefix] => _} ->
             current_module = resolve_alias(aliases, prefix, suffix)
 
             Module.concat([current_module | suffix])
@@ -60,7 +60,7 @@ defmodule Engine.Analyzer.Aliases do
   defp resolve_alias(aliases, prefix, suffix) do
     current_module =
       aliases
-      |> Map.get(prefix)
+      |> Map.get(List.wrap(prefix))
       |> Alias.to_module()
 
     Module.concat([current_module | suffix])

--- a/apps/engine/lib/engine/code_action/handlers/add_alias.ex
+++ b/apps/engine/lib/engine/code_action/handlers/add_alias.ex
@@ -53,7 +53,7 @@ defmodule Engine.CodeAction.Handlers.AddAlias do
 
       {:elixir, segments} ->
         {insert_position, trailer} = CodeMod.Aliases.insert_position(analysis, range.start)
-        alias_to_add = %Alias{module: segments, as: List.last(segments), explicit?: true}
+        alias_to_add = %Alias{module: segments, as: [List.last(segments)], explicit?: true}
         replace_current_alias = get_current_replacement(analysis, range, segments)
 
         alias_edits =

--- a/apps/engine/lib/engine/code_action/handlers/remove_unused_alias.ex
+++ b/apps/engine/lib/engine/code_action/handlers/remove_unused_alias.ex
@@ -184,7 +184,7 @@ defmodule Engine.CodeAction.Handlers.RemoveUnusedAlias do
   defp fetch_full_alias(%Analysis{} = analysis, %Position{} = position, last_segment) do
     aliases = Analyzer.aliases_at(analysis, position)
 
-    with {:ok, aliased_module} <- Map.fetch(aliases, last_segment),
+    with {:ok, aliased_module} <- Map.fetch(aliases, [last_segment]),
          {:elixir, full_alias} <- Ast.Module.safe_split(aliased_module, as: :atoms) do
       {:ok, full_alias}
     end

--- a/apps/engine/lib/engine/code_mod/aliases.ex
+++ b/apps/engine/lib/engine/code_mod/aliases.ex
@@ -75,10 +75,10 @@ defmodule Engine.CodeMod.Aliases do
   end
 
   defp render_alias(%Alias{} = a) do
-    if List.last(a.module) == a.as do
+    if [List.last(a.module)] == a.as do
       "alias #{join(a.module)}"
     else
-      "alias #{join(a.module)}, as: #{join(List.wrap(a.as))}"
+      "alias #{join(a.module)}, as: #{join(a.as)}"
     end
   end
 end

--- a/apps/engine/test/engine/analyzer/aliases_test.exs
+++ b/apps/engine/test/engine/analyzer/aliases_test.exs
@@ -15,6 +15,7 @@ defmodule Engine.Analyzer.AliasesTest do
     document
     |> Ast.analyze()
     |> Analyzer.aliases_at(position)
+    |> Map.new(fn {k, v} -> {k |> concat_without_prefix(), v} end)
   end
 
   defp scope_aliases(text) do
@@ -25,9 +26,15 @@ defmodule Engine.Analyzer.AliasesTest do
       |> Ast.analyze()
       |> Ast.Analysis.scopes_at(position)
       |> Enum.flat_map(& &1.aliases)
-      |> Map.new(&{&1.as, &1})
+      |> Map.new(&{&1.as |> concat_without_prefix(), &1})
 
     {aliases, document}
+  end
+
+  # Acts like Module.concat/1 for elixir modules but skips the "Elixir." prefix.
+  defp concat_without_prefix(segments) do
+    # Used only in tests, atom table growth is not a concern here.
+    segments |> Enum.join(".") |> String.to_atom()
   end
 
   describe "top level aliases" do
@@ -447,6 +454,22 @@ defmodule Engine.Analyzer.AliasesTest do
         |> aliases_at_cursor()
 
       assert aliases[:__MODULE__] == Parent.Child
+    end
+
+    test "doted parent and child" do
+      aliases =
+        ~q[
+          defmodule Parent.Foo do
+            defmodule Bar.Baz do
+              |
+            end
+          end
+        ]
+        |> aliases_at_cursor()
+
+      assert aliases[:"Bar.Baz"] == Parent.Foo.Bar.Baz
+      assert aliases[:"Parent.Foo"] == Parent.Foo
+      assert aliases[:__MODULE__] == Parent.Foo.Bar.Baz
     end
   end
 

--- a/apps/forge/lib/forge/ast/analysis.ex
+++ b/apps/forge/lib/forge/ast/analysis.ex
@@ -442,21 +442,33 @@ defmodule Forge.Ast.Analysis do
     state
   end
 
-  defp maybe_push_implicit_alias(%State{} = state, [first_segment | _], document, quoted)
+  defp maybe_push_implicit_alias(
+         %State{} = state,
+         [first_segment | _] = module_segments,
+         document,
+         quoted
+       )
        when is_atom(first_segment) do
     segments =
       case State.current_module(state) do
         # the head element of top-level modules can be aliased, so we
         # must expand them
         [] ->
-          expand_alias([first_segment], state)
+          expand_alias(module_segments, state)
 
-        # if we have a current module, we prefix the first segment with it
+        # if we have a current module, we prefix the segments with it
         current_module ->
-          current_module ++ [first_segment]
+          current_module ++ module_segments
       end
 
-    implicit_alias = Alias.implicit(document, quoted, segments, first_segment)
+    implicit_alias =
+      Alias.implicit(
+        document,
+        quoted,
+        segments,
+        module_segments
+      )
+
     State.push_alias(state, implicit_alias)
   end
 
@@ -484,7 +496,7 @@ defmodule Forge.Ast.Analysis do
     alias_map = state |> State.current_scope() |> Scope.alias_map()
 
     case alias_map do
-      %{^first => existing_alias} ->
+      %{[^first] => existing_alias} ->
         existing_alias.module ++ rest
 
       _ ->

--- a/apps/forge/lib/forge/ast/analysis/alias.ex
+++ b/apps/forge/lib/forge/ast/analysis/alias.ex
@@ -8,18 +8,19 @@ defmodule Forge.Ast.Analysis.Alias do
 
   @type t :: %__MODULE__{
           module: [atom],
-          as: module(),
+          as: [module()],
           range: Range.t() | nil
         }
 
   def explicit(%Document{} = document, ast, module, as) when is_list(module) do
+    as = List.wrap(as)
     range = range_for_ast(document, ast, module, as)
     %__MODULE__{module: module, as: as, range: range}
   end
 
   def implicit(%Document{} = document, ast, module, as) when is_list(module) do
     range = implicit_range(document, ast)
-    %__MODULE__{module: module, as: as, range: range, explicit?: false}
+    %__MODULE__{module: module, as: List.wrap(as), range: range, explicit?: false}
   end
 
   def to_module(%__MODULE__{} = alias) do
@@ -27,7 +28,7 @@ defmodule Forge.Ast.Analysis.Alias do
   end
 
   @implicit_aliases [:__MODULE__, :"@for", :"@protocol"]
-  defp range_for_ast(document, ast, _alias, as) when as in @implicit_aliases do
+  defp range_for_ast(document, ast, _alias, [as]) when as in @implicit_aliases do
     implicit_range(document, ast)
   end
 

--- a/apps/forge/lib/forge/ast/analysis/scope.ex
+++ b/apps/forge/lib/forge/ast/analysis/scope.ex
@@ -48,7 +48,7 @@ defmodule Forge.Ast.Analysis.Scope do
     %__MODULE__{id: :global, range: range}
   end
 
-  @spec alias_map(t(), scope_position()) :: %{module() => t()}
+  @spec alias_map(t(), scope_position()) :: %{[module()] => t()}
   def alias_map(%__MODULE__{} = scope, position \\ :end) do
     scope.aliases
     # sorting by line ensures that aliases on later lines
@@ -70,7 +70,7 @@ defmodule Forge.Ast.Analysis.Scope do
   end
 
   def fetch_alias_with_prefix(%__MODULE__{} = scope, prefix) do
-    case Enum.find(scope.aliases, fn %Alias{} = alias -> alias.as == prefix end) do
+    case Enum.find(scope.aliases, fn %Alias{} = alias -> alias.as == List.wrap(prefix) end) do
       %Alias{} = existing -> {:ok, existing}
       _ -> :error
     end


### PR DESCRIPTION
Close #497

We used only first segment of nested modules to create alias, which was failing if nested module name started with segment that was already an alias