### PR TITLE
ci: change to taiki-e/install-action for just and fix erlang patch version issue on setup-beam

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -128,13 +128,13 @@
     },
     {
       "os": "ubuntu-latest",
-      "otp": "27.3.4.1",
+      "otp": "27.3.4.10",
       "elixir": "1.18.4",
       "project": "expert"
     },
     {
       "os": "windows-2022",
-      "otp": "27.3.4.1",
+      "otp": "27.3.4.10",
       "elixir": "1.18.4",
       "project": "expert"
     }

--- a/.github/workflows/ci-justfile.yaml
+++ b/.github/workflows/ci-justfile.yaml
@@ -29,7 +29,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
 
       - name: Run formatter
         run: just --fmt --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - name: Set up Elixir
         id: setup-beam
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -87,7 +90,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - name: Set up Elixir
         id: setup-beam
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
@@ -165,7 +171,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - name: Set up Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
@@ -226,7 +235,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - name: Set up Elixir
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
@@ -265,4 +277,3 @@ jobs:
         run: |
           echo "::error Some required job has failed!"
           exit 1
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,7 +163,7 @@ jobs:
 
         include:
           - elixir: "1.17.3"
-            otp: "27.3.4.1"
+            otp: "27.3.4.10"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -53,7 +53,7 @@ jobs:
           fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: "27.3.4.1"
+          otp-version: "27.3.4.10"
           elixir-version: "1.17.3"
           version-type: strict
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,7 +47,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: "27.3.4.1"

--- a/.github/workflows/release-backports.yaml
+++ b/.github/workflows/release-backports.yaml
@@ -58,7 +58,7 @@ jobs:
           fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: "27.3.4.1"
+          otp-version: "27.3.4.10"
           elixir-version: "1.17.3"
           version-type: strict
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.github/workflows/release-backports.yaml
+++ b/.github/workflows/release-backports.yaml
@@ -52,7 +52,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: "27.3.4.1"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2.75.23
+        with:
+          tool: just@1.50.0
+          fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: "27.3.4.1"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           fallback: none
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: "27.3.4.1"
+          otp-version: "27.3.4.10"
           elixir-version: "1.17.3"
           version-type: strict
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 zig 0.15.2
 elixir 1.17.3-otp-27
-erlang 27.3.4.1
+erlang 27.3.4.10


### PR DESCRIPTION
The `setup-just` action is failing to get `casey/just`, and the setup-beam action no longer returns the otp version we used to pin in their query to the hex builds

Moving to a different action to install just, and bumping the patch version of otp seems to fix both