### PR TITLE
chore(engine): bump schema to ensure valid index

### DIFF
--- a/apps/engine/lib/engine/search/store/backends/ets/schemas/v4.ex
+++ b/apps/engine/lib/engine/search/store/backends/ets/schemas/v4.ex
@@ -1,0 +1,34 @@
+defmodule Engine.Search.Store.Backends.Ets.Schemas.V4 do
+  @moduledoc """
+  V4 of the schema is the same as v3, but some releases had duplicate
+  IDs. This schema just causes a reindex so we remove them entirely
+  """
+  alias Engine.Search.Store.Backends.Ets.Schema
+  alias Engine.Search.Store.Backends.Ets.Schemas.V3
+
+  alias Forge.Search.Indexer.Entry
+
+  require Entry
+  use Schema, version: 4
+
+  defkey :by_id, [:id, :type, :subtype]
+
+  defkey :by_subject, [
+    :subject,
+    :type,
+    :subtype,
+    :path
+  ]
+
+  defkey :by_path, [:path]
+  defkey :by_block_id, [:block_id, :path]
+  defkey :structure, [:path]
+
+  defdelegate to_rows(entry), to: V3
+  defdelegate table_options(), to: V3
+  defdelegate to_subject(subject), to: V3
+
+  def migrate(_) do
+    {:ok, []}
+  end
+end

--- a/apps/engine/lib/engine/search/store/backends/ets/state.ex
+++ b/apps/engine/lib/engine/search/store/backends/ets/state.ex
@@ -15,13 +15,14 @@ defmodule Engine.Search.Store.Backends.Ets.State do
     Schemas.LegacyV0,
     Schemas.V1,
     Schemas.V2,
-    Schemas.V3
+    Schemas.V3,
+    Schemas.V4
   ]
 
   import Wal, only: :macros
   import Entry, only: :macros
 
-  import Schemas.V3,
+  import Schemas.V4,
     only: [
       by_block_id: 1,
       query_by_id: 1,

--- a/apps/engine/test/engine/search/store/backends/ets/state_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets/state_test.exs
@@ -1,12 +1,12 @@
 defmodule Engine.Search.Store.Backends.Ets.StateTest do
   alias Engine.Search.Store.Backends.Ets.Schema
-  alias Engine.Search.Store.Backends.Ets.Schemas.V3
+  alias Engine.Search.Store.Backends.Ets.Schemas.V4
   alias Engine.Search.Store.Backends.Ets.State
 
   use ExUnit.Case, async: true
 
   import Engine.Test.Entry.Builder
-  import V3, only: [by_id: 1]
+  import V4, only: [by_id: 1]
 
   describe "resilience to stale index references" do
     setup do
@@ -20,7 +20,7 @@ defmodule Engine.Search.Store.Backends.Ets.StateTest do
       entry1 = definition(id: 1, subject: Foo.Bar)
       entry2 = definition(id: 2, subject: Foo.Bar)
 
-      rows = Schema.entries_to_rows([entry1, entry2], V3)
+      rows = Schema.entries_to_rows([entry1, entry2], V4)
       :ets.insert(state.table_name, rows)
 
       :ets.delete(state.table_name, by_id(id: 2, type: :module, subtype: :definition))
@@ -35,7 +35,7 @@ defmodule Engine.Search.Store.Backends.Ets.StateTest do
       entry1 = definition(id: 1, subject: Foo.Bar)
       entry2 = definition(id: 2, subject: Foo.Baz)
 
-      rows = Schema.entries_to_rows([entry1, entry2], V3)
+      rows = Schema.entries_to_rows([entry1, entry2], V4)
       :ets.insert(state.table_name, rows)
 
       :ets.delete(state.table_name, by_id(id: 2, type: :module, subtype: :definition))


### PR DESCRIPTION
If someone had been using one of the pre-release versions of expert, it's likely they have an index that contains duplicate IDs.

Buming the schema and making the migration return no entries causes expert to re-index their project, ensuring their index is valid.