### PR TITLE
chore: fix nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,6 +73,6 @@ jobs:
       - name: Delete previous nightly release
         run: |
           gh release delete nightly --yes || true
-          git push origin :nightly || true
+          gh api -X DELETE repos/${{ github.repository }}/git/refs/tags/nightly || true
       - name: Create nightly release
         run: gh release create nightly --prerelease ./apps/expert/burrito_out/*


### PR DESCRIPTION
The build was failing to push the "nightly" tag because of credentials not being persisted. As a result the nightly was published from the same commit for the past 2 weeks.

Error in the job:

```
Run gh release delete nightly --yes || true
  gh release delete nightly --yes || true
  git push origin :nightly || true
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    GH_TOKEN: ***
    INSTALL_DIR_FOR_OTP: /home/runner/work/_temp/.setup-beam/otp
    INSTALL_DIR_FOR_ELIXIR: /home/runner/work/_temp/.setup-beam/elixir
    ZIG_GLOBAL_CACHE_DIR: /home/runner/work/expert/expert/.zig-cache
    ZIG_LOCAL_CACHE_DIR: /home/runner/work/expert/expert/.zig-cache
fatal: could not read Username for 'https://github.com/': No such device or address
```

This is because of `persist-credentials: false` added in #486. We could re-enable `persist-credentials`, but I think it's better to just use `gh` tor tag deletion as well.