### PR TITLE
perf(indexer): only use relevant extractors when indexing deps

### DIFF
--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -2,6 +2,7 @@ defmodule Engine.Search.Indexer do
   alias Engine.ApplicationCache
   alias Engine.Progress
   alias Engine.Search.Indexer
+  alias Engine.Search.Indexer.Extractors
   alias Forge.Identifier
   alias Forge.ProcessCache
   alias Forge.Project
@@ -10,6 +11,18 @@ defmodule Engine.Search.Indexer do
   require ProcessCache
 
   @indexable_extensions "*.{ex,exs}"
+
+  # Deps files only contribute definitions to the index, so we skip pure-reference
+  # extractors (the most expensive one being FunctionReference, which resolves
+  # aliases and arity on every call site). ModuleAttribute stays because it
+  # produces both definitions and references; the post-filter drops its references.
+  @deps_extractors [
+    Extractors.Module,
+    Extractors.ModuleAttribute,
+    Extractors.FunctionDefinition,
+    Extractors.StructDefinition,
+    Extractors.EctoSchema
+  ]
 
   def create_index(%Project{} = project) do
     :ok = ApplicationCache.clear()
@@ -76,15 +89,16 @@ defmodule Engine.Search.Indexer do
   end
 
   defp index_path(path, deps_dir) do
+    in_deps? = is_binary(deps_dir) and Forge.Path.contains?(path, deps_dir)
+    extractors = if in_deps?, do: @deps_extractors
+
     with {:ok, contents} <- File.read(path),
-         {:ok, entries} <- Indexer.Source.index(path, contents) do
-      Enum.filter(entries, fn entry ->
-        if is_binary(deps_dir) and Forge.Path.contains?(path, deps_dir) do
-          entry.subtype == :definition
-        else
-          true
-        end
-      end)
+         {:ok, entries} <- Indexer.Source.index(path, contents, extractors) do
+      if in_deps? do
+        Enum.filter(entries, &(&1.subtype == :definition))
+      else
+        entries
+      end
     else
       _ ->
         []


### PR DESCRIPTION
When indexing dependencies, we are only interested in the definitions. Currently we are doing a full extraction and then filtering out non-definition entries. After this change we are running more focused set of extractors - only the ones that can actually produce definitions.

Tried to benchmark this in separation and got these results (indexing Expert's deps):

```
Name                                    ips        average  deviation         median         99th %
new: deps extractors + filter          0.70         1.42 s     ±8.59%         1.38 s         1.68 s
old: all extractors + filter           0.49         2.04 s     ±1.39%         2.04 s         2.09 s

Comparison: 
new: deps extractors + filter          0.70
old: all extractors + filter           0.49 - 1.44x slower +0.63 s

Memory usage statistics:

Name                                  average  deviation         median         99th %
new: deps extractors + filter         0.97 GB     ±0.02%        0.97 GB        0.97 GB
old: all extractors + filter          1.09 GB     ±0.00%        1.09 GB        1.09 GB

Comparison: 
new: deps extractors + filter         0.97 GB
old: all extractors + filter          1.09 GB - 1.12x memory usage +0.121 GB
```