### PR TITLE
fix(engine): fix interpreting words inside strings as identifiers

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/entity.ex
+++ b/apps/engine/lib/engine/code_intelligence/entity.ex
@@ -1,6 +1,7 @@
 defmodule Engine.CodeIntelligence.Entity do
   alias Forge.Ast
   alias Forge.Ast.Analysis
+  alias Forge.Ast.Detection
   alias Forge.Document
   alias Forge.Document.Position
   alias Forge.Document.Range
@@ -35,6 +36,7 @@ defmodule Engine.CodeIntelligence.Entity do
       |> Engine.CodeIntelligence.Heex.maybe_normalize(position)
 
     with :ok <- check_commented(analysis, position),
+         :ok <- check_in_string(analysis, position),
          {:ok, surround_context} <- Ast.surround_context(analysis, position),
          {:ok, resolved, {begin_pos, end_pos}} <-
            resolve(surround_context, analysis, position) do
@@ -64,11 +66,11 @@ defmodule Engine.CodeIntelligence.Entity do
   end
 
   defp check_commented(%Analysis{} = analysis, %Position{} = position) do
-    if Analysis.commented?(analysis, position) do
-      :error
-    else
-      :ok
-    end
+    if Analysis.commented?(analysis, position), do: {:error, :no_code}, else: :ok
+  end
+
+  defp check_in_string(%Analysis{} = analysis, %Position{} = position) do
+    if Detection.String.detected?(analysis, position), do: {:error, :no_code}, else: :ok
   end
 
   defp resolve(%{context: context, begin: begin_pos, end: end_pos}, analysis, position) do

--- a/apps/engine/test/engine/code_intelligence/entity_test.exs
+++ b/apps/engine/test/engine/code_intelligence/entity_test.exs
@@ -643,7 +643,7 @@ defmodule Engine.CodeIntelligence.EntityTest do
         end
       ]
 
-      assert {:error, :not_found} = resolve(code)
+      assert {:error, :no_code} = resolve(code)
     end
   end
 
@@ -1311,6 +1311,32 @@ defmodule Engine.CodeIntelligence.EntityTest do
       ]
 
       assert {:ok, {:call, Kernel, :to_string, 1}, _} = resolve(code)
+    end
+  end
+
+  describe "resolve/2 inside a string" do
+    test "does not resolve an ident inside a plain string (not interpolation)" do
+      code = ~q[
+        defmodule MyModule do
+          def my_fun do
+            "hello {wor|ld}"
+          end
+        end
+      ]
+
+      assert {:error, :no_code} = resolve(code)
+    end
+
+    test "resolves an ident inside string interpolation" do
+      code = ~S[
+        defmodule MyModule do
+          def my_fun(world) do
+            "hello #{wor|ld}"
+          end
+        end
+      ]
+
+      assert {:ok, {:variable, :world}, _} = resolve(code)
     end
   end
 

--- a/apps/expert/lib/expert/provider/handlers/hover.ex
+++ b/apps/expert/lib/expert/provider/handlers/hover.ex
@@ -30,10 +30,7 @@ defmodule Expert.Provider.Handlers.Hover do
         content = Markdown.to_content(markdown)
         %Structures.Hover{contents: content, range: range}
       else
-        {:error, :no_doc} ->
-          nil
-
-        {:error, :no_type} ->
+        {:error, reason} when reason in [:no_code, :no_doc, :no_type] ->
           nil
 
         :error ->

--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -882,6 +882,32 @@ defmodule Expert.Provider.Handlers.HoverTest do
     end
   end
 
+  describe "hover inside strings" do
+    test "returns nil inside a plain string (not interpolation)", %{project: project} do
+      hovered = ~q[
+        defmodule StringHover do
+          def foo do
+            "hello {Str|ing}"
+          end
+        end
+      ]
+
+      assert {:ok, nil} = hover(project, hovered)
+    end
+
+    test "returns a result inside string interpolation", %{project: project} do
+      hovered = ~S[
+        defmodule StringHover do
+          def foo do
+            "hello #{Str|ing}"
+          end
+        end
+      ]
+
+      assert {:ok, %Structures.Hover{}} = hover(project, hovered)
+    end
+  end
+
   defp with_indexed(project, code, fun) do
     tmp_dir = Fixtures.file_path(project, "lib/tmp")
 


### PR DESCRIPTION
Previously Expert interpreted words inside string (not inside interpolation) leading to bugs like this
<img width="390" height="268" alt="image" src="https://github.com/user-attachments/assets/df6dcc2b-a66c-443b-8ca8-a002827f00e3" />
