### PR TITLE
fix(forge): use `project.root_uri` for cache key in `Forge.Project.config`

### DIFF
--- a/apps/forge/lib/forge/project.ex
+++ b/apps/forge/lib/forge/project.ex
@@ -85,7 +85,7 @@ defmodule Forge.Project do
   end
 
   def config(%__MODULE__{} = project) do
-    config_key = {__MODULE__, name(project), :config}
+    config_key = {__MODULE__, project.root_uri, :config}
 
     case :persistent_term.get(config_key, :not_found) do
       :not_found ->


### PR DESCRIPTION
Using `name(project)` risks a collision, especially with supporting multiple workspace folders. Replacing it with `root_uri` is a much safer choice.

For now this is only used in `Forge.Project.display_name` + I don't think a lot of project use `:name` key in Mix config, so the impact is not great, but I think it's a good change for correctness.