### PR TITLE
feat(expert): allow setting file log level via configuration

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -11,21 +11,25 @@ defmodule Expert.Configuration do
   alias GenLSP.Structures
 
   @default_lsp_log_level :info
+  @default_file_log_level :debug
 
   @type lsp_level :: :error | :warning | :info | :log
+  @type file_level :: :debug | :info | :warning | :error
 
   defstruct support: nil,
             client_name: nil,
             additional_watched_extensions: nil,
             workspace_symbols: %WorkspaceSymbols{},
-            log_level: @default_lsp_log_level
+            log_level: @default_lsp_log_level,
+            file_log_level: @default_file_log_level
 
   @type t :: %__MODULE__{
           support: support | nil,
           client_name: String.t() | nil,
           additional_watched_extensions: [String.t()] | nil,
           workspace_symbols: WorkspaceSymbols.t(),
-          log_level: lsp_level()
+          log_level: lsp_level(),
+          file_log_level: file_level()
         }
 
   @opaque support :: Support.t()
@@ -61,6 +65,11 @@ defmodule Expert.Configuration do
   @spec log_level() :: lsp_level()
   def log_level do
     get().log_level
+  end
+
+  @spec file_log_level() :: file_level()
+  def file_log_level do
+    get().file_log_level
   end
 
   @spec window_log_message_enabled?() :: boolean()
@@ -106,9 +115,11 @@ defmodule Expert.Configuration do
     new_config =
       old_config
       |> set_lsp_log_level(settings)
+      |> set_file_log_level(settings)
       |> set_workspace_symbols(settings)
       |> set()
 
+    apply_file_log_level(new_config)
     maybe_watched_extensions_request(new_config, settings)
   end
 
@@ -125,6 +136,29 @@ defmodule Expert.Configuration do
   defp parse_lsp_log_level(%{"logLevel" => "info"}), do: :info
   defp parse_lsp_log_level(%{"logLevel" => "log"}), do: :log
   defp parse_lsp_log_level(_), do: @default_lsp_log_level
+
+  defp set_file_log_level(%__MODULE__{} = config, %{"fileLogLevel" => value}) do
+    %__MODULE__{config | file_log_level: parse_file_log_level(value)}
+  end
+
+  defp set_file_log_level(%__MODULE__{} = config, _settings) do
+    config
+  end
+
+  defp parse_file_log_level("debug"), do: :debug
+  defp parse_file_log_level("info"), do: :info
+  defp parse_file_log_level("warning"), do: :warning
+  defp parse_file_log_level("error"), do: :error
+  defp parse_file_log_level(_), do: @default_file_log_level
+
+  defp apply_file_log_level(%__MODULE__{file_log_level: level}) do
+    handler_name = Expert.Logging.ProjectLogFile.handler_name()
+
+    case :logger.set_handler_config(handler_name, :level, level) do
+      :ok -> :ok
+      {:error, _} -> :ok
+    end
+  end
 
   defp set_workspace_symbols(%__MODULE__{} = config, settings) do
     %__MODULE__{config | workspace_symbols: WorkspaceSymbols.new(settings)}

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -73,6 +73,20 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
+  describe "file_log_level/0" do
+    test "defaults to :debug" do
+      assert Configuration.file_log_level() == :debug
+    end
+
+    test "can be set via new/1" do
+      [file_log_level: :warning]
+      |> Configuration.new()
+      |> Configuration.set()
+
+      assert Configuration.file_log_level() == :warning
+    end
+  end
+
   describe "on_change/1 with logLevel" do
     test "parses the 4 valid LSP log level strings" do
       for {string, atom} <- [
@@ -115,6 +129,101 @@ defmodule Expert.ConfigurationTest do
         assert updated.log_level == :warning
         assert updated.workspace_symbols.min_query_length == 2
       end
+    end
+  end
+
+  describe "on_change/1 with fileLogLevel" do
+    test "parses valid file log level strings" do
+      for {string, atom} <- [
+            {"debug", :debug},
+            {"info", :info},
+            {"warning", :warning},
+            {"error", :error}
+          ] do
+        change = build_change(%{"fileLogLevel" => string})
+
+        {:ok, updated} = Configuration.on_change(change)
+
+        assert updated.file_log_level == atom
+      end
+    end
+
+    test "preserves previous value when setting is missing" do
+      change = build_change(%{"fileLogLevel" => "error"})
+      {:ok, _} = Configuration.on_change(change)
+
+      change = build_change(%{})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.file_log_level == :error
+    end
+
+    test "resets to default when explicit null is sent" do
+      change = build_change(%{"fileLogLevel" => "error"})
+      {:ok, _} = Configuration.on_change(change)
+
+      change = build_change(%{"fileLogLevel" => nil})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.file_log_level == :debug
+    end
+
+    test "resets to default for invalid string values" do
+      change = build_change(%{"fileLogLevel" => "verbose"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.file_log_level == :debug
+    end
+
+    test "updates the project log file handler level" do
+      handler_name = Expert.Logging.ProjectLogFile.handler_name()
+      had_handler = match?({:ok, _}, :logger.get_handler_config(handler_name))
+
+      if !had_handler do
+        :logger.add_handler(handler_name, :logger_std_h, %{
+          config: %{file: ~c"/dev/null"},
+          level: :debug
+        })
+      end
+
+      on_exit(fn ->
+        if had_handler do
+          :logger.set_handler_config(handler_name, :level, :debug)
+        else
+          :logger.remove_handler(handler_name)
+        end
+      end)
+
+      change = build_change(%{"fileLogLevel" => "warning"})
+      {:ok, _updated} = Configuration.on_change(change)
+
+      {:ok, handler_config} = :logger.get_handler_config(handler_name)
+      assert handler_config.level == :warning
+    end
+
+    test "does not crash when handler is not attached" do
+      handler_name = Expert.Logging.ProjectLogFile.handler_name()
+
+      previous_config =
+        case :logger.get_handler_config(handler_name) do
+          {:ok, config} ->
+            :logger.remove_handler(handler_name)
+            config
+
+          {:error, _} ->
+            nil
+        end
+
+      on_exit(fn ->
+        if previous_config do
+          :logger.add_handler(handler_name, previous_config.module, previous_config)
+        end
+      end)
+
+      change = build_change(%{"fileLogLevel" => "error"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.file_log_level == :error
     end
   end
 

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -9,7 +9,8 @@ Expert supports the following configuration options.
   "workspaceSymbols": {
     "minQueryLength": 2
   },
-  "logLevel": "info"
+  "logLevel": "info",
+  "fileLogLevel": "info"
 }
 ```
 
@@ -19,3 +20,4 @@ Expert supports the following configuration options.
 |---------|------|---------|-------------|
 | `workspaceSymbols.minQueryLength` | integer | `2` | Minimum characters required before workspace symbol search returns results. Set to `0` to return all symbols with an empty query. |
 | `logLevel` | string | `"info"` | Minimum severity of log messages forwarded to the editor. Valid values: `"error"`, `"warning"`, `"info"`, `"log"`. |
+| `fileLogLevel` | string | `"debug"` | Minimum severity of log messages written to the log file (`.expert/expert.log`). Valid values: `"debug"`, `"info"`, `"warning"`, `"error"`, `null`. Sending `null` resets log level to default. |


### PR DESCRIPTION
This is separated from LSP logging configuration. It defines the log level for expert.log file via workspace configuration under key `fileLogLevel`. It only affects `expert.log` in this PR. `project.log` is handled by Engine, so it can be done as a followup (at the same time, the default level for `project.log` is `info`, not `debug`, so it's not so dire as `expert.log` in terms of growing file size.

Sending explicit `null` as `fileLogLevel` resets it to default value (`debug`).

Addresses #541 
