### PR TITLE
feat(expert): support folding ranges

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -536,6 +536,9 @@ defmodule Expert do
       %Requests.TextDocumentDocumentSymbol{} ->
         {:ok, Handlers.DocumentSymbols}
 
+      %Requests.TextDocumentFoldingRange{} ->
+        {:ok, Handlers.CodeFolding}
+
       %GenLSP.Requests.WorkspaceSymbol{} ->
         {:ok, Handlers.WorkspaceSymbol}
 

--- a/apps/expert/lib/expert/provider/handlers/code_folding.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_folding.ex
@@ -1,0 +1,125 @@
+defmodule Expert.Provider.Handlers.CodeFolding do
+  @behaviour Expert.Provider.Handler
+
+  alias Expert.Document.Context
+  alias Forge.Ast
+  alias Forge.Document
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  @impl Expert.Provider.Handler
+  def handle(
+        %Requests.TextDocumentFoldingRange{params: %Structures.FoldingRangeParams{}},
+        %Context{} = context
+      ) do
+    %Context{document: document} = context
+    {:ok, folding_ranges(document)}
+  end
+
+  defp folding_ranges(%Document{} = document) do
+    case Ast.from(document) do
+      {:ok, ast, _comments} ->
+        ranges_from(ast)
+
+      {:error, ast, _parse_error, _comments} when is_tuple(ast) ->
+        ranges_from(ast)
+
+      _ ->
+        []
+    end
+  end
+
+  defp ranges_from(ast) do
+    block_ranges(ast) ++ string_ranges(ast)
+  end
+
+  defp block_ranges(ast) do
+    {_, ranges} =
+      Macro.prewalk(ast, [], fn
+        {_form, meta, _args} = node, acc when is_list(meta) ->
+          {node, collect_block(meta, acc)}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    ranges
+    |> Enum.map(&to_block_folding_range/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp collect_block(meta, acc) do
+    do_line = meta_line(meta, :do)
+    end_line = meta_line(meta, :end)
+
+    if is_integer(do_line) and is_integer(end_line) do
+      [{do_line, end_line} | acc]
+    else
+      acc
+    end
+  end
+
+  defp meta_line(meta, key) do
+    case Keyword.get(meta, key) do
+      keyword when is_list(keyword) -> Keyword.get(keyword, :line)
+      _ -> nil
+    end
+  end
+
+  defp to_block_folding_range({do_line, end_line}) do
+    start_line = do_line - 1
+    last_line = end_line - 2
+
+    if last_line > start_line do
+      %Structures.FoldingRange{start_line: start_line, end_line: last_line}
+    end
+  end
+
+  defp string_ranges(ast) do
+    {_, ranges} =
+      Macro.prewalk(ast, [], fn
+        {:__block__, meta, [str]} = node, acc when is_binary(str) and is_list(meta) ->
+          {node, collect_string(meta, str, acc)}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.reject(ranges, &is_nil/1)
+  end
+
+  defp collect_string(meta, str, acc) do
+    start_line = Keyword.get(meta, :line)
+    delimiter = Keyword.get(meta, :delimiter)
+    newlines = count_newlines(str)
+
+    cond do
+      not is_integer(start_line) or newlines < 1 ->
+        acc
+
+      delimiter == "\"\"\"" ->
+        prepend_string_range(start_line, start_line + newlines + 1, acc)
+
+      delimiter == "\"" ->
+        prepend_string_range(start_line, start_line + newlines, acc)
+
+      true ->
+        acc
+    end
+  end
+
+  defp prepend_string_range(open_line, close_line, acc) do
+    start_line = open_line - 1
+    end_line = close_line - 2
+
+    if end_line > start_line do
+      [%Structures.FoldingRange{start_line: start_line, end_line: end_line} | acc]
+    else
+      acc
+    end
+  end
+
+  defp count_newlines(str) do
+    str |> :binary.matches("\n") |> length()
+  end
+end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -350,6 +350,7 @@ defmodule Expert.State do
         document_formatting_provider: true,
         document_symbol_provider: true,
         execute_command_provider: command_options,
+        folding_range_provider: true,
         hover_provider: true,
         references_provider: true,
         text_document_sync: sync_options,

--- a/apps/expert/test/expert/provider/handlers/code_folding_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_folding_test.exs
@@ -1,0 +1,182 @@
+defmodule Expert.Provider.Handlers.CodeFoldingTest do
+  use ExUnit.Case, async: true
+
+  alias Expert.Document.Context
+  alias Expert.Provider.Handlers.CodeFolding
+  alias Forge.Document
+  alias GenLSP.Requests.TextDocumentFoldingRange
+  alias GenLSP.Structures.FoldingRange
+  alias GenLSP.Structures.FoldingRangeParams
+  alias GenLSP.Structures.TextDocumentIdentifier
+
+  defp fold(source) do
+    uri = "file:///fold_test.ex"
+    document = Document.new(uri, source, 1)
+
+    request = %TextDocumentFoldingRange{
+      id: 1,
+      params: %FoldingRangeParams{
+        text_document: %TextDocumentIdentifier{uri: uri}
+      }
+    }
+
+    context = %Context{uri: uri, document: document, project: nil}
+
+    {:ok, ranges} = CodeFolding.handle(request, context)
+    Enum.sort_by(ranges, &{&1.start_line, &1.end_line})
+  end
+
+  defp range(start_line, end_line) do
+    %FoldingRange{start_line: start_line, end_line: end_line}
+  end
+
+  describe "do/end blocks" do
+    test "folds a multi-line module" do
+      source = """
+      defmodule Foo do
+        :ok
+      end
+      """
+
+      assert fold(source) == [range(0, 1)]
+    end
+
+    test "folds nested function inside a module" do
+      source = """
+      defmodule Foo do
+        def bar do
+          :ok
+        end
+      end
+      """
+
+      assert fold(source) == [range(0, 3), range(1, 2)]
+    end
+
+    test "folds if/else, case, with, and other do/end constructs" do
+      source = """
+      defmodule Foo do
+        def bar(x) do
+          if x do
+            :a
+          else
+            :b
+          end
+
+          case x do
+            :a -> :ok
+            _ -> :err
+          end
+
+          with {:ok, v} <- {:ok, x} do
+            v
+          end
+        end
+      end
+      """
+
+      ranges = fold(source)
+
+      assert range(0, 16) in ranges
+      assert range(1, 15) in ranges
+      assert range(2, 5) in ranges
+      assert range(8, 10) in ranges
+      assert range(13, 14) in ranges
+    end
+
+    test "does not fold a single-line do/end" do
+      assert fold("def foo, do: :ok\n") == []
+    end
+
+    test "does not fold an empty body" do
+      source = """
+      defmodule Foo do
+      end
+      """
+
+      assert fold(source) == []
+    end
+  end
+
+  describe "heredocs" do
+    test "folds a multi-line @moduledoc heredoc" do
+      source = """
+      defmodule Foo do
+        @moduledoc \"\"\"
+        Line one.
+        Line two.
+        \"\"\"
+      end
+      """
+
+      ranges = fold(source)
+
+      assert range(0, 4) in ranges
+      assert range(1, 3) in ranges
+    end
+
+    test "folds a multi-line @doc heredoc" do
+      source = """
+      defmodule Foo do
+        @doc \"\"\"
+        Function doc.
+        More content.
+        \"\"\"
+        def bar, do: :ok
+      end
+      """
+
+      assert range(1, 3) in fold(source)
+    end
+
+    test "folds an inline heredoc string" do
+      source = """
+      defmodule Foo do
+        def bar do
+          \"\"\"
+          a
+          b
+          \"\"\"
+        end
+      end
+      """
+
+      assert range(2, 4) in fold(source)
+    end
+
+    test "does not fold a 2-line heredoc with empty content" do
+      source = """
+      defmodule Foo do
+        @moduledoc \"\"\"
+        \"\"\"
+      end
+      """
+
+      ranges = fold(source)
+
+      refute Enum.any?(ranges, fn r -> r.start_line == 1 end)
+    end
+  end
+
+  describe "multi-line plain strings" do
+    test "folds a string spanning multiple lines" do
+      source = """
+      defmodule Foo do
+        def bar do
+          "line1
+          line2
+          line3"
+        end
+      end
+      """
+
+      assert range(2, 3) in fold(source)
+    end
+  end
+
+  describe "invalid input" do
+    test "returns an empty list for syntactically invalid documents" do
+      assert fold("defmodule Foo do def bar(\n") == []
+    end
+  end
+end


### PR DESCRIPTION
While attempting to address https://github.com/expert-lsp/vscode-expert/issues/45 I realized that while we can fix the particular issue that was reported, we can't really have reliable folding based on what VSCode offers (which is basically regexes to determine start of the fold and end of the fold). For example, this will always be problematic:

```elixir
def foo do
  """
  abc
  """
  :foo
end
```

In this example there's no way to tell if `"""` is opening or closing, using just regexes.

That lead me to investigate [foldingRange request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange) in LSP spec. I realized that it's much more fitting for Elixir, probably, and decided to try to implement it.

It works pretty well in my tests and VSCode automatically picks this up when the server advertises its capabilities of defining the ranges. I haven't checked other editors yet though.