### PR TITLE
ci(backport): use app token in checkout

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -14,15 +14,16 @@ jobs:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: true
-
       - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Create backport PR
         id: backport
@@ -45,4 +46,3 @@ jobs:
               repo: context.repo.repo,
               labels: ['needs:backport']
             })
-


### PR DESCRIPTION
PRs that touch github workflows can't be pushed unless we use the token
during the git commit. I assumed that this would be the case when you
pass it to the backport action, but that is just the github api
operations.

You can achieve this by using the token during checkout. This is
mentioned in https://github.com/korthout/backport-action/issues/368
