### PR TITLE
chore(expert): bump versions in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 zig 0.15.2
-elixir 1.15.8-otp-25
-erlang 25.3.2.21
+elixir 1.17.3-otp-27
+erlang 27.3.4.1


### PR DESCRIPTION
The version we were running under was too old to work with newer versions of elixir / erlang. When running expert under 1.19, the server would refuse to start.