### PR TITLE
chore(just): add mix-local recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 os := if os() == "macos" { "darwin" } else { os() }
-arch := if arch() =~ "(arm|aarch64)" { "arm64" } else { if arch() =~ "(x86|x86_64)" { "amd64" } else { "unsupported" } }
+arch := if arch() =~ "(arm|aarch64)" { "arm64" } else if arch() =~ "(x86|x86_64)" { "amd64" } else { "unsupported" }
 local_target := if os =~ "(darwin|linux|windows)" { os + "_" + arch } else { "unsupported" }
 apps := "expert engine forge expert_credo"
 expert_erl_flags := "-start_epmd false -epmd_module Elixir.Forge.EPMD"
@@ -9,53 +9,56 @@ engine_erl_flags := "-start_epmd false -epmd_module Elixir.Forge.EPMD"
 deps project="all" *args="":
   @just mix {{ project }} deps.get {{ args }}
 
-
 [doc('Run an arbitrary command inside the given project directory')]
 run project +ARGS:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    cd apps/{{ project }}
-    eval "{{ ARGS }}"
+  #!/usr/bin/env bash
+  set -euo pipefail
+  cd apps/{{ project }}
+  eval "{{ ARGS }}"
 
 [doc('Compile the given project.')]
-compile project *args="": (deps project)
+compile project *args="": mix-local (deps project)
   cd apps/{{ project }} && mix compile {{ args }}
 
 [doc('Run tests in the given project')]
 test project="all" *args="":
-  @just mix {{ project }} test {{args}}
+  @just mix {{ project }} test {{ args }}
+
+[doc('Run mix local.hex and mix local.rebar')]
+mix-local:
+  @mix do local.hex --force --if-missing + local.rebar --force --if-missing
 
 [doc('Run a mix command in one or all projects. Use `just test` to run tests.')]
 mix project="all" *args="":
-    #!/usr/bin/env bash
-    set -euxo pipefail
+  #!/usr/bin/env bash
+  set -euxo pipefail
 
-    case {{ project }} in
-      all)
-        for proj in {{ apps }}; do
-          case $proj in
-            expert)
-              (cd "apps/$proj" && elixir --erl "{{ expert_erl_flags }}" -S mix {{args}})
-            ;;
-            engine)
-              (cd "apps/$proj" && elixir --erl "{{ engine_erl_flags }}" -S mix {{args}})
-            ;;
-            *)
-              (cd "apps/$proj" && mix {{args}})
-            ;;
-          esac
-        done
-      ;;
-      expert)
-        (cd "apps/expert" && elixir --erl "{{ expert_erl_flags }}" -S mix {{args}})
-      ;;
-      engine)
-        (cd "apps/engine" && elixir --erl "{{ engine_erl_flags }}" -S mix {{args}})
-      ;;
-      *)
-        (cd "apps/{{ project }}" && mix {{args}})
-      ;;
-    esac
+  case {{ project }} in
+    all)
+      for proj in {{ apps }}; do
+        case $proj in
+          expert)
+            (cd "apps/$proj" && elixir --erl "{{ expert_erl_flags }}" -S mix {{ args }})
+          ;;
+          engine)
+            (cd "apps/$proj" && elixir --erl "{{ engine_erl_flags }}" -S mix {{ args }})
+          ;;
+          *)
+            (cd "apps/$proj" && mix {{ args }})
+          ;;
+        esac
+      done
+    ;;
+    expert)
+      (cd "apps/expert" && elixir --erl "{{ expert_erl_flags }}" -S mix {{ args }})
+    ;;
+    engine)
+      (cd "apps/engine" && elixir --erl "{{ engine_erl_flags }}" -S mix {{ args }})
+    ;;
+    *)
+      (cd "apps/{{ project }}" && mix {{ args }})
+    ;;
+  esac
 
 [doc('Lint all projects or just a single project')]
 lint *project="all":
@@ -68,7 +71,7 @@ lint *project="all":
 
 [doc('Build a burrito release for the local system')]
 [unix]
-burrito-local: (deps "engine") (deps "expert")
+burrito-local: mix-local (deps "engine") (deps "expert")
   #!/usr/bin/env bash
   cd apps/expert
 
@@ -78,35 +81,35 @@ burrito-local: (deps "engine") (deps "expert")
     echo "unsupported OS/Arch combination: {{ local_target }}"
     exit 1
   fi
-  MIX_ENV={{ env('MIX_ENV', 'prod')}} EXPERT_RELEASE_MODE=burrito BURRITO_TARGET="{{ local_target }}" mix release --overwrite
+  MIX_ENV={{ env('MIX_ENV', 'prod') }} EXPERT_RELEASE_MODE=burrito BURRITO_TARGET="{{ local_target }}" mix release --overwrite
 
 [windows]
-burrito-local: (deps "engine") (deps "expert")
-    export EXPERT_RELEASE_MODE=burrito && \
-    export BURRITO_TARGET="windows_amd64" && \
-    export MIX_ENV={{ env('MIX_ENV', 'prod')}} && \
-    cd apps/expert && \
-    mix release --overwrite
+burrito-local: mix-local (deps "engine") (deps "expert")
+  export EXPERT_RELEASE_MODE=burrito && \
+  export BURRITO_TARGET="windows_amd64" && \
+  export MIX_ENV={{ env('MIX_ENV', 'prod') }} && \
+  cd apps/expert && \
+  mix release --overwrite
 
 [doc('Build releases for all target platforms')]
-burrito: (deps "engine") (deps "expert")
-    #!/usr/bin/env bash
-    cd apps/expert
+burrito: mix-local (deps "engine") (deps "expert")
+  #!/usr/bin/env bash
+  cd apps/expert
 
-    set -euxo pipefail
+  set -euxo pipefail
 
-    EXPERT_RELEASE_MODE=burrito MIX_ENV={{ env('MIX_ENV', 'prod')}} mix release --overwrite
+  EXPERT_RELEASE_MODE=burrito MIX_ENV={{ env('MIX_ENV', 'prod') }} mix release --overwrite
 
 [doc('Build a plain release for the local system')]
 [unix]
-release: (deps "engine") (deps "expert")
-    #!/usr/bin/env bash
-    cd apps/expert
-    MIX_ENV={{ env('MIX_ENV', 'prod')}} mix release plain --overwrite
+release: mix-local (deps "engine") (deps "expert")
+  #!/usr/bin/env bash
+  cd apps/expert
+  MIX_ENV={{ env('MIX_ENV', 'prod') }} mix release plain --overwrite
 
 [windows]
-release: (deps "engine") (deps "expert")
-    cd apps/expert && export MIX_ENV={{ env('MIX_ENV', 'prod')}} && mix release plain --overwrite
+release: mix-local (deps "engine") (deps "expert")
+  cd apps/expert && export MIX_ENV={{ env('MIX_ENV', 'prod') }} && mix release plain --overwrite
 
 [doc('Compiles .github/matrix.json')]
 compile-ci-matrix:
@@ -126,6 +129,6 @@ clean-engine:
   elixir -e ':filename.basedir(:user_cache, "expert") |> File.rm_rf!() |> IO.inspect()'
 
 start *args="":
-  ./apps/expert/_build/{{ env('MIX_ENV', 'prod')}}/rel/plain/bin/start_expert {{ args }}
+  ./apps/expert/_build/{{ env('MIX_ENV', 'prod') }}/rel/plain/bin/start_expert {{ args }}
 
 default: burrito-local


### PR DESCRIPTION
This is a small nicety to ensure that these components are installed when you attempt to run any of the build recepies