### PR TITLE
fix: extractor not working with ExUnit.CaseTemplate

### DIFF
--- a/apps/engine/lib/engine/search/indexer/extractors/ex_unit.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/ex_unit.ex
@@ -1,5 +1,6 @@
 defmodule Engine.Search.Indexer.Extractors.ExUnit do
   alias Engine.Analyzer
+  alias Engine.Module.Loader
   alias Engine.Search.Indexer.Metadata
   alias Engine.Search.Indexer.Source.Reducer
   alias Forge.Ast
@@ -71,10 +72,33 @@ defmodule Engine.Search.Indexer.Extractors.ExUnit do
   end
 
   defp exunit_in_scope?(%Reducer{} = reducer, %Position{} = position) do
-    ExUnit.Case in Analyzer.uses_at(reducer.analysis, position) or
+    current_module =
+      case Analyzer.current_module(reducer.analysis, position) do
+        {:ok, module} -> module
+        _ -> nil
+      end
+
+    exunit_module?(current_module) or
+      exunit_from_uses?(reducer, position) or
       ExUnit.Case in Analyzer.requires_at(reducer.analysis, position) or
       exunit_imported?(reducer, position)
   end
+
+  defp exunit_from_uses?(%Reducer{} = reducer, %Position{} = position) do
+    uses = Analyzer.uses_at(reducer.analysis, position)
+
+    ExUnit.Case in uses or
+      ExUnit.CaseTemplate in uses or
+      Enum.any?(uses, &exunit_module?/1)
+  end
+
+  defp exunit_module?(module) when is_atom(module) do
+    Loader.ensure_loaded?(module) and
+      (function_exported?(module, :__ex_unit__, 1) or
+         function_exported?(module, :__ex_unit__, 2))
+  end
+
+  defp exunit_module?(_), do: false
 
   defp exunit_imported?(%Reducer{} = reducer, %Position{} = position) do
     Enum.any?(Analyzer.imports_at(reducer.analysis, position), fn {mod, _, _} ->

--- a/apps/engine/test/engine/search/indexer/extractors/ex_unit_test.exs
+++ b/apps/engine/test/engine/search/indexer/extractors/ex_unit_test.exs
@@ -396,6 +396,62 @@ defmodule Engine.Search.Indexer.Extractors.ExUnitTest do
     end
   end
 
+  describe "when ExUnit.CaseTemplate is in scope" do
+    defmodule MyCase do
+      use ExUnit.CaseTemplate
+    end
+
+    test "indexes test/describe/setup when directly used" do
+      {:ok, entries, _doc} =
+        ~q[
+        defmodule SomeTest do
+          use ExUnit.CaseTemplate
+
+          setup do
+            :ok
+          end
+
+          describe "some group" do
+            test "my test" do
+              :ok
+            end
+          end
+        end
+        ]
+        |> index_definitions()
+
+      types = Enum.map(entries, & &1.type)
+      assert :ex_unit_setup in types
+      assert :ex_unit_describe in types
+      assert :ex_unit_test in types
+    end
+
+    test "indexes test/describe/setup through a case template" do
+      {:ok, entries, _doc} =
+        ~q[
+        defmodule SomeTest do
+          use Engine.Search.Indexer.Extractors.ExUnitTest.MyCase
+
+          setup do
+            :ok
+          end
+
+          describe "some group" do
+            test "my test" do
+              :ok
+            end
+          end
+        end
+        ]
+        |> index_definitions()
+
+      types = Enum.map(entries, & &1.type)
+      assert :ex_unit_setup in types
+      assert :ex_unit_describe in types
+      assert :ex_unit_test in types
+    end
+  end
+
   describe "when ExUnit.Case is not in scope" do
     test "does not index" do
       {:ok, entries, _doc} =


### PR DESCRIPTION
Fix #501 

The fix is basically to check if any of the used modules export `__ex_unit__/2` instead of only checking for `ExUnit.Case` being used directly.

`__ex_unit__/2` is defined by using `ExUnit.Case`, and is also used internally by ExUnit to determine if the current file is a test file like [here](https://github.com/elixir-lang/elixir/blob/d33fd8e413fe98e0e54dde7ef94fadb272b1ef67/lib/ex_unit/lib/ex_unit.ex#L463).

This is internal behavior and it comes with the usual caveats of relying on internal behavior, but I'm unsure of another way to reliably do this at the moment