### PR TITLE
fix: hang at startup if .bashrc contains exec call

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -263,26 +263,7 @@ defmodule Expert.Port do
       {"PATH", System.get_env("PATH", @default_unix_path)}
     ]
 
-    shell_name = Path.basename(shell)
-
-    args =
-      case shell_name do
-        "fish" ->
-          cmd =
-            "cd #{directory}; printf \"#{@path_marker}:%s:#{@path_marker}\" (string join ':' $PATH)"
-
-          ["-l", "-c", cmd]
-
-        "nu" ->
-          cmd =
-            "cd #{directory}; print $\"#{@path_marker}:($env.PATH | str join \":\"):#{@path_marker}\""
-
-          ["-l", "-c", cmd]
-
-        _ ->
-          cmd = "cd #{directory} && printf \"#{@path_marker}:%s:#{@path_marker}\" \"$PATH\""
-          ["-i", "-l", "-c", cmd]
-      end
+    args = path_fetch_cmd_args(shell, directory)
 
     maybe_cmd_output =
       case cmd_with_timeout(shell, args, env: env, timeout: 1_000) do
@@ -305,10 +286,10 @@ defmodule Expert.Port do
       {:ok, {output, exit_code}} ->
         case Regex.run(~r/#{@path_marker}:(.*?):#{@path_marker}/s, output) do
           [_, clean_path] when exit_code == 0 ->
-            clean_path
+            {:ok, clean_path}
 
           _ ->
-            output |> String.trim() |> String.split("\n") |> List.last()
+            {:ok, output |> String.trim() |> String.split("\n") |> List.last()}
         end
 
       {:error, :timeout} ->
@@ -316,17 +297,36 @@ defmodule Expert.Port do
     end
   end
 
+  defp path_fetch_cmd_args(shell, directory) do
+    case Path.basename(shell) do
+      "fish" ->
+        cmd =
+          "cd #{directory}; printf \"#{@path_marker}:%s:#{@path_marker}\" (string join ':' $PATH)"
+
+        ["-l", "-c", cmd]
+
+      "nu" ->
+        cmd =
+          "cd #{directory}; print $\"#{@path_marker}:($env.PATH | str join \":\"):#{@path_marker}\""
+
+        ["-l", "-c", cmd]
+
+      _ ->
+        cmd = "cd #{directory} && printf \"#{@path_marker}:%s:#{@path_marker}\" \"$PATH\""
+        ["-i", "-l", "-c", cmd]
+    end
+  end
+
   defp cmd_with_timeout(shell, args, env: env, timeout: timeout) do
     task = Task.async(fn -> System.cmd(shell, args, env: env) end)
 
-    {output, exit_code} =
-      case Task.yield(task, timeout) || Task.shutdown(task) do
-        {:ok, result} ->
-          {:ok, result}
+    case Task.yield(task, timeout) || Task.shutdown(task) do
+      {:ok, result} ->
+        {:ok, result}
 
-        _ ->
-          {:error, :timeout}
-      end
+      _ ->
+        {:error, :timeout}
+    end
   end
 
   defp fallback_executable(name) do

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -266,7 +266,7 @@ defmodule Expert.Port do
     args = path_fetch_cmd_args(shell, directory)
 
     maybe_cmd_output =
-      case cmd_with_timeout(shell, args, env: env, timeout: 1_000) do
+      case cmd_with_timeout(shell, args, env, 1_000) do
         {:ok, result} ->
           {:ok, result}
 
@@ -276,7 +276,7 @@ defmodule Expert.Port do
             # Some users have exec calls or blocking prompts in their .bashrc,
             # so we would hang here without the timeout
             args = Enum.reject(args, &(&1 == "-i"))
-            cmd_with_timeout(shell, args, env: env, timeout: 1_000)
+            cmd_with_timeout(shell, args, env, 1_000)
           else
             {:error, :timeout}
           end
@@ -317,7 +317,7 @@ defmodule Expert.Port do
     end
   end
 
-  defp cmd_with_timeout(shell, args, env: env, timeout: timeout) do
+  defp cmd_with_timeout(shell, args, env, timeout) do
     task = Task.async(fn -> System.cmd(shell, args, env: env) end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -190,7 +190,10 @@ defmodule Expert.Port do
 
     path =
       if shell_available?(shell_env) do
-        path_env_at_directory(root_path, shell_env)
+        case path_env_at_directory(root_path, shell_env) do
+          {:ok, path} -> path
+          {:error, :timeout} -> filter_release_root_from_path()
+        end
       else
         filter_release_root_from_path()
       end
@@ -281,15 +284,49 @@ defmodule Expert.Port do
           ["-i", "-l", "-c", cmd]
       end
 
-    {output, exit_code} = System.cmd(shell, args, env: env)
+    maybe_cmd_output =
+      case cmd_with_timeout(shell, args, env: env, timeout: 1_000) do
+        {:ok, result} ->
+          {:ok, result}
 
-    case Regex.run(~r/#{@path_marker}:(.*?):#{@path_marker}/s, output) do
-      [_, clean_path] when exit_code == 0 ->
-        clean_path
+        {:error, :timeout} ->
+          if Enum.member?(args, "-i") do
+            # If the command contained the -i flag, try again without it.
+            # Some users have exec calls or blocking prompts in their .bashrc,
+            # so we would hang here without the timeout
+            args = Enum.reject(args, &(&1 == "-i"))
+            cmd_with_timeout(shell, args, env: env, timeout: 1_000)
+          else
+            {:error, :timeout}
+          end
+      end
 
-      _ ->
-        output |> String.trim() |> String.split("\n") |> List.last()
+    case maybe_cmd_output do
+      {:ok, {output, exit_code}} ->
+        case Regex.run(~r/#{@path_marker}:(.*?):#{@path_marker}/s, output) do
+          [_, clean_path] when exit_code == 0 ->
+            clean_path
+
+          _ ->
+            output |> String.trim() |> String.split("\n") |> List.last()
+        end
+
+      {:error, :timeout} ->
+        {:error, :timeout}
     end
+  end
+
+  defp cmd_with_timeout(shell, args, env: env, timeout: timeout) do
+    task = Task.async(fn -> System.cmd(shell, args, env: env) end)
+
+    {output, exit_code} =
+      case Task.yield(task, timeout) || Task.shutdown(task) do
+        {:ok, result} ->
+          {:ok, result}
+
+        _ ->
+          {:error, :timeout}
+      end
   end
 
   defp fallback_executable(name) do


### PR DESCRIPTION
See: https://github.com/elixir-lang/expert/issues/340

In my .bashrc I've got this at the end:

```
# If not running interactively, don't do anything
[[ $- != *i* ]] && return
exec fish
```
This is one of the recommended ways on how to set up fish on the arch wiki.
But, with this .bashrc, expert hangs indefinitely at startup.



The problem with the original code is the use of the `-i` flag.
I don't know the original intent behind using that flag here, so instead of simply removing it, I added a timeout + fallback without -i instead.