### PR TITLE
perf(indexer): cache application and available modules

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -10,6 +10,7 @@ defmodule Engine.Application do
     children =
       if Engine.project_node?() do
         [
+          Engine.ApplicationCache,
           Engine.Api.Proxy,
           Engine.Commands.Reindex,
           Engine.Module.Loader,

--- a/apps/engine/lib/engine/application_cache.ex
+++ b/apps/engine/lib/engine/application_cache.ex
@@ -1,0 +1,67 @@
+defmodule Engine.ApplicationCache do
+  @moduledoc false
+
+  use GenServer
+
+  @applications __MODULE__.Applications
+  @available_modules __MODULE__.AvailableModules
+  @table_opts [:named_table, :public, :set, read_concurrency: true, write_concurrency: true]
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec application(module() | nil) :: atom() | nil
+  def application(nil), do: nil
+
+  def application(module) when is_atom(module) do
+    case lookup_application(module) do
+      {:ok, app} ->
+        app
+
+      :error ->
+        app = Application.get_application(module)
+        true = :ets.insert(@applications, {module, app})
+        app
+    end
+  end
+
+  @spec available_module?(module()) :: boolean()
+  def available_module?(module) when is_atom(module) do
+    :ets.member(@available_modules, module)
+  end
+
+  def clear do
+    :ets.delete_all_objects(@applications)
+    load_available_modules()
+
+    :ok
+  end
+
+  @impl true
+  def init(:ok) do
+    :ets.new(@applications, @table_opts)
+    :ets.new(@available_modules, @table_opts)
+    load_available_modules()
+
+    {:ok, nil}
+  end
+
+  defp load_available_modules do
+    :ets.delete_all_objects(@available_modules)
+
+    modules =
+      Enum.map(:code.all_available(), fn {module_charlist, _, _} ->
+        {List.to_atom(module_charlist), true}
+      end)
+
+    true = :ets.insert(@available_modules, modules)
+  end
+
+  defp lookup_application(module) do
+    case :ets.lookup(@applications, module) do
+      [{^module, app}] -> {:ok, app}
+      [] -> :error
+    end
+  end
+end

--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -1,4 +1,5 @@
 defmodule Engine.Search.Indexer do
+  alias Engine.ApplicationCache
   alias Engine.Progress
   alias Engine.Search.Indexer
   alias Forge.Identifier
@@ -11,6 +12,8 @@ defmodule Engine.Search.Indexer do
   @indexable_extensions "*.{ex,exs}"
 
   def create_index(%Project{} = project) do
+    :ok = ApplicationCache.clear()
+
     ProcessCache.with_cleanup do
       deps_dir = deps_dir(project)
 
@@ -21,12 +24,18 @@ defmodule Engine.Search.Indexer do
 
       {:ok, entries}
     end
+  after
+    ApplicationCache.clear()
   end
 
   def update_index(%Project{} = project, backend) do
+    :ok = ApplicationCache.clear()
+
     ProcessCache.with_cleanup do
       do_update_index(project, backend)
     end
+  after
+    ApplicationCache.clear()
   end
 
   defp do_update_index(%Project{} = project, backend) do

--- a/apps/engine/lib/engine/search/indexer/extractors/ecto_schema.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/ecto_schema.ex
@@ -51,7 +51,7 @@ defmodule Engine.Search.Indexer.Extractors.EctoSchema do
           :struct,
           block_range,
           detail_range,
-          Application.get_application(struct_module)
+          Engine.ApplicationCache.application(struct_module)
         )
 
       {:ok, definition}
@@ -83,7 +83,7 @@ defmodule Engine.Search.Indexer.Extractors.EctoSchema do
           :struct,
           range,
           detail_range,
-          Application.get_application(current_module)
+          Engine.ApplicationCache.application(current_module)
         )
 
       {:ok, definition_entry}

--- a/apps/engine/lib/engine/search/indexer/extractors/ex_unit.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/ex_unit.ex
@@ -111,7 +111,7 @@ defmodule Engine.Search.Indexer.Extractors.ExUnit do
     block = Reducer.current_block(reducer)
 
     {:ok, module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
-    app = Application.get_application(module)
+    app = Engine.ApplicationCache.application(module)
 
     case detail_range(reducer.analysis, ast) do
       nil -> :ignored
@@ -124,7 +124,7 @@ defmodule Engine.Search.Indexer.Extractors.ExUnit do
     block = Reducer.current_block(reducer)
 
     {:ok, module} = Analyzer.current_module(reducer.analysis, Reducer.position(reducer))
-    app = Application.get_application(module)
+    app = Engine.ApplicationCache.application(module)
 
     case detail_range(reducer.analysis, ast) do
       nil ->

--- a/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
@@ -16,7 +16,7 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
       min_arity = arity - count_defaults(extract_args(def_ast))
       block_r = block_range(reducer.analysis, ast)
       fun_type = type(definition)
-      app = Application.get_application(module)
+      app = Engine.ApplicationCache.application(module)
 
       entries =
         for a <- min_arity..arity do
@@ -56,7 +56,7 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
           Subject.mfa(module, delegate_name, arity),
           {:function, :delegate},
           detail_range,
-          Application.get_application(module)
+          Engine.ApplicationCache.application(module)
         )
 
       {:ok, Entry.put_metadata(entry, metadata)}

--- a/apps/engine/lib/engine/search/indexer/extractors/function_reference.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/function_reference.ex
@@ -113,7 +113,7 @@ defmodule Engine.Search.Indexer.Extractors.FunctionReference do
             Forge.Formats.mfa(module, function_name, arity),
             {:function, :usage},
             Ast.Range.get(ast, analysis.document),
-            Application.get_application(module)
+            Engine.ApplicationCache.application(module)
           )
 
         {:ok, entry, []}
@@ -181,7 +181,7 @@ defmodule Engine.Search.Indexer.Extractors.FunctionReference do
                mfa,
                {:function, :usage},
                range,
-               Application.get_application(module)
+               Engine.ApplicationCache.application(module)
              )}
 
           _ ->

--- a/apps/engine/lib/engine/search/indexer/extractors/module.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/module.ex
@@ -9,7 +9,6 @@ defmodule Engine.Search.Indexer.Extractors.Module do
   alias Forge.Ast
   alias Forge.Document.Position
   alias Forge.Document.Range
-  alias Forge.ProcessCache
   alias Forge.Search.Indexer.Entry
   alias Forge.Search.Indexer.Source.Block
 
@@ -40,7 +39,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           @definition_mappings[definition],
           block_range(reducer.analysis.document, defmodule_ast),
           detail_range,
-          Application.get_application(aliased_module)
+          Engine.ApplicationCache.application(aliased_module)
         )
 
       module_name_meta = Reducer.skip(module_name_meta)
@@ -75,7 +74,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           {:protocol, :implementation},
           block_range(reducer.analysis.document, defimpl_ast),
           detail_range,
-          Application.get_application(protocol_module)
+          Engine.ApplicationCache.application(protocol_module)
         )
 
       module_entry =
@@ -105,7 +104,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           Subject.module(module),
           :module,
           range,
-          Application.get_application(module)
+          Engine.ApplicationCache.application(module)
         )
 
       {:ok, entry, nil}
@@ -132,7 +131,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           Subject.module(current_module),
           :module,
           range,
-          Application.get_application(current_module)
+          Engine.ApplicationCache.application(current_module)
         )
 
       {:ok, entry}
@@ -155,7 +154,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           Subject.module(module),
           :module,
           range,
-          Application.get_application(module)
+          Engine.ApplicationCache.application(module)
         )
 
       {:ok, entry}
@@ -187,7 +186,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
           Subject.module(module),
           :module,
           range,
-          Application.get_application(module)
+          Engine.ApplicationCache.application(module)
         )
 
       {:ok, entry}
@@ -254,7 +253,7 @@ defmodule Engine.Search.Indexer.Extractors.Module do
   end
 
   defp module(%Reducer{}, maybe_erlang_module) when is_atom(maybe_erlang_module) do
-    if available_module?(maybe_erlang_module) do
+    if Engine.ApplicationCache.available_module?(maybe_erlang_module) do
       {:ok, maybe_erlang_module}
     else
       :error
@@ -276,18 +275,6 @@ defmodule Engine.Search.Indexer.Extractors.Module do
   defp module_part?({:__MODULE__, _, context}) when is_atom(context), do: true
 
   defp module_part?(_), do: false
-
-  defp available_module?(potential_module) do
-    MapSet.member?(all_modules(), potential_module)
-  end
-
-  defp all_modules do
-    ProcessCache.trans(:all_modules, fn ->
-      MapSet.new(:code.all_available(), fn {module_charlist, _, _} ->
-        List.to_atom(module_charlist)
-      end)
-    end)
-  end
 
   defp module_range(%Reducer{} = reducer, module_name, metadata) do
     case Metadata.position(metadata) do

--- a/apps/engine/lib/engine/search/indexer/extractors/module_attribute.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/module_attribute.ex
@@ -25,7 +25,7 @@ defmodule Engine.Search.Indexer.Extractors.ModuleAttribute do
             Subject.module_attribute(current_module, attr_name),
             :module_attribute,
             reference_range(reducer, attr_name),
-            Application.get_application(current_module)
+            Engine.ApplicationCache.application(current_module)
           )
 
         {:ok, reference}
@@ -56,7 +56,7 @@ defmodule Engine.Search.Indexer.Extractors.ModuleAttribute do
             Subject.module_attribute(current_module, attr_name),
             :module_attribute,
             definition_range(reducer, attr),
-            Application.get_application(current_module)
+            Engine.ApplicationCache.application(current_module)
           )
 
         {:ok, definition}

--- a/apps/engine/lib/engine/search/indexer/extractors/struct_definition.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/struct_definition.ex
@@ -19,7 +19,7 @@ defmodule Engine.Search.Indexer.Extractors.StructDefinition do
             current_module,
             :struct,
             range,
-            Application.get_application(current_module)
+            Engine.ApplicationCache.application(current_module)
           )
 
         {:ok, entry}

--- a/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/struct_reference.ex
@@ -69,7 +69,7 @@ defmodule Engine.Search.Indexer.Extractors.StructReference do
       subject,
       :struct,
       Ast.Range.fetch!(reference, document),
-      Application.get_application(struct_module)
+      Engine.ApplicationCache.application(struct_module)
     )
   end
 

--- a/apps/engine/lib/engine/search/indexer/extractors/variable.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/variable.ex
@@ -237,7 +237,7 @@ defmodule Engine.Search.Indexer.Extractors.Variable do
 
   defp get_current_app(%Reducer{} = reducer) do
     with {:ok, module} <- Analyzer.current_module(reducer.analysis, Reducer.position(reducer)) do
-      Application.get_application(module)
+      Engine.ApplicationCache.application(module)
     end
   end
 

--- a/apps/engine/test/engine/application_cache_test.exs
+++ b/apps/engine/test/engine/application_cache_test.exs
@@ -1,0 +1,57 @@
+defmodule Engine.ApplicationCacheTest do
+  use ExUnit.Case, async: false
+
+  alias Engine.ApplicationCache
+
+  @applications ApplicationCache.Applications
+  @available_modules ApplicationCache.AvailableModules
+
+  setup do
+    start_supervised!(ApplicationCache)
+    :ok
+  end
+
+  describe "application/1" do
+    test "returns the owning application for a loaded module" do
+      assert ApplicationCache.application(ApplicationCache) == :engine
+    end
+
+    test "caches missing applications as nil" do
+      module = __MODULE__.UnknownModule
+
+      assert ApplicationCache.application(module) == nil
+      assert :ets.lookup(@applications, module) == [{module, nil}]
+    end
+  end
+
+  describe "available_module?/1" do
+    test "returns true for an available Erlang module" do
+      assert ApplicationCache.available_module?(:timer) == true
+    end
+
+    test "returns false for an unavailable module" do
+      assert ApplicationCache.available_module?(__MODULE__.UnknownModule) == false
+    end
+  end
+
+  describe "clear/0" do
+    test "clears application lookups" do
+      assert ApplicationCache.application(ApplicationCache) == :engine
+      assert :ets.lookup(@applications, ApplicationCache) == [{ApplicationCache, :engine}]
+
+      assert ApplicationCache.clear() == :ok
+
+      assert :ets.lookup(@applications, ApplicationCache) == []
+    end
+
+    test "reloads available modules" do
+      assert ApplicationCache.available_module?(:timer)
+
+      :ets.delete_all_objects(@available_modules)
+      refute ApplicationCache.available_module?(:timer)
+
+      assert ApplicationCache.clear() == :ok
+      assert ApplicationCache.available_module?(:timer)
+    end
+  end
+end

--- a/apps/engine/test/engine/code_intelligence/references_test.exs
+++ b/apps/engine/test/engine/code_intelligence/references_test.exs
@@ -19,6 +19,7 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
     Backends.Ets.destroy_all(project)
     Engine.set_project(project)
 
+    start_supervised!(Engine.ApplicationCache)
     start_supervised!(Document.Store)
     start_supervised!(Engine.Dispatch)
     start_supervised!(Backends.Ets)

--- a/apps/engine/test/engine/code_intelligence/symbols_test.exs
+++ b/apps/engine/test/engine/code_intelligence/symbols_test.exs
@@ -10,6 +10,11 @@ defmodule Engine.CodeIntelligence.SymbolsTest do
   alias Engine.Search.Indexer.Source
   alias Forge.CodeIntelligence.Symbols.Document
 
+  setup do
+    start_supervised!(Engine.ApplicationCache)
+    :ok
+  end
+
   def document_symbols(code) do
     doc = Forge.Document.new("file:///file.ex", code, 1)
     symbols = Symbols.for_document(doc)

--- a/apps/engine/test/engine/code_intelligence/variable_test.exs
+++ b/apps/engine/test/engine/code_intelligence/variable_test.exs
@@ -8,6 +8,11 @@ defmodule Engine.CodeIntelligence.VariableTest do
   alias Engine.CodeIntelligence.Variable
   alias Forge.Ast
 
+  setup do
+    start_supervised!(Engine.ApplicationCache)
+    :ok
+  end
+
   def find_definition(code) do
     {position, document} = pop_cursor(code, as: :document)
     analysis = Ast.analyze(document)

--- a/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
+++ b/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
@@ -31,6 +31,7 @@ defmodule Engine.Dispatch.Handlers.IndexingTest do
 
     patch(Engine.Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
+    start_supervised!(Engine.ApplicationCache)
     start_supervised!(Engine.Dispatch)
     start_supervised!(Commands.Reindex)
     start_supervised!(Search.Store.Backends.Ets)

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -26,6 +26,7 @@ defmodule Engine.Search.IndexerTest do
 
   setup do
     project = project()
+    start_supervised!(Engine.ApplicationCache)
     start_supervised(Dispatch)
     # Mock the broadcast so progress reporting doesn't fail
     patch(Engine.Api.Proxy, :broadcast, fn _ -> :ok end)

--- a/apps/engine/test/engine/search/store_test.exs
+++ b/apps/engine/test/engine/search/store_test.exs
@@ -33,6 +33,11 @@ defmodule Engine.Search.StoreTest do
     {:ok, project: project}
   end
 
+  setup do
+    start_supervised!(Engine.ApplicationCache)
+    :ok
+  end
+
   def all_entries(backend) do
     []
     |> backend.reduce(fn entry, acc -> [entry | acc] end)

--- a/apps/engine/test/support/test/extractor_case.ex
+++ b/apps/engine/test/support/test/extractor_case.ex
@@ -11,6 +11,11 @@ defmodule Engine.Test.ExtractorCase do
       import Forge.Test.CodeSigil
       import Forge.Test.RangeSupport
       import unquote(__MODULE__)
+
+      setup do
+        start_supervised!(Engine.ApplicationCache)
+        :ok
+      end
     end
   end
 

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -59,6 +59,8 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
   end
 
   setup %{project: project} do
+    start_supervised!(Engine.ApplicationCache)
+
     uri = subject_module_uri(project)
 
     # NOTE: We need to make sure every tests start with fresh caller content file

--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -43,6 +43,7 @@ defmodule Expert.Provider.Handlers.HoverTest do
   end
 
   setup do
+    start_supervised!(Engine.ApplicationCache)
     :persistent_term.erase(Expert.Configuration)
     :ok
   end


### PR DESCRIPTION
Caches the result of `Application.get_application` and `:code.all_available`

Indexing the `apps/expert` project with `main` takes over 20 seconds on my machine(sometimes as much as 28 seconds)
<img width="453" height="70" alt="baseline" src="https://github.com/user-attachments/assets/94c7e945-59be-44d3-9afe-b876306e361a" />

I profiled the indexer with `:tprof` and the reports suggested these two functions were a bottleneck(the total time is cumulative, it's distributed over the tasks created by `async_chunks` in the indexer):

```
Module                                       Function/Arity                Calls     Total           Per Call µs       %
application_controller                       get_application_module/1      438643    19.72 s         44.96             5.55
code                                         -all_available/2-F/2-1-/2     11907594  2.08 s          0.17              0.58
```

This PR introduces a cache for both. The cache also clears after the indexer runs because those values rarely change while the indexer run, but they may change between runs(like if you work in a monorepo and move files from one project to the other).

After that, the expert app indexes in a little over 10 seconds for me(there's quite some variation though, it oscilates between 10 and 14 seconds, it's still way less than 20 seconds though)
<img width="353" height="73" alt="app cache" src="https://github.com/user-attachments/assets/6a90c2c4-7216-40a4-b989-6b0ecee819d7" />
