### PR TITLE
fix: skip regular files on engine clean

### DIFF
--- a/apps/expert/lib/expert/engine.ex
+++ b/apps/expert/lib/expert/engine.ex
@@ -100,8 +100,10 @@ defmodule Expert.Engine do
 
     if File.exists?(base) do
       for expert_ver_dir <- File.ls!(base),
-          tool_ver_dir <- File.ls!(Path.join(base, expert_ver_dir)),
-          path = Path.join([base, expert_ver_dir, tool_ver_dir]),
+          expert_ver_path = Path.join(base, expert_ver_dir),
+          File.dir?(expert_ver_path),
+          tool_ver_dir <- File.ls!(expert_ver_path),
+          path = Path.join(expert_ver_path, tool_ver_dir),
           File.dir?(path) do
         path
       end

--- a/apps/expert/test/expert/engine_test.exs
+++ b/apps/expert/test/expert/engine_test.exs
@@ -121,6 +121,36 @@ defmodule Expert.EngineTest do
       assert Enum.at(attempted_dirs, 0) =~ "0.1.0/foobar"
       assert Enum.at(attempted_dirs, 1) =~ "0.2.0/bazbeau"
     end
+
+    test "skips regular file at top level of cache dir", %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "0.1.0/foobar")
+      file = Path.join(tmp_dir, ".DS_Store")
+      File.mkdir_p!(dir)
+      File.write!(file, "")
+
+      capture_io(fn ->
+        exit_code = Engine.run(["clean", "--force"])
+        assert exit_code == 0
+      end)
+
+      refute File.exists?(dir)
+      assert File.exists?(file)
+    end
+
+    test "skips regular file inside an engine version dir", %{tmp_dir: tmp_dir} do
+      dir = Path.join(tmp_dir, "0.1.0/foobar")
+      file = Path.join(tmp_dir, "0.1.0/.DS_Store")
+      File.mkdir_p!(dir)
+      File.write!(file, "")
+
+      capture_io(fn ->
+        exit_code = Engine.run(["clean", "--force"])
+        assert exit_code == 0
+      end)
+
+      refute File.exists?(dir)
+      assert File.exists?(file)
+    end
   end
 
   describe "run/1 - clean subcommand interactive mode" do


### PR DESCRIPTION
This was found in a #570 , which added DETS file inside the cache directory. Then when `engine clean` was run, it failed because it could only handle directories.

The failure looked like this:

```
❯ ~/.local/bin/expert_darwin_arm64 engine clean --force
Kernel pid terminated (application_controller) ("{application_start_failure,xp_expert,{bad_return,{{'Elixir.XPExpert.Application',start,[normal,[]]},{'EXIT',{#{reason => enotdir,path => <<\"/Users/pawel.sw/Library/Caches/expert/hex.dets\">>,'__struct__' => 'Elixir.File.Error','__exception__' => true,action => <<\"list directory\">>},[{'Elixir.File','ls!',1,[{file,\"lib/file.ex\"},{line,2064}]},{'Elixir.XPExpert.Engine','-get_engine_dirs/0-fun-1-',3,[{file,\"lib/expert/engine.ex\"},{line,103}]},{'Elixir.Enum','-reduce/3-lists^foldl/2-0-',3,[{file,\"lib/enum.ex\"},{line,2520}]},{'Elixir.XPExpert.Engine',get_engine_dirs,0,[{file,\"lib/expert/engine.ex\"},{line,102}]},{'Elixir.XPExpert.Engine',clean_engines,1,[{file,\"lib/expert/engine.ex\"},{line,80}]},{'Elixir.XPExpert.Application',start,2,[{file,\"lib/expert/application.ex\"},{line,26}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,299}]}]}}}}}")

Crash dump is being written to: erl_crash.dump...done
```

This PR makes the `clean` command skip any files in the cache directory.