### PR TITLE
fix(engine): respect formatter line length in Refactorex actions

### DIFF
--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -46,11 +46,18 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   defp ast_to_changes(doc, ast) do
     {formatter, opts} = CodeMod.Format.formatter_for_file(Engine.get_project(), doc.uri)
 
+    sourceror_opts =
+      Keyword.reject(
+        [
+          formatter: formatter,
+          locals_without_parens: opts[:locals_without_parens] || [],
+          line_length: opts[:line_length]
+        ],
+        fn {_k, v} -> is_nil(v) end
+      )
+
     ast
-    |> Sourceror.to_string(
-      formatter: formatter,
-      locals_without_parens: opts[:locals_without_parens] || []
-    )
+    |> Sourceror.to_string(sourceror_opts)
     |> then(&CodeMod.Diff.diff(doc, &1))
     |> then(&Changes.new(doc, &1))
   end

--- a/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
@@ -1,10 +1,12 @@
 defmodule Engine.CodeAction.Handlers.RefactorexTest do
   use Forge.Test.CodeMod.Case
+  use Patch
 
   import Forge.Test.CodeSigil
   import Forge.Test.RangeSupport
 
   alias Engine.CodeAction.Handlers.Refactorex
+  alias Engine.CodeMod.Format
   alias Forge.Document
 
   def apply_code_mod(original_text, _ast, options) do
@@ -79,6 +81,53 @@ defmodule Engine.CodeAction.Handlers.RefactorexTest do
 
         defp extracted_function(i) do
           i + 20
+        end
+      end]
+    )
+  end
+
+  test "Refactorex respects formatter line length" do
+    patch(Format, :formatter_for_file, fn _project, _path ->
+      {nil, [line_length: 120, locals_without_parens: []]}
+    end)
+
+    assert_refactored(
+      "Remove pipe",
+      ~q[
+      defmodule Foo do
+        def my_func(%{} = map, %{key1: _key1, key2: _key2, key3: _key3, key4: _key4, key5: _key5} = other) do
+          «»map |> Map.merge(other)
+        end
+      end],
+      ~q[
+      defmodule Foo do
+        def my_func(%{} = map, %{key1: _key1, key2: _key2, key3: _key3, key4: _key4, key5: _key5} = other) do
+          Map.merge(map, other)
+        end
+      end]
+    )
+  end
+
+  test "Refactorex formats when formatter line length is missing" do
+    patch(Format, :formatter_for_file, fn _project, _path ->
+      {nil, [locals_without_parens: []]}
+    end)
+
+    assert_refactored(
+      "Remove pipe",
+      ~q[
+      defmodule Foo do
+        def my_func(%{} = map, %{key1: _key1, key2: _key2, key3: _key3, key4: _key4, key5: _key5} = other) do
+          «»map |> Map.merge(other)
+        end
+      end],
+      ~q[
+      defmodule Foo do
+        def my_func(
+              %{} = map,
+              %{key1: _key1, key2: _key2, key3: _key3, key4: _key4, key5: _key5} = other
+            ) do
+          Map.merge(map, other)
         end
       end]
     )


### PR DESCRIPTION
Fix Refactorex code actions to respect project formatter `line_length` when rewriting code (for example, `Remove pipe`).

`Refactorex` was calling `Sourceror.to_string/2` without forwarding `line_length` from formatter config. As a result, code actions formatted output using Sourceror’s default `line_length` of `98`, even when the project configured a different value.