### PR TITLE
fix: don't connect to the epmd daemon

### DIFF
--- a/apps/forge/lib/forge/epmd.ex
+++ b/apps/forge/lib/forge/epmd.ex
@@ -100,8 +100,9 @@ defmodule Forge.EPMD do
   defp format_host({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
   defp format_host(host) when is_list(host), do: List.to_string(host)
 
+  def names(_host_name), do: {:error, :address}
+
   defdelegate start_link, to: :erl_epmd
   defdelegate listen_port_please(name, host), to: :erl_epmd
   defdelegate address_please(name, host, family), to: :erl_epmd
-  defdelegate names(host_name), to: :erl_epmd
 end

--- a/apps/forge/lib/forge/epmd.ex
+++ b/apps/forge/lib/forge/epmd.ex
@@ -61,14 +61,12 @@ defmodule Forge.EPMD do
 
   def register_node(name, port), do: register_node(name, port, :inet)
 
-  def register_node(name, port, family) do
+  def register_node(_name, port, _family) do
+    # We never connect to EPMD, so we pretend the registration is successful without doing anything.
+    # We only care about the distribution port
     :persistent_term.put(:expert_dist_port, port)
 
-    # We don't care if EPMD is not running
-    case :erl_epmd.register_node(name, port, family) do
-      {:error, _} -> {:ok, -1}
-      {:ok, _} = ok -> ok
-    end
+    {:ok, -1}
   end
 
   def port_please(name, host), do: port_please(name, host, :infinity)
@@ -95,8 +93,8 @@ defmodule Forge.EPMD do
     end
   end
 
-  def port_please(name, host, timeout) do
-    :erl_epmd.port_please(name, host, timeout)
+  def port_please(_name, _host, _timeout) do
+    :noport
   end
 
   defp format_host({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"

--- a/apps/forge/test/forge/epmd_test.exs
+++ b/apps/forge/test/forge/epmd_test.exs
@@ -1,0 +1,34 @@
+defmodule Forge.EPMDTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Forge.EPMD
+
+  setup do
+    original_port = :persistent_term.get(:expert_dist_port, :__missing__)
+
+    on_exit(fn ->
+      case original_port do
+        :__missing__ -> :persistent_term.erase(:expert_dist_port)
+        port -> :persistent_term.put(:expert_dist_port, port)
+      end
+    end)
+
+    :ok
+  end
+
+  test "register_node stores dist port without calling erl_epmd" do
+    patch(:erl_epmd, :register_node, fn _, _, _ ->
+      flunk("should not call :erl_epmd.register_node/3")
+    end)
+
+    assert {:ok, -1} = EPMD.register_node(~c"expert-manager-test", 41_234, :inet)
+    assert EPMD.dist_port() == 41_234
+  end
+
+  test "names returns address error without calling erl_epmd" do
+    patch(:erl_epmd, :names, fn _ -> flunk("should not call :erl_epmd.names/1") end)
+
+    assert EPMD.names(~c"localhost") == {:error, :address}
+  end
+end


### PR DESCRIPTION
Fix #552

#339 already did most of this, but missed two places where we would still try to use the default epmd daemon:
- `:erl_epmd.register_node` makes the node join the epmd cluster, which has proven to cause issues with our custom setup. I don't fully understand the mechanism, but the observed effect is that project nodes can't connect to the manager node nor with eachother.
- There is a remaining `:erl_epmd.port_please` call. It should not be reached and it does not make the current node join the epmd cluster, but it still tries to reach the epmd daemon and I think that should be avoided as much as possible

That said, it's been a long time since I've been able to reproduce that error, and I couldn't do it so far today. I think the issue is being connected to EPMD based on my previous experience with that kind of trace. It's that, and the fact that expert is *still* connecting to epmd when it should not:

```
✦ ❯ epmd -names
epmd: up and running on port 4369 with data:
name expert-project-sourceror-26930 at port 55567
name expert-project-rainet-55311 at port 55566
name expert-manager-rainet-55311 at port 55535
name expert-manager-sourceror-26930 at port 55533
name expert-project-use_references-28058 at port 63147
name expert-manager-use_references-28058 at port 63145
name expert-project-engine-13612 at port 53734
name expert-project-main-40757 at port 52990
name expert-project-secondary-46962 at port 52980
name expert-project-monorepo_test-54379 at port 52966
name expert-manager-monorepo_test-54379 at port 52912
name expert-project-main-10873 at port 61870
name expert-project-umbrella-35374 at port 61864
name expert-manager-umbrella-35374 at port 61775
name expert-project-rainet-6647 at port 61653
name expert-manager-rainet-6647 at port 61576
name expert-project-forge-17118 at port 61539
name expert-project-expert-11330 at port 61487
name expert-manager-expert-11330 at port 61485
```