### PR TITLE
fix(forge): normalize Erlang release candidate versions

### DIFF
--- a/apps/forge/lib/forge/vm/versions.ex
+++ b/apps/forge/lib/forge/vm/versions.ex
@@ -196,6 +196,7 @@ defmodule Forge.VM.Versions do
     version_components =
       erlang_version
       |> String.split(".")
+      |> Enum.map(&strip_pre_release/1)
       |> Enum.take(3)
 
     normalized =
@@ -207,6 +208,13 @@ defmodule Forge.VM.Versions do
       end
 
     Enum.join(normalized, ".")
+  end
+
+  defp strip_pre_release(component) do
+    case Integer.parse(component) do
+      {int, _rest} -> Integer.to_string(int)
+      :error -> "0"
+    end
   end
 
   defp code_find_file(file_name) when is_binary(file_name) do

--- a/apps/forge/test/forge/vm/versions_test.exs
+++ b/apps/forge/test/forge/vm/versions_test.exs
@@ -79,6 +79,19 @@ defmodule Forge.VM.VersionTest do
       assert "25.3.2" == private(Versions.normalize("25.3.2.1.2"))
       assert "25.3.2" == private(Versions.normalize("25.3.2.4.2.3"))
     end
+
+    test "strips pre-release suffixes from components and produces a parseable version" do
+      # Erlang OTP release candidates expose versions like "29.0-rc3" or
+      # "29.0-rc3.0" (the latter is what the OTP_VERSION file contains for
+      # OTP 29.0-rc3). Both must produce a SemVer-parseable string.
+      assert "29.0.0" == private(Versions.normalize("29.0-rc3"))
+      assert "29.0.0" == private(Versions.normalize("29.0-rc3.0"))
+      assert {:ok, _} = Version.parse(private(Versions.normalize("29.0-rc3.0")))
+    end
+
+    test "falls back to 0 when a component has no leading digits" do
+      assert "0.0.0" == private(Versions.normalize("rc3"))
+    end
   end
 
   test "an untagged directory is not compatible" do
@@ -112,6 +125,23 @@ defmodule Forge.VM.VersionTest do
       patch_tagged_versions("1.15.8", "25.0")
 
       assert compatible?("/foo/bar/baz")
+    end
+
+    test "release candidate erlang versions do not crash compatibility checks" do
+      # Reproduces the crash hit on OTP 29.0-rc3 + Elixir 1.20.0-rc.4, where
+      # `Version.parse!/1` rejected "29.0-rc3.0" because the pre-release tag
+      # appeared before patch.
+      patch_system_versions("1.20.0-rc.4", "29.0-rc3.0")
+      patch_tagged_versions("1.18.4", "28.0.2")
+
+      assert compatible?("/foo/bar/baz")
+    end
+
+    test "release candidate erlang versions are compared by major version" do
+      patch_system_versions("1.20.0-rc.4", "29.0-rc3.0")
+      patch_tagged_versions("1.20.0-rc.4", "30.0.0")
+
+      refute compatible?("/foo/bar/baz")
     end
   end
 end


### PR DESCRIPTION
Erlang reports OTP release candidates as MAJOR.MINOR-rcN (e.g. 29.0-rc3), and the in-release OTP_VERSION file contains MAJOR.MINOR-rcN.PATCH (e.g. 29.0-rc3.0). The previous normalize/1 implementation joined those components
back unchanged, producing strings like \"29.0-rc3.0\" that Version.parse!/1 rejects because the pre-release tag must follow a full major.minor.patch.

This MR fixes the normalize function by replacing the "-rcN" by 0.

I tested with a bunch of different versions, and it does not affect how non rc versions are handled.

tested with the vscode extension. 

here is the crash : 
```
09:28:07.054 instance_id=19DCDD68559 [error] GenServer XPEngine.Build terminating
** (Version.InvalidVersionError) invalid version: "29.0-rc3.0"
    (elixir 1.20.0-rc.4) lib/version.ex:420: Version.parse!/1
    (xp_forge 0.1.3) lib/forge/vm/versions.ex:96: XPForge.VM.Versions.compatible?/1
    (xp_engine 0.1.3) lib/engine/build/state.ex:62: XPEngine.Build.State.ensure_build_directory/1
    (xp_engine 0.1.3) lib/engine/build.ex:69: XPEngine.Build.handle_continue/2
    (stdlib 8.0) gen_server.erl:2424: :gen_server.try_handle_continue/3
    (stdlib 8.0) gen_server.erl:2291: :gen_server.loop/4
    (stdlib 8.0) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
Last message: {:continue, :ensure_build_directory}
State: %XPEngine.Build.State{project: %XPForge.Project{root_uri: "file:///home/****/project", mix_exs_uri: "file:///home/****/mix.exs", mix_project?: true, mix_env: nil, mix_target: nil, env_variables: %{}, project_module: Project.MixProject, entropy: 52701}, build_number: 0, uri_to_document: %{}, project_compile: :none}

10:13:15.200 instance_id=19D80C077B6 [error] Failed to start child {XPExpert.Project.Diagnostics, "project::89964991"}: {:exception, {:noproc, {:gen_event, :call, [XPEngine.Dispatch, XPEngine.Dispatch.PubSub, {:register, #PID<0.212.0>, [{:file_diagnostics, nil, 0, nil, []}, {:project_compile_requested, nil, 0}, {:project_compiled, nil, 0, :successful, [], 0}, {:project_diagnostics, nil, 0, []}]}]}}}
```

code written by me, tests written by opus 4.7

fixes #640