### PR TITLE
ci: disable Windows Defender

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,6 +211,13 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prep-matrix.outputs.matrix) }}
     steps:
+      - name: Disable Windows Defender real-time scanning
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Set-MpPreference -DisableScriptScanning $true
+          Set-MpPreference -DisableArchiveScanning $true
       - name: Set git to use original line ending (Windows)
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false


### PR DESCRIPTION
Apparently this scanning is what makes our CI on Windows so excruciatingly slow, at least now it seem to pass.