### PR TITLE
feat(expert): make log level for log files configurable

### DIFF
--- a/apps/engine/lib/engine/bootstrap.ex
+++ b/apps/engine/lib/engine/bootstrap.ex
@@ -16,7 +16,8 @@ defmodule Engine.Bootstrap do
         document_store_entropy,
         app_configs,
         manager_node,
-        logger_global_metadata
+        logger_global_metadata,
+        log_level \\ :debug
       ) do
     :logger.update_primary_config(%{metadata: logger_global_metadata})
 
@@ -40,7 +41,7 @@ defmodule Engine.Bootstrap do
         Mix.env(:test)
         set_mix_build_path(project)
         ExUnit.start()
-        start_logger(project)
+        start_logger(project, log_level)
         maybe_change_directory(project)
         :ok
       end
@@ -73,7 +74,7 @@ defmodule Engine.Bootstrap do
     end
   end
 
-  defp start_logger(%Project{} = project) do
+  defp start_logger(%Project{} = project, log_level) do
     log_file_name =
       project
       |> Project.workspace_path("project.log")
@@ -88,7 +89,7 @@ defmodule Engine.Bootstrap do
         max_no_files: 1
       },
       formatter: Logger.Formatter.new(metadata: [:instance_id]),
-      level: :info
+      level: log_level
     }
 
     :logger.add_handler(handler_name, :logger_std_h, config)

--- a/apps/expert/lib/expert/application.ex
+++ b/apps/expert/lib/expert/application.ex
@@ -45,7 +45,13 @@ defmodule Expert.Application do
 
     {opts, _argv, _invalid} =
       OptionParser.parse(argv,
-        strict: [version: :boolean, help: :boolean, stdio: :boolean, port: :integer]
+        strict: [
+          version: :boolean,
+          help: :boolean,
+          stdio: :boolean,
+          port: :integer,
+          log_level: :string
+        ]
       )
 
     help_text = """
@@ -63,6 +69,7 @@ defmodule Expert.Application do
 
       --stdio             Use stdio as the transport mechanism
       --port <port>       Use TCP as the transport mechanism, with the given port
+      --log-level <level> Set log level for log files (debug, info, warning, error). Default: debug
       --help              Show this help message
       --version           Show Expert version
 
@@ -85,19 +92,26 @@ defmodule Expert.Application do
         :noop
     end
 
+    log_level = parse_log_level(opts[:log_level])
+    Application.put_env(:expert, :log_level, log_level)
+
     buffer_opts =
       cond do
         opts[:stdio] ->
           :ok = Expert.Logging.ProjectLogFile.attach()
           :ok = mute_default_log_handler()
           Logger.info("Expert v#{Expert.vsn()} starting on stdio")
+          apply_log_level(log_level)
           []
 
         is_integer(opts[:port]) ->
           :ok = Expert.Logging.ProjectLogFile.attach()
           :ok = mute_default_log_handler()
           IO.puts("Starting on port #{opts[:port]}")
+
           Logger.info("Expert v#{Expert.vsn()} starting on port #{opts[:port]}")
+
+          apply_log_level(log_level)
           [communication: {GenLSP.Communication.TCP, [port: opts[:port]]}]
 
         true ->
@@ -150,6 +164,25 @@ defmodule Expert.Application do
   @doc false
   def document_store_child_spec do
     {Document.Store, derive: [analysis: &Forge.Ast.analyze/1]}
+  end
+
+  defp apply_log_level(log_level) do
+    Logger.info("Log level set to #{log_level}")
+
+    handler_name = Expert.Logging.ProjectLogFile.handler_name()
+    :logger.update_handler_config(handler_name, :level, log_level)
+    :logger.set_primary_config(:level, log_level)
+  end
+
+  defp parse_log_level(nil), do: :debug
+  defp parse_log_level("debug"), do: :debug
+  defp parse_log_level("info"), do: :info
+  defp parse_log_level("warning"), do: :warning
+  defp parse_log_level("error"), do: :error
+
+  defp parse_log_level(other) do
+    Logger.error("Invalid log level '#{other}'. Must be one of: debug, info, warning, error")
+    System.halt(2)
   end
 
   defp mute_default_log_handler do

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -218,7 +218,8 @@ defmodule Expert.EngineNode do
       Node.self(),
       # Copy logger global metadata to engine instances.
       # Everything spawned from single expert instance will use same `instance_id`
-      :logger.get_primary_config().metadata
+      :logger.get_primary_config().metadata,
+      Application.get_env(:expert, :log_level, :debug)
     ]
 
     with {:ok, node_pid} <- EngineSupervisor.start_project_node(project),

--- a/apps/expert/lib/expert/logging/project_log_file.ex
+++ b/apps/expert/lib/expert/logging/project_log_file.ex
@@ -8,9 +8,12 @@ defmodule Expert.Logging.ProjectLogFile do
     :expert_project_log
   end
 
-  def attach(root_path \\ File.cwd!()) when is_binary(root_path) do
+  def attach(opts \\ []) do
+    root_path = Keyword.get(opts, :root_path, File.cwd!())
+    level = Keyword.get(opts, :level, :debug)
+
     with :ok <- ensure_workspace(root_path) do
-      add_handler(log_config(root_path))
+      add_handler(log_config(root_path, level))
     end
   end
 
@@ -36,7 +39,7 @@ defmodule Expert.Logging.ProjectLogFile do
     |> :logger.add_handler(:logger_std_h, config)
   end
 
-  defp log_config(root_path) do
+  defp log_config(root_path, level) do
     log_file_name =
       root_path
       |> Path.join(".expert")
@@ -50,7 +53,7 @@ defmodule Expert.Logging.ProjectLogFile do
         max_no_files: @max_no_files
       },
       formatter: Logger.Formatter.new(metadata: [:instance_id]),
-      level: :debug
+      level: level
     }
   end
 end

--- a/apps/expert/test/expert/logging/project_log_file_test.exs
+++ b/apps/expert/test/expert/logging/project_log_file_test.exs
@@ -17,7 +17,7 @@ defmodule Expert.Logging.ProjectLogFileTest do
     log_path = Path.join([tmp_dir, ".expert", "expert.log"])
     gitignore_path = Path.join([tmp_dir, ".expert", ".gitignore"])
 
-    assert :ok = ProjectLogFile.attach(tmp_dir)
+    assert :ok = ProjectLogFile.attach(root_path: tmp_dir)
 
     Logger.info("project log file test")
     Logger.flush()
@@ -25,5 +25,13 @@ defmodule Expert.Logging.ProjectLogFileTest do
     assert File.dir?(Path.join(tmp_dir, ".expert"))
     assert File.read!(gitignore_path) == "*\n"
     assert File.regular?(log_path)
+  end
+
+  @tag :tmp_dir
+  test "attach/1 applies the given log level to the handler", %{tmp_dir: tmp_dir} do
+    assert :ok = ProjectLogFile.attach(root_path: tmp_dir, level: :warning)
+
+    {:ok, config} = :logger.get_handler_config(ProjectLogFile.handler_name())
+    assert config.level == :warning
   end
 end


### PR DESCRIPTION
This adds a command-line flag --log-level which affects the filtering of the log level in expert.log and project.log. It keeps `:debug` as default.

Addresses #541  (I don't want to close it automatically, as we may want to continue there for feedback)

First few logs on info level are kept always for debugging. This is when I set the log level to `error`:

```
17:07:10.045 instance_id=19D6DA20D51 [info] Expert v0.1.0 starting on stdio, argv=["--stdio", "--log-level", "error"]
17:07:10.046 instance_id=19D6DA20D51 [info] Log level set to error
```