### PR TITLE
perf(engine): load module store after build

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -16,6 +16,7 @@ defmodule Engine.Application do
           Engine.Dispatch,
           Engine.ModuleMappings,
           Engine.Build,
+          Engine.ModuleStore,
           Engine.Build.CaptureServer,
           Engine.Plugin.Runner.Supervisor,
           Engine.Plugin.Runner.Coordinator,

--- a/apps/engine/lib/engine/module_store.ex
+++ b/apps/engine/lib/engine/module_store.ex
@@ -1,0 +1,31 @@
+defmodule Engine.ModuleStore do
+  use GenServer
+
+  import Forge.EngineApi.Messages
+
+  alias ElixirSense.Providers.Plugins.ModuleStore
+  alias Engine.Dispatch
+  alias Engine.Progress
+
+  require Logger
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    Dispatch.register_listener(self(), project_compiled())
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def handle_info(project_compiled(), state) do
+    Progress.with_progress("Finding Completion Candidates", fn token ->
+      ModuleStore.build()
+      {:done, token}
+    end)
+
+    {:stop, :normal, state}
+  end
+end


### PR DESCRIPTION
After expert starts, a user's completion request trigger's elixir_sense's module store to load, which on my project takes 12 seconds. This makes expert feel sluggish.

This change automatically loads the module store after the project's build completes and provides progress while this is happening. After the module store is built, completions are fast.