### PR TITLE
feat: allow setting Elixir source directory

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -22,7 +22,7 @@ defmodule Expert.Configuration do
             workspace_symbols: %WorkspaceSymbols{},
             log_level: @default_lsp_log_level,
             file_log_level: @default_file_log_level,
-            elixir_src: nil
+            elixir_source_path: nil
 
   @type t :: %__MODULE__{
           support: support | nil,
@@ -31,7 +31,7 @@ defmodule Expert.Configuration do
           workspace_symbols: WorkspaceSymbols.t(),
           log_level: lsp_level(),
           file_log_level: file_level(),
-          elixir_src: String.t() | nil
+          elixir_source_path: String.t() | nil
         }
 
   @opaque support :: Support.t()
@@ -119,7 +119,7 @@ defmodule Expert.Configuration do
       |> set_lsp_log_level(settings)
       |> set_file_log_level(settings)
       |> set_workspace_symbols(settings)
-      |> set_elixir_src(settings)
+      |> set_elixir_source_path(settings)
       |> set()
 
     apply_file_log_level(new_config)
@@ -163,15 +163,16 @@ defmodule Expert.Configuration do
     end
   end
 
-  defp set_elixir_src(%__MODULE__{} = config, %{"elixirSrc" => value}) when is_binary(value) do
-    %__MODULE__{config | elixir_src: value}
+  defp set_elixir_source_path(%__MODULE__{} = config, %{"elixirSourcePath" => value})
+       when is_binary(value) do
+    %__MODULE__{config | elixir_source_path: value}
   end
 
-  defp set_elixir_src(%__MODULE__{} = config, %{"elixirSrc" => _}) do
-    %__MODULE__{config | elixir_src: nil}
+  defp set_elixir_source_path(%__MODULE__{} = config, %{"elixirSourcePath" => _}) do
+    %__MODULE__{config | elixir_source_path: nil}
   end
 
-  defp set_elixir_src(%__MODULE__{} = config, _settings) do
+  defp set_elixir_source_path(%__MODULE__{} = config, _settings) do
     config
   end
 

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -21,7 +21,8 @@ defmodule Expert.Configuration do
             additional_watched_extensions: nil,
             workspace_symbols: %WorkspaceSymbols{},
             log_level: @default_lsp_log_level,
-            file_log_level: @default_file_log_level
+            file_log_level: @default_file_log_level,
+            elixir_src: nil
 
   @type t :: %__MODULE__{
           support: support | nil,
@@ -29,7 +30,8 @@ defmodule Expert.Configuration do
           additional_watched_extensions: [String.t()] | nil,
           workspace_symbols: WorkspaceSymbols.t(),
           log_level: lsp_level(),
-          file_log_level: file_level()
+          file_log_level: file_level(),
+          elixir_src: String.t() | nil
         }
 
   @opaque support :: Support.t()
@@ -117,6 +119,7 @@ defmodule Expert.Configuration do
       |> set_lsp_log_level(settings)
       |> set_file_log_level(settings)
       |> set_workspace_symbols(settings)
+      |> set_elixir_src(settings)
       |> set()
 
     apply_file_log_level(new_config)
@@ -158,6 +161,18 @@ defmodule Expert.Configuration do
       :ok -> :ok
       {:error, _} -> :ok
     end
+  end
+
+  defp set_elixir_src(%__MODULE__{} = config, %{"elixirSrc" => value}) when is_binary(value) do
+    %__MODULE__{config | elixir_src: value}
+  end
+
+  defp set_elixir_src(%__MODULE__{} = config, %{"elixirSrc" => _}) do
+    %__MODULE__{config | elixir_src: nil}
+  end
+
+  defp set_elixir_src(%__MODULE__{} = config, _settings) do
+    config
   end
 
   defp set_workspace_symbols(%__MODULE__{} = config, settings) do

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -398,8 +398,14 @@ defmodule Expert.EngineNode do
 
   @deps_apps Mix.Project.deps_apps()
   defp all_app_configs do
-    Enum.map(@deps_apps, fn app_name ->
-      {app_name, Application.get_all_env(app_name)}
-    end)
+    configs =
+      Enum.map(@deps_apps, fn app_name ->
+        {app_name, Application.get_all_env(app_name)}
+      end)
+
+    case Expert.Configuration.get().elixir_src do
+      nil -> configs
+      elixir_src -> [{:language_server, [elixir_src: elixir_src]} | configs]
+    end
   end
 end

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -403,9 +403,12 @@ defmodule Expert.EngineNode do
         {app_name, Application.get_all_env(app_name)}
       end)
 
-    case Expert.Configuration.get().elixir_src do
-      nil -> configs
-      elixir_src -> [{:language_server, [elixir_src: elixir_src]} | configs]
+    case Expert.Configuration.get().elixir_source_path do
+      nil ->
+        configs
+
+      elixir_source_path ->
+        [{:language_server, [elixir_source_path: elixir_source_path]} | configs]
     end
   end
 end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -88,11 +88,15 @@ defmodule Expert.State do
   end
 
   def apply(%__MODULE__{} = state, %Notifications.WorkspaceDidChangeConfiguration{} = event) do
+    old_elixir_src = Configuration.get().elixir_src
+
     case Configuration.on_change(event) do
-      {:ok, _config} ->
+      {:ok, config} ->
+        if config.elixir_src != old_elixir_src, do: propagate_elixir_src(config)
         {:ok, state}
 
-      {:ok, _config, request} ->
+      {:ok, config, request} ->
+        if config.elixir_src != old_elixir_src, do: propagate_elixir_src(config)
         GenLSP.request(Expert.get_lsp(), request)
         {:ok, state}
     end
@@ -262,6 +266,22 @@ defmodule Expert.State do
         %Project{} = project
       ) do
     %__MODULE__{state | deps_declined_projects: MapSet.put(declined, project.root_uri)}
+  end
+
+  defp propagate_elixir_src(%Configuration{elixir_src: nil}) do
+    for project <- ActiveProjects.projects(), ActiveProjects.active?(project) do
+      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_src])
+    end
+  rescue
+    _ -> :ok
+  end
+
+  defp propagate_elixir_src(%Configuration{elixir_src: elixir_src}) do
+    for project <- ActiveProjects.projects(), ActiveProjects.active?(project) do
+      EngineApi.call(project, Application, :put_env, [:language_server, :elixir_src, elixir_src])
+    end
+  rescue
+    _ -> :ok
   end
 
   def initialize_result do

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -88,15 +88,19 @@ defmodule Expert.State do
   end
 
   def apply(%__MODULE__{} = state, %Notifications.WorkspaceDidChangeConfiguration{} = event) do
-    old_elixir_src = Configuration.get().elixir_src
+    old_elixir_source_path = Configuration.get().elixir_source_path
 
     case Configuration.on_change(event) do
       {:ok, config} ->
-        if config.elixir_src != old_elixir_src, do: propagate_elixir_src(config)
+        if config.elixir_source_path != old_elixir_source_path,
+          do: propagate_elixir_source_path(config)
+
         {:ok, state}
 
       {:ok, config, request} ->
-        if config.elixir_src != old_elixir_src, do: propagate_elixir_src(config)
+        if config.elixir_source_path != old_elixir_source_path,
+          do: propagate_elixir_source_path(config)
+
         GenLSP.request(Expert.get_lsp(), request)
         {:ok, state}
     end
@@ -268,17 +272,21 @@ defmodule Expert.State do
     %__MODULE__{state | deps_declined_projects: MapSet.put(declined, project.root_uri)}
   end
 
-  defp propagate_elixir_src(%Configuration{elixir_src: nil}) do
+  defp propagate_elixir_source_path(%Configuration{elixir_source_path: nil}) do
     for project <- ActiveProjects.projects(), ActiveProjects.active?(project) do
-      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_src])
+      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_source_path])
     end
   rescue
     _ -> :ok
   end
 
-  defp propagate_elixir_src(%Configuration{elixir_src: elixir_src}) do
+  defp propagate_elixir_source_path(%Configuration{elixir_source_path: elixir_source_path}) do
     for project <- ActiveProjects.projects(), ActiveProjects.active?(project) do
-      EngineApi.call(project, Application, :put_env, [:language_server, :elixir_src, elixir_src])
+      EngineApi.call(project, Application, :put_env, [
+        :language_server,
+        :elixir_source_path,
+        elixir_source_path
+      ])
     end
   rescue
     _ -> :ok

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -293,46 +293,46 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
-  describe "on_change/1 with elixirSrc" do
+  describe "on_change/1 with elixirSourcePath" do
     test "parses a valid directory path" do
-      change = build_change(%{"elixirSrc" => "/path/to/elixir/source"})
+      change = build_change(%{"elixirSourcePath" => "/path/to/elixir/source"})
       {:ok, updated} = Configuration.on_change(change)
 
-      assert updated.elixir_src == "/path/to/elixir/source"
+      assert updated.elixir_source_path == "/path/to/elixir/source"
     end
 
     test "preserves previous value when setting is missing" do
-      change = build_change(%{"elixirSrc" => "/some/path"})
+      change = build_change(%{"elixirSourcePath" => "/some/path"})
       {:ok, _} = Configuration.on_change(change)
 
       change = build_change(%{})
       {:ok, updated} = Configuration.on_change(change)
 
-      assert updated.elixir_src == "/some/path"
+      assert updated.elixir_source_path == "/some/path"
     end
 
     test "clears the value when explicit null is sent" do
-      change = build_change(%{"elixirSrc" => "/some/path"})
+      change = build_change(%{"elixirSourcePath" => "/some/path"})
       {:ok, _} = Configuration.on_change(change)
 
-      change = build_change(%{"elixirSrc" => nil})
+      change = build_change(%{"elixirSourcePath" => nil})
       {:ok, updated} = Configuration.on_change(change)
 
-      assert updated.elixir_src == nil
+      assert updated.elixir_source_path == nil
     end
 
     test "defaults to nil" do
       change = build_change(%{})
       {:ok, updated} = Configuration.on_change(change)
 
-      assert updated.elixir_src == nil
+      assert updated.elixir_source_path == nil
     end
 
     test "ignores non-string values" do
-      change = build_change(%{"elixirSrc" => 123})
+      change = build_change(%{"elixirSourcePath" => 123})
       {:ok, updated} = Configuration.on_change(change)
 
-      assert updated.elixir_src == nil
+      assert updated.elixir_source_path == nil
     end
   end
 

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -293,6 +293,49 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
+  describe "on_change/1 with elixirSrc" do
+    test "parses a valid directory path" do
+      change = build_change(%{"elixirSrc" => "/path/to/elixir/source"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_src == "/path/to/elixir/source"
+    end
+
+    test "preserves previous value when setting is missing" do
+      change = build_change(%{"elixirSrc" => "/some/path"})
+      {:ok, _} = Configuration.on_change(change)
+
+      change = build_change(%{})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_src == "/some/path"
+    end
+
+    test "clears the value when explicit null is sent" do
+      change = build_change(%{"elixirSrc" => "/some/path"})
+      {:ok, _} = Configuration.on_change(change)
+
+      change = build_change(%{"elixirSrc" => nil})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_src == nil
+    end
+
+    test "defaults to nil" do
+      change = build_change(%{})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_src == nil
+    end
+
+    test "ignores non-string values" do
+      change = build_change(%{"elixirSrc" => 123})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_src == nil
+    end
+  end
+
   describe "race condition prevention" do
     defmodule DummyServer do
       use GenServer

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -10,7 +10,8 @@ Expert supports the following configuration options.
     "minQueryLength": 2
   },
   "logLevel": "info",
-  "fileLogLevel": "info"
+  "fileLogLevel": "info",
+  "elixirSrc": "/path/to/elixir/source"
 }
 ```
 
@@ -21,3 +22,4 @@ Expert supports the following configuration options.
 | `workspaceSymbols.minQueryLength` | integer | `2` | Minimum characters required before workspace symbol search returns results. Set to `0` to return all symbols with an empty query. |
 | `logLevel` | string | `"info"` | Minimum severity of log messages forwarded to the editor. Valid values: `"error"`, `"warning"`, `"info"`, `"log"`. |
 | `fileLogLevel` | string | `"debug"` | Minimum severity of log messages written to the log file (`.expert/expert.log`). Valid values: `"debug"`, `"info"`, `"warning"`, `"error"`, `null`. Sending `null` resets log level to default. |
+| `elixirSrc` | string | `null` | Path to a local Elixir source directory. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result. Should be an absolute path. |

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -11,7 +11,7 @@ Expert supports the following configuration options.
   },
   "logLevel": "info",
   "fileLogLevel": "info",
-  "elixirSrc": "/path/to/elixir/source"
+  "elixirSourcePath": "/path/to/elixir/source"
 }
 ```
 
@@ -22,4 +22,4 @@ Expert supports the following configuration options.
 | `workspaceSymbols.minQueryLength` | integer | `2` | Minimum characters required before workspace symbol search returns results. Set to `0` to return all symbols with an empty query. |
 | `logLevel` | string | `"info"` | Minimum severity of log messages forwarded to the editor. Valid values: `"error"`, `"warning"`, `"info"`, `"log"`. |
 | `fileLogLevel` | string | `"debug"` | Minimum severity of log messages written to the log file (`.expert/expert.log`). Valid values: `"debug"`, `"info"`, `"warning"`, `"error"`, `null`. Sending `null` resets log level to default. |
-| `elixirSrc` | string | `null` | Path to a local Elixir source directory. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result. Should be an absolute path. |
+| `elixirSourcePath` | string | `null` | Path to a local Elixir source directory. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result. Should be an absolute path. |


### PR DESCRIPTION
Addresses #507 (but without automatic source downloading)

Seems to work well for me with two caveats:
- There is just one value for the whole workspace. In theory a workspace can include multiple Elixir project with different version, but ElixirSense setting is global per Expert instance. Likely, this is not a huge problem, as the versions don't need to match perfectly for most lookups.
- For some reason for me it only worked with absolute paths. Probably ElixirSense implementation limitation.