### PR TITLE
fix: handle LSP supported invalid configuration values

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -112,6 +112,10 @@ defmodule Expert.Configuration do
     maybe_watched_extensions_request(new_config, settings)
   end
 
+  defp apply_config_change(%__MODULE__{} = old_config, _settings) do
+    {:ok, old_config}
+  end
+
   defp set_lsp_log_level(%__MODULE__{} = config, settings) do
     %__MODULE__{config | log_level: parse_lsp_log_level(settings)}
   end

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -102,6 +102,20 @@ defmodule Expert.ConfigurationTest do
 
       assert updated.log_level == :info
     end
+
+    test "ignores non-map settings values" do
+      change = build_change(%{"logLevel" => "warning"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.log_level == :warning
+
+      for settings <- [nil, [], "bad", 123, true] do
+        assert {:ok, updated} = Configuration.on_change(build_change(settings))
+
+        assert updated.log_level == :warning
+        assert updated.workspace_symbols.min_query_length == 2
+      end
+    end
   end
 
   describe "on_change/1 with workspace_symbols.min_query_length" do
@@ -224,6 +238,31 @@ defmodule Expert.ConfigurationTest do
 
       # The update should persist, not be overwritten by the slow handler
       assert Configuration.get().workspace_symbols.min_query_length == 0
+    end
+  end
+
+  describe "on_change/1 watched files registration" do
+    test "does not register watched files for non-map settings" do
+      assert {:ok, updated} = Configuration.on_change(build_change(nil))
+
+      assert updated.additional_watched_extensions == nil
+    end
+
+    test "nil settings do not reset previously configured values" do
+      change =
+        build_change(%{
+          "logLevel" => "warning",
+          "workspaceSymbols" => %{"minQueryLength" => 5}
+        })
+
+      {:ok, updated} = Configuration.on_change(change)
+      assert updated.log_level == :warning
+      assert updated.workspace_symbols.min_query_length == 5
+
+      {:ok, after_nil} = Configuration.on_change(build_change(nil))
+
+      assert after_nil.log_level == :warning
+      assert after_nil.workspace_symbols.min_query_length == 5
     end
   end
 

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -8,6 +8,8 @@ defmodule Expert.ExpertTest do
   alias Expert.State
   alias Forge.Project
   alias Forge.Test.Fixtures
+  alias GenLSP.Notifications.WorkspaceDidChangeConfiguration
+  alias GenLSP.Structures.DidChangeConfigurationParams
 
   setup do
     :persistent_term.erase(Expert.Configuration)
@@ -102,6 +104,22 @@ defmodule Expert.ExpertTest do
                         message: ^error_message
                       }
                     }}
+  end
+
+  test "accepts didChangeConfiguration notifications with null settings" do
+    project = Fixtures.project()
+
+    {:ok, _response, state} = State.initialize(State.new(), initialize_request(project, []))
+
+    notification = %WorkspaceDidChangeConfiguration{
+      params: %DidChangeConfigurationParams{settings: nil}
+    }
+
+    assert {:ok, ^state} = State.apply(state, notification)
+
+    config = Expert.Configuration.get()
+    assert config.log_level == :info
+    assert config.workspace_symbols.min_query_length == 2
   end
 
   defp initialize_lsp(project, opts \\ []) do


### PR DESCRIPTION
Fix #540 

Normalized invalid values to an empty map. The LSP spec apparently supports a variety of non-object values, so in this PR we just ignore anything that is not an object/map.