### PR TITLE
fix: startup and tests on Windows

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -323,8 +323,8 @@ defmodule Expert.Port do
         cmd_exe = "cmd" |> System.find_executable() |> to_charlist()
 
         opts =
-          Keyword.update(opts, :args, ["/c", executable_str], fn args ->
-            ["/c", executable_str | args]
+          Keyword.update(opts, :args, ["/c", "call", executable_str], fn args ->
+            ["/c", "call", executable_str | args]
           end)
 
         {cmd_exe, [:hide | opts]}


### PR DESCRIPTION
With the default Elixir installation on Windows running tests or trying to start Expert ended up in an error message like:

```
  ** (EXIT) shutdown: {:node_exit, %{status: 1, last_message: "| was unexpected at this time.\r\n"}}
```

This is likely due to installation path being in "Program Files" directory. Because of a space in the path, it gets quoted when Elixir executable is fetched. And as a result, the build command has more than two quotation marks and falls under this cmd.exe behaviour:

```
If /C or /K is specified, then the remainder of the command line after the switch is processed as a command line, where the following logic is used to process quote (") characters:

1.  If all of the following conditions are met, then quote characters on the command line are preserved:

    - no /S switch
    - exactly two quote characters
    - no special characters between the two quote characters, where special is one of: &<>()@^|
    - there are one or more whitespace characters between the two quote characters
    - the string between the two quote characters is the name of an executable file.

2.  Otherwise, old behavior is to see if the first character is a quote character and if so, strip the leading character and remove the last quote character on the command line, preserving any text after the last quote character.
```

The solution here is to prepend the command with `call`, which is Windows' analogue of `exec`. It does pretty much nothing, but now the first character is not a quote, so it does not fall under quote-removal process of CMD.

Fixes #515 