### PR TITLE
chore(just): ensure install recipe always works

### DIFF
--- a/justfile
+++ b/justfile
@@ -119,8 +119,9 @@ install prefix="$HOME/.local": release
   #!/usr/bin/env bash
   set -euxo pipefail
 
+  rm -rf "{{ prefix }}"/libexec/expert
   mkdir -p "{{ prefix }}"/bin "{{ prefix }}"/libexec
-  cp -a ./apps/expert/_build/prod/rel/plain "{{ prefix }}"/libexec/expert
+  cp -a ./apps/expert/_build/{{ env('MIX_ENV', 'prod') }}/rel/plain "{{ prefix }}"/libexec/expert
   ln -sf ../libexec/expert/bin/start_expert "{{ prefix }}"/bin/expert
 
 clean-engine:


### PR DESCRIPTION
Delete `libexec/expert` if it exists to ensure that the recipe will correctly copy the release if it is invoked more than once

Also take `MIX_ENV` into account when copying the release