### PR TITLE
fix(expert): add no-op handler for $/setTrace

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -226,6 +226,10 @@ defmodule Expert do
     end
   end
 
+  def handle_notification(%GenLSP.Notifications.DollarSetTrace{}, lsp) do
+    {:noreply, lsp}
+  end
+
   def handle_notification(notification, lsp) do
     with {:ok, handler} <- fetch_handler(notification),
          {:ok, notification} <- Convert.to_native(notification),


### PR DESCRIPTION
VSCode sends it whenever Expert settings are touched, which results in a message about unhandled message. I think it's better to add a no-op handling that show this warning.