### PR TITLE
fix: eager loading for large projects

### DIFF
--- a/apps/engine/lib/engine/module/loader.ex
+++ b/apps/engine/lib/engine/module/loader.ex
@@ -18,22 +18,20 @@ defmodule Engine.Module.Loader do
   end
 
   def load_all(module_list) do
-    Agent.update(__MODULE__, fn modules ->
-      loaded_modules =
-        case Code.ensure_all_loaded(module_list) do
-          :ok ->
-            modules
+    loaded_modules =
+      case Code.ensure_all_loaded(module_list) do
+        :ok ->
+          module_list
 
-          {:error, errors} ->
-            failed_modules = MapSet.new(errors, &elem(&1, 0))
-            Enum.reject(module_list, &MapSet.member?(failed_modules, &1))
-        end
+        {:error, errors} ->
+          failed_modules = MapSet.new(errors, &elem(&1, 0))
+          Enum.reject(module_list, &MapSet.member?(failed_modules, &1))
+      end
 
-      newly_loaded =
-        Map.new(loaded_modules, fn module_name -> {module_name, {:module, module_name}} end)
+    newly_loaded =
+      Map.new(loaded_modules, fn module_name -> {module_name, {:module, module_name}} end)
 
-      Map.merge(modules, newly_loaded)
-    end)
+    Agent.update(__MODULE__, fn modules -> Map.merge(modules, newly_loaded) end)
   end
 
   def ensure_loaded(module_name) do


### PR DESCRIPTION
On a fairly large project as of today I'm seeing the following error causing the application compiling failure:

```
22:50:58.662 instance_id=19DBC1BD7FD [debug] Node port message: 
22:50:58.622 [error] GenServer XPEngine.Build terminating
** (stop) exited in: GenServer.call(XPEngine.Module.Loader, {:update, #Function<1.33268632/1 in XPEngine.Module.Loader.load_all/1>}, 5000)
    ** (EXIT) time out
    (elixir 1.19.4) lib/gen_server.ex:1142: GenServer.call/3
    (xp_engine 0.1.0) lib/engine/build/project.ex:66: anonymous fn/2 in XPEngine.Build.Project.do_compile/3
    (xp_engine 0.1.0) lib/engine/build/project.ex:72: XPEngine.Build.Project.do_compile/3
    (xp_engine 0.1.0) lib/engine/build/project.ex:21: anonymous fn/3 in XPEngine.Build.Project.compile/2
    (xp_engine 0.1.0) lib/engine/progress.ex:6: XPEngine.Progress.execute_work/2
    (mix 1.19.4) lib/mix/project.ex:557: Mix.Project.in_project/4
    (elixir 1.19.4) lib/file.ex:2013: File.cd!/2
    (xp_engine 0.1.0) lib/engine/mix.ex:31: anonymous fn/3 in XPEngine.Mix.in_project/2
Last message: :timeout
State: %XPEngine.Build.State{project: %XPForge.Project{root_uri: "file:///Users/pawel.sw/jump/Jump/api", mix_exs_uri: "file:///Users/pawel.sw/jump/Jump/api/mix.exs", kind: :mix, mix_env: nil, mix_target: nil, env_variables: %{}, project_module: Jump.MixProject, entropy: 22236}, build_number: 0, uri_to_document: %{}, project_compile: :force, last_deps_fetch_result: nil}
```

This seems to be caused by #604 and the fact that it tries to load all modules inside `Agent.update` with a default timeout of 5 seconds. This is not enough time, so it crashes.

The solution here is to perform the loading outside `Agent.update` and only update the agent when we have the results.