### PR TITLE
chore: ignore justfile formatting rev

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,6 @@
 
 # style: add quokka and format code (#511)
 059b64df1e4da1a7ddc8b407e7d9725f19ef7d56
+
+# chore(just): apply formatting changes (#614)
+38366c6eec94181d5c8a901c15817fc45dbcd794


### PR DESCRIPTION
This adds #614 to the `.git-blame-ignore-revs` file