### PR TITLE
fix: don't infinitely loop prompting to fetch dependencies if it fails

### DIFF
--- a/apps/engine/lib/engine/build.ex
+++ b/apps/engine/lib/engine/build.ex
@@ -78,9 +78,9 @@ defmodule Engine.Build do
 
   @impl GenServer
   def handle_call({:clean_and_fetch_deps, %Project{} = project}, _from, %State{} = state) do
-    {state, result} = State.fetch_deps(state, project)
+    state = State.fetch_deps(state, project)
 
-    {:reply, result, state}
+    {:reply, State.last_deps_fetch_result(state), state}
   end
 
   @impl GenServer

--- a/apps/engine/lib/engine/build.ex
+++ b/apps/engine/lib/engine/build.ex
@@ -78,9 +78,9 @@ defmodule Engine.Build do
 
   @impl GenServer
   def handle_call({:clean_and_fetch_deps, %Project{} = project}, _from, %State{} = state) do
-    State.fetch_deps(state, project)
+    {state, result} = State.fetch_deps(state, project)
 
-    {:reply, :ok, state}
+    {:reply, result, state}
   end
 
   @impl GenServer

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -13,7 +13,8 @@ defmodule Engine.Build.State do
   defstruct project: nil,
             build_number: 0,
             uri_to_document: %{},
-            project_compile: :none
+            project_compile: :none,
+            last_deps_fetch_result: nil
 
   def new(%Project{} = project) do
     %__MODULE__{project: project}
@@ -88,13 +89,17 @@ defmodule Engine.Build.State do
         Logger.warning("Failed to remove build path #{path}: #{inspect(reason)}")
     end
 
-    result = Engine.Build.Project.fetch_deps(project)
+    result =
+      project
+      |> Engine.Build.Project.fetch_deps()
+      |> normalize_fetch_deps_result()
 
-    {state, normalize_fetch_deps_result(result)}
+    %{state | last_deps_fetch_result: result}
   end
 
+  def last_deps_fetch_result(%__MODULE__{last_deps_fetch_result: result}), do: result
+
   defp normalize_fetch_deps_result({:ok, :ok}), do: :ok
-  defp normalize_fetch_deps_result({:ok, result}), do: {:ok, result}
   defp normalize_fetch_deps_result(result), do: result
 
   defp compile_project(%__MODULE__{} = state, initial?) do

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -88,10 +88,14 @@ defmodule Engine.Build.State do
         Logger.warning("Failed to remove build path #{path}: #{inspect(reason)}")
     end
 
-    Engine.Build.Project.fetch_deps(project)
+    result = Engine.Build.Project.fetch_deps(project)
 
-    state
+    {state, normalize_fetch_deps_result(result)}
   end
+
+  defp normalize_fetch_deps_result({:ok, :ok}), do: :ok
+  defp normalize_fetch_deps_result({:ok, result}), do: {:ok, result}
+  defp normalize_fetch_deps_result(result), do: result
 
   defp compile_project(%__MODULE__{} = state, initial?) do
     state = increment_build_number(state)

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -162,7 +162,6 @@ defmodule Engine.Build.StateTest do
       assert_called(Build.Project.compile(_, _))
     end
   end
-
   describe "bare project compilation" do
     setup [:with_bare_project_state, :with_a_valid_document]
 
@@ -183,6 +182,26 @@ defmodule Engine.Build.StateTest do
       assert Engine.Build.Project.compile(state.project, true) == :ok
 
       refute_called(Engine.Mix.in_project(_, _))
+    end
+  end
+
+  describe "fetching deps" do
+    test "returns :ok when deps fetch succeeds" do
+      {:ok, state} = with_project_state(:project_metadata)
+
+      patch(File, :rm_rf, fn _path -> {:ok, []} end)
+      patch(Build.Project, :fetch_deps, fn _project -> :ok end)
+
+      assert {^state, :ok} = State.fetch_deps(state, state.project)
+    end
+
+    test "returns error when deps fetch fails" do
+      {:ok, state} = with_project_state(:project_metadata)
+
+      patch(File, :rm_rf, fn _path -> {:ok, []} end)
+      patch(Build.Project, :fetch_deps, fn _project -> {:error, "deps failed"} end)
+
+      assert {^state, {:error, "deps failed"}} = State.fetch_deps(state, state.project)
     end
   end
 end

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -162,6 +162,7 @@ defmodule Engine.Build.StateTest do
       assert_called(Build.Project.compile(_, _))
     end
   end
+
   describe "bare project compilation" do
     setup [:with_bare_project_state, :with_a_valid_document]
 
@@ -186,22 +187,26 @@ defmodule Engine.Build.StateTest do
   end
 
   describe "fetching deps" do
-    test "returns :ok when deps fetch succeeds" do
+    test "stores :ok when deps fetch succeeds" do
       {:ok, state} = with_project_state(:project_metadata)
 
       patch(File, :rm_rf, fn _path -> {:ok, []} end)
       patch(Build.Project, :fetch_deps, fn _project -> :ok end)
 
-      assert {^state, :ok} = State.fetch_deps(state, state.project)
+      state = State.fetch_deps(state, state.project)
+
+      assert State.last_deps_fetch_result(state) == :ok
     end
 
-    test "returns error when deps fetch fails" do
+    test "stores error when deps fetch fails" do
       {:ok, state} = with_project_state(:project_metadata)
 
       patch(File, :rm_rf, fn _path -> {:ok, []} end)
       patch(Build.Project, :fetch_deps, fn _project -> {:error, "deps failed"} end)
 
-      assert {^state, {:error, "deps failed"}} = State.fetch_deps(state, state.project)
+      state = State.fetch_deps(state, state.project)
+
+      assert State.last_deps_fetch_result(state) == {:error, "deps failed"}
     end
   end
 end

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -25,7 +25,6 @@ defmodule Expert do
     GenLSP.Notifications.Exit,
     GenLSP.Requests.Shutdown
   ]
-
   @dialyzer {:nowarn_function, apply_to_state: 2}
 
   def vsn, do: :expert |> Application.spec(:vsn) |> to_string()
@@ -245,8 +244,7 @@ defmodule Expert do
   end
 
   def handle_info({:engine_initialized, project, {:ok, _pid}}, lsp) do
-    ActiveProjects.set_blocked(project, false)
-    ActiveProjects.set_ready(project, true)
+    Store.transition(project, :ready)
 
     Logger.info(
       "Engine initialized for project #{Project.name(project)}",
@@ -260,9 +258,12 @@ defmodule Expert do
     {:noreply, maybe_prompt_deps_fetch(lsp, project)}
   end
 
+  def handle_info({:deps_fetch_failed, project, message}, lsp) do
+    {:noreply, prompt_deps_fetch_retry(lsp, project, message)}
+  end
+
   def handle_info({:engine_initialized, project, {:error, {:shutdown, :deps_error}}}, lsp) do
-    ActiveProjects.set_blocked(project, false)
-    ActiveProjects.set_ready(project, false)
+    Store.transition(project, :pending)
 
     log_error(
       lsp,
@@ -274,8 +275,7 @@ defmodule Expert do
   end
 
   def handle_info({:engine_initialized, project, {:error, reason}}, lsp) do
-    ActiveProjects.set_blocked(project, false)
-    ActiveProjects.set_ready(project, false)
+    Store.transition(project, :pending)
 
     error_message = initialization_error_message(reason)
     log_error(lsp, project, error_message)
@@ -287,34 +287,14 @@ defmodule Expert do
     state = assigns(lsp).state
 
     supports_show_message = Expert.Configuration.client_support(:show_message)
-    blocked = ActiveProjects.blocked?(project)
 
     # Avoids spamming the user with the same prompt if they already declined
     deps_declined = State.deps_declined?(state, project)
 
-    if supports_show_message && not deps_declined && not blocked do
-      project_name = Project.name(project)
+    if supports_show_message && not deps_declined do
+      Store.transition(project, :blocked)
 
-      ActiveProjects.set_blocked(project, true)
-      ActiveProjects.set_ready(project, false)
-
-      response =
-        GenLSP.request(
-          lsp,
-          %Requests.WindowShowMessageRequest{
-            id: Id.next(),
-            params: %Structures.ShowMessageRequestParams{
-              type: Enumerations.MessageType.error(),
-              message:
-                "The Expert engine failed with errors on dependencies for project #{project_name}. Would you like to fetch them?",
-              actions: [
-                %Structures.MessageActionItem{title: "Yes"},
-                %Structures.MessageActionItem{title: "No"}
-              ]
-            }
-          },
-          :infinity
-        )
+      response = prompt_deps_fetch(lsp, project)
 
       handle_deps_fetch_result(response, lsp, project)
     else
@@ -337,50 +317,20 @@ defmodule Expert do
     end
   end
 
-  defp handle_deps_fetch_result(%Structures.MessageActionItem{title: "Yes"}, lsp, project) do
-    Logger.info("Running mix deps.get for #{Project.name(project)}", project: project)
-
-    Task.Supervisor.start_child(:expert_task_queue, fn ->
-      result =
-        try do
-          Expert.EngineApi.clean_and_fetch_deps(project)
-        rescue
-          error in ErlangError ->
-            {:error, error.original}
-        end
-
-      case result do
-        :ok ->
-          Logger.info("mix deps.get completed successfully", project: project)
-
-          Expert.Project.Supervisor.stop_node(project)
-
-
-          Logger.info("Restarting engine for #{Project.name(project)}", project: project)
-          start_result = Expert.Project.Supervisor.ensure_node_started(project, blocked?: false)
-          send(lsp.pid, {:engine_initialized, project, start_result})
-
-        {:error, msg} ->
-          ActiveProjects.set_blocked(project, false)
-          log_error(lsp, project, "mix deps.get failed: #{inspect(msg)}")
-
-        error ->
-          ActiveProjects.set_blocked(project, false)
-
-          log_error(
-            lsp,
-            project,
-            "Unexpected error from clean_and_fetch_deps: #{inspect(error)}"
-          )
-      end
-    end)
-
-    lsp
+  defp handle_deps_fetch_result(
+         %Structures.MessageActionItem{title: "Yes"},
+         lsp,
+         project
+       ) do
+    start_deps_fetch_task(lsp, project)
   end
 
-  defp handle_deps_fetch_result(%Structures.MessageActionItem{title: "No"}, lsp, project) do
-    ActiveProjects.set_blocked(project, false)
-    ActiveProjects.set_ready(project, true)
+  defp handle_deps_fetch_result(
+         %Structures.MessageActionItem{title: "No"},
+         lsp,
+         project
+       ) do
+    Store.transition(project, :ready)
 
     Logger.info("User declined to run mix deps.get for #{Project.name(project)}",
       project: project
@@ -391,8 +341,141 @@ defmodule Expert do
     assign(lsp, state: new_state)
   end
 
-  defp handle_deps_fetch_result(_, lsp, _project) do
+  defp handle_deps_fetch_result(_, lsp, project) do
+    Store.transition(project, :pending)
+
+    Logger.info("Dismissed dependency fetch prompt for #{Project.name(project)}",
+      project: project
+    )
+
     lsp
+  end
+
+  defp start_deps_fetch_task(lsp, project) do
+    case Task.Supervisor.start_child(:expert_task_queue, fn ->
+           run_deps_fetch_recovery(lsp, project)
+         end) do
+      {:ok, _pid} ->
+        lsp
+
+      {:error, reason} ->
+        Store.transition(project, :pending)
+
+        log_error(
+          lsp,
+          project,
+          "Failed to start dependency fetch task: #{inspect(reason)}"
+        )
+
+        lsp
+    end
+  end
+
+  defp run_deps_fetch_recovery(lsp, project) do
+    Logger.info("Running mix deps.get for #{Project.name(project)}", project: project)
+
+    result =
+      try do
+        Expert.EngineApi.clean_and_fetch_deps(project)
+      rescue
+        error in ErlangError ->
+          {:error, error.original}
+      end
+
+    case result do
+      :ok ->
+        Logger.info("mix deps.get completed successfully", project: project)
+
+        Expert.Project.Supervisor.stop_node(project)
+
+        Logger.info("Restarting engine for #{Project.name(project)}", project: project)
+        start_result = Expert.Project.Supervisor.ensure_node_started(project, blocked?: false)
+        send(lsp.pid, {:engine_initialized, project, start_result})
+
+      {:error, msg} ->
+        send(lsp.pid, {:deps_fetch_failed, project, "mix deps.get failed: #{inspect(msg)}"})
+
+      error ->
+        send(
+          lsp.pid,
+          {:deps_fetch_failed, project,
+           "Unexpected error from clean_and_fetch_deps: #{inspect(error)}"}
+        )
+    end
+  end
+
+  defp prompt_deps_fetch(lsp, project) do
+    project_name = Project.name(project)
+
+    prompt_with_actions(
+      lsp,
+      "The Expert engine failed with errors on dependencies for project #{project_name}. Would you like to fetch them?",
+      ["Yes", "No"]
+    )
+  end
+
+  defp prompt_deps_fetch_retry(lsp, project, message) do
+    Logger.error(message, project: project)
+
+    response =
+      prompt_with_actions(
+        lsp,
+        "Fetching dependencies for project #{Project.name(project)} failed. #{message}. Would you like to retry?",
+        ["Retry", "Cancel"]
+      )
+
+    handle_deps_fetch_retry_result(response, lsp, project)
+  end
+
+  defp handle_deps_fetch_retry_result(
+         %Structures.MessageActionItem{title: "Retry"},
+         lsp,
+         project
+       ) do
+    start_deps_fetch_task(lsp, project)
+  end
+
+  defp handle_deps_fetch_retry_result(
+         %Structures.MessageActionItem{title: "Cancel"},
+         lsp,
+         project
+       ) do
+    Store.transition(project, :pending)
+
+    state = assigns(lsp).state
+    new_state = State.mark_deps_declined(state, project)
+
+    Logger.info("Cancelled dependency fetch retry for #{Project.name(project)}", project: project)
+
+    assign(lsp, state: new_state)
+  end
+
+  defp handle_deps_fetch_retry_result(_, lsp, project) do
+    Store.transition(project, :pending)
+
+    state = assigns(lsp).state
+    new_state = State.mark_deps_declined(state, project)
+
+    Logger.info("Dismissed dependency fetch retry prompt for #{Project.name(project)}",
+      project: project
+    )
+
+    assign(lsp, state: new_state)
+  end
+
+  defp prompt_with_actions(lsp, message, actions) do
+    GenLSP.request(
+      lsp,
+      %Requests.WindowShowMessageRequest{
+        id: Id.next(),
+        params: %Structures.ShowMessageRequestParams{
+          type: Enumerations.MessageType.error(),
+          message: message,
+          actions: Enum.map(actions, &%Structures.MessageActionItem{title: &1})
+        }
+      },
+      :infinity
+    )
   end
 
   # When logging errors we also notify the client to display the message

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -245,6 +245,9 @@ defmodule Expert do
   end
 
   def handle_info({:engine_initialized, project, {:ok, _pid}}, lsp) do
+    ActiveProjects.set_blocked(project, false)
+    ActiveProjects.set_ready(project, true)
+
     Logger.info(
       "Engine initialized for project #{Project.name(project)}",
       project: project
@@ -258,7 +261,8 @@ defmodule Expert do
   end
 
   def handle_info({:engine_initialized, project, {:error, {:shutdown, :deps_error}}}, lsp) do
-    Store.transition(project, :pending)
+    ActiveProjects.set_blocked(project, false)
+    ActiveProjects.set_ready(project, false)
 
     log_error(
       lsp,
@@ -270,7 +274,8 @@ defmodule Expert do
   end
 
   def handle_info({:engine_initialized, project, {:error, reason}}, lsp) do
-    Store.transition(project, :pending)
+    ActiveProjects.set_blocked(project, false)
+    ActiveProjects.set_ready(project, false)
 
     error_message = initialization_error_message(reason)
     log_error(lsp, project, error_message)
@@ -282,14 +287,16 @@ defmodule Expert do
     state = assigns(lsp).state
 
     supports_show_message = Expert.Configuration.client_support(:show_message)
+    blocked = ActiveProjects.blocked?(project)
 
     # Avoids spamming the user with the same prompt if they already declined
     deps_declined = State.deps_declined?(state, project)
 
-    if supports_show_message && not deps_declined do
+    if supports_show_message && not deps_declined && not blocked do
       project_name = Project.name(project)
 
-      Store.transition(project, :blocked)
+      ActiveProjects.set_blocked(project, true)
+      ActiveProjects.set_ready(project, false)
 
       response =
         GenLSP.request(
@@ -347,16 +354,19 @@ defmodule Expert do
           Logger.info("mix deps.get completed successfully", project: project)
 
           Expert.Project.Supervisor.stop_node(project)
-          Store.transition(project, :pending)
+
 
           Logger.info("Restarting engine for #{Project.name(project)}", project: project)
-          start_result = Expert.Project.Supervisor.ensure_node_started(project)
+          start_result = Expert.Project.Supervisor.ensure_node_started(project, blocked?: false)
           send(lsp.pid, {:engine_initialized, project, start_result})
 
         {:error, msg} ->
+          ActiveProjects.set_blocked(project, false)
           log_error(lsp, project, "mix deps.get failed: #{inspect(msg)}")
 
         error ->
+          ActiveProjects.set_blocked(project, false)
+
           log_error(
             lsp,
             project,
@@ -369,7 +379,8 @@ defmodule Expert do
   end
 
   defp handle_deps_fetch_result(%Structures.MessageActionItem{title: "No"}, lsp, project) do
-    Store.transition(project, :ready)
+    ActiveProjects.set_blocked(project, false)
+    ActiveProjects.set_ready(project, true)
 
     Logger.info("User declined to run mix deps.get for #{Project.name(project)}",
       project: project

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -172,7 +172,8 @@ defmodule Expert.EngineNode do
 
     @deps_error_patterns [
       "Can't continue due to errors on dependencies",
-      "Unchecked dependencies"
+      "Unchecked dependencies",
+      "Hex dependency resolution failed"
     ]
     def detect_deps_error(message) when is_binary(message) do
       Enum.any?(@deps_error_patterns, &String.contains?(message, &1))

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -245,7 +245,8 @@ defmodule Expert.EngineNode.Builder do
 
   @deps_error_patterns [
     "Can't continue due to errors on dependencies",
-    "Unchecked dependencies"
+    "Unchecked dependencies",
+    "Hex dependency resolution failed"
   ]
   defp detect_deps_error(message) when is_binary(message) do
     Enum.any?(@deps_error_patterns, &String.contains?(message, &1))

--- a/apps/expert/lib/expert/project/supervisor.ex
+++ b/apps/expert/lib/expert/project/supervisor.ex
@@ -51,7 +51,7 @@ defmodule Expert.Project.Supervisor do
   def ensure_node_started(%Project{} = project, opts) when is_list(opts) do
     blocked? = Keyword.get(opts, :blocked?, true)
 
-    if blocked? and ActiveProjects.blocked?(project) do
+    if blocked? and Store.blocked?(project) do
       Logger.info("Project node start blocked for #{Project.name(project)}")
       {:error, :deps_error}
     else

--- a/apps/expert/lib/expert/project/supervisor.ex
+++ b/apps/expert/lib/expert/project/supervisor.ex
@@ -45,7 +45,13 @@ defmodule Expert.Project.Supervisor do
   end
 
   def ensure_node_started(%Project{} = project) do
-    if Store.blocked?(project) do
+    ensure_node_started(project, blocked?: true)
+  end
+
+  def ensure_node_started(%Project{} = project, opts) when is_list(opts) do
+    blocked? = Keyword.get(opts, :blocked?, true)
+
+    if blocked? and ActiveProjects.blocked?(project) do
       Logger.info("Project node start blocked for #{Project.name(project)}")
       {:error, :deps_error}
     else

--- a/apps/expert/test/expert/engine_node/builder_test.exs
+++ b/apps/expert/test/expert/engine_node/builder_test.exs
@@ -67,6 +67,41 @@ defmodule Expert.EngineNode.BuilderTest do
              Task.await(task, 5_000)
   end
 
+  test "retries with --force when hex dependency resolution fails", %{project: project} do
+    test_pid = self()
+    attempt_counter = :counters.new(1, [])
+
+    patch(Builder, :start_build, fn _project, from, opts ->
+      :counters.add(attempt_counter, 1, 1)
+      current_attempt = :counters.get(attempt_counter, 1)
+
+      case current_attempt do
+        1 ->
+          refute opts[:force]
+          send(test_pid, {:attempt, 1, from})
+
+        2 ->
+          assert opts[:force]
+          GenServer.reply(from, {:ok, {test_ebin_entries(), nil}})
+          send(test_pid, {:attempt, 2, from})
+      end
+
+      {:ok, :fake_port}
+    end)
+
+    {:ok, builder_pid} = Builder.start_link(project)
+    task = Task.async(fn -> GenServer.call(builder_pid, :build, :infinity) end)
+
+    assert_receive {:attempt, 1, _from}, 1_000
+
+    send(builder_pid, {nil, {:data, {:eol, "** (Mix.Error) Hex dependency resolution failed"}}})
+
+    assert_receive {:attempt, 2, _from}, 1_000
+
+    assert {:ok, {paths, nil}} = Task.await(task, 5_000)
+    assert paths == test_ebin_entries()
+  end
+
   test "parses engine_meta after unrelated output", %{project: project} do
     patch(Builder, :start_build, fn _project, _from, _opts ->
       {:ok, :fake_port}

--- a/apps/expert/test/expert/engine_node_test.exs
+++ b/apps/expert/test/expert/engine_node_test.exs
@@ -91,6 +91,7 @@ defmodule Expert.EngineNodeTest do
            )
 
     assert EngineNode.State.detect_deps_error("Unchecked dependencies for dependency_foo")
+    assert EngineNode.State.detect_deps_error("** (Mix.Error) Hex dependency resolution failed")
     refute EngineNode.State.detect_deps_error("Compiling 1 file (.ex)")
     refute EngineNode.State.detect_deps_error("")
   end

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -1140,8 +1140,8 @@ defmodule ExpertTest do
         :ok
       end)
 
-      patch(Expert.Project.Supervisor, :ensure_node_started, fn _project ->
-        send(test_pid, :project_restarted)
+      patch(Expert.Project.Supervisor, :ensure_node_started, fn _project, opts ->
+        send(test_pid, {:project_restarted, opts})
         {:ok, self()}
       end)
 
@@ -1163,7 +1163,63 @@ defmodule ExpertTest do
 
       assert_receive :deps_fetched, 5000
       assert_receive :project_stopped, 5000
-      assert_receive :project_restarted, 5000
+      assert_receive {:project_restarted, [blocked?: false]}, 5000
+    end
+
+    test "does not prompt again while deps fetch is already in progress", %{
+      client: client,
+      server: server,
+      project_root: project_root,
+      main_project: main_project
+    } do
+      test_pid = self()
+
+      patch(Expert.EngineApi, :clean_and_fetch_deps, fn _project ->
+        send(test_pid, {:deps_fetch_started, self()})
+
+        receive do
+          :continue_deps_fetch -> :ok
+        after
+          5000 -> {:error, :timeout}
+        end
+      end)
+
+      patch(Expert.Project.Supervisor, :stop_node, fn _project ->
+        send(test_pid, :project_stopped)
+        :ok
+      end)
+
+      patch(Expert.Project.Supervisor, :ensure_node_started, fn _project, opts ->
+        send(test_pid, {:project_restarted, opts})
+        {:ok, self()}
+      end)
+
+      assert :ok =
+               request(client, initialize_request(project_root, id: 1, projects: [main_project]))
+
+      assert_result(1, _)
+      assert :ok = notify(client, initialized_notification())
+
+      assert_request(client, "client/registerCapability", fn _params -> nil end)
+
+      send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
+
+      assert_request(
+        client,
+        "window/showMessageRequest",
+        fn _params -> %{"title" => "Yes"} end
+      )
+
+      assert_receive {:deps_fetch_started, fetch_pid}, 5000
+
+      send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed again"}})
+
+      refute_receive {:request, "window/showMessageRequest", _}, 1000
+
+      send(fetch_pid, :continue_deps_fetch)
+
+      assert_receive :project_stopped, 5000
+      assert_receive {:project_restarted, [blocked?: false]}, 5000
     end
 
     test "does not run deps.get when user declines", %{
@@ -1241,11 +1297,23 @@ defmodule ExpertTest do
       project_root: project_root,
       main_project: main_project
     } do
+      test_pid = self()
+
       patch(Expert.EngineApi, :clean_and_fetch_deps, fn _project ->
         {:error, "Could not resolve dependency foo"}
       end)
 
+      patch(Expert.Project.Supervisor, :stop_node, fn _project ->
+        send(test_pid, :unexpected_project_stopped)
+        :ok
+      end)
+
       patch(Expert.Project.Supervisor, :ensure_node_started, fn _project ->
+        {:ok, self()}
+      end)
+
+      patch(Expert.Project.Supervisor, :ensure_node_started, fn _project, _opts ->
+        send(test_pid, :unexpected_project_restarted)
         {:ok, self()}
       end)
 
@@ -1271,6 +1339,9 @@ defmodule ExpertTest do
       )
 
       assert message =~ "mix deps.get failed"
+
+      refute_receive :unexpected_project_stopped, 1000
+      refute_receive :unexpected_project_restarted, 1000
     end
   end
 

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -1291,7 +1291,7 @@ defmodule ExpertTest do
       refute_receive :unexpected_deps_fetch, 1000
     end
 
-    test "logs error when mix deps.get fails", %{
+    test "prompts to retry when mix deps.get fails", %{
       client: client,
       server: server,
       project_root: project_root,
@@ -1333,15 +1333,84 @@ defmodule ExpertTest do
         fn _params -> %{"title" => "Yes"} end
       )
 
-      assert_notification(
-        "window/showMessage",
-        %{"type" => 1, "message" => message}
-      )
+      assert_request(
+        client,
+        "window/showMessageRequest",
+        fn params ->
+          assert params["message"] =~ "mix deps.get failed"
+          assert params["message"] =~ "retry"
+          assert Enum.map(params["actions"], & &1["title"]) == ["Retry", "Cancel"]
 
-      assert message =~ "mix deps.get failed"
+          %{"title" => "Cancel"}
+        end
+      )
 
       refute_receive :unexpected_project_stopped, 1000
       refute_receive :unexpected_project_restarted, 1000
+    end
+
+    test "reruns mix deps.get when user retries after a fetch failure", %{
+      client: client,
+      server: server,
+      project_root: project_root,
+      main_project: main_project
+    } do
+      test_pid = self()
+      attempt_counter = :counters.new(1, [])
+
+      patch(Expert.EngineApi, :clean_and_fetch_deps, fn _project ->
+        :counters.add(attempt_counter, 1, 1)
+
+        case :counters.get(attempt_counter, 1) do
+          1 ->
+            send(test_pid, :deps_fetch_failed)
+            {:error, "Could not resolve dependency foo"}
+
+          2 ->
+            send(test_pid, :deps_fetch_succeeded)
+            :ok
+        end
+      end)
+
+      patch(Expert.Project.Supervisor, :stop_node, fn _project ->
+        send(test_pid, :project_stopped)
+        :ok
+      end)
+
+      patch(Expert.Project.Supervisor, :ensure_node_started, fn _project, opts ->
+        send(test_pid, {:project_restarted, opts})
+        {:ok, self()}
+      end)
+
+      assert :ok =
+               request(client, initialize_request(project_root, id: 1, projects: [main_project]))
+
+      assert_result(1, _)
+      assert :ok = notify(client, initialized_notification())
+
+      assert_request(client, "client/registerCapability", fn _params -> nil end)
+
+      send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
+
+      assert_request(
+        client,
+        "window/showMessageRequest",
+        fn _params -> %{"title" => "Yes"} end
+      )
+
+      assert_request(
+        client,
+        "window/showMessageRequest",
+        fn params ->
+          assert params["message"] =~ "Would you like to retry?"
+          %{"title" => "Retry"}
+        end
+      )
+
+      assert_receive :deps_fetch_failed, 5000
+      assert_receive :deps_fetch_succeeded, 5000
+      assert_receive :project_stopped, 5000
+      assert_receive {:project_restarted, [blocked?: false]}, 5000
     end
   end
 


### PR DESCRIPTION
Fix #534 

I couldn't reproduce it, but from the looks of it, it's very likely it happens because the `:clean_and_fetch_deps` handler unconditionally returns `:ok`, so the upstream code doesn't know how to properly handle a failure to fetch deps and keeps asking to fetch them again.

Also to avoid spamming further and to also provide a way for the user to properly retry deps fetching in case of error(or refuse to keep trying), a new notification and handler for a "Retry" path is added