### PR TITLE
fix: don't index build paths

### DIFF
--- a/apps/engine/lib/engine/mix.ex
+++ b/apps/engine/lib/engine/mix.ex
@@ -6,61 +6,111 @@ defmodule Engine.Mix do
   end
 
   def in_project(fun) do
-    if Engine.project_node?() do
-      in_project(Engine.get_project(), fun)
-    else
-      {:error, :not_project_node}
+    case Engine.get_project() do
+      %Project{} = project ->
+        in_project(project, fun)
+
+      _ ->
+        {:error, :not_project_node}
     end
   end
 
-  def in_project(%Project{} = project, fun) do
-    # Locking on the build make sure we don't get a conflict on the mix.exs being
-    # already defined
+  def in_project(%Project{kind: :bare}, fun) do
+    run_and_normalize(fn -> fun.(nil) end)
+  end
 
-    old_cwd = File.cwd!()
-    project_root = Project.root_path(project)
-    build_path = Project.versioned_build_path(project)
-    app = Project.atom_name(project)
-    file = Project.mix_exs_path(project)
-
-    # We bypass Mix.Project.in_project/4 so we can release
-    # Engine.Mix.StackMutation between push and fun, allowing other callers
-    # (Format, Quoted.prepare_compile) to mutate the stack while fun runs.
-
+  def in_project(%Project{kind: :mix} = project, fun) do
     with_lock(fn ->
-      try do
-        File.cd!(project_root)
+      run_and_normalize(fn ->
+        project
+        |> ensure_project_loaded()
+        |> in_loaded_project(fun)
+      end)
+    end)
+  end
 
-        Engine.with_lock(Engine.Mix.StackMutation, fn ->
-          Mix.ProjectStack.post_config(prune_code_paths: false, build_path: build_path)
-          Mix.Project.push(project.project_module, file, app)
-        end)
+  defp ensure_project_loaded(%Project{kind: :mix, project_module: nil} = project) do
+    load_project_from_mix_exs(project)
+  end
 
-        try do
-          fun.(project.project_module)
-        rescue
-          ex ->
-            blamed = Exception.blame(:error, ex, __STACKTRACE__)
-            {:error, {:exception, blamed, __STACKTRACE__}}
-        else
-          result ->
-            case result do
-              error when is_tuple(error) and elem(error, 0) == :error ->
-                error
+  defp ensure_project_loaded(%Project{} = project), do: project
 
-              ok when is_tuple(ok) and elem(ok, 0) == :ok ->
-                ok
+  defp load_project_from_mix_exs(%Project{} = project) do
+    build_path = Project.versioned_build_path(project)
+    mix_exs_dir = project |> Project.mix_exs_path() |> Path.dirname()
 
-              other ->
-                {:ok, other}
-            end
-        after
-          Engine.with_lock(Engine.Mix.StackMutation, fn -> Mix.Project.pop() end)
+    # Mix.Project.in_project/4 loads and caches the mix.exs module, but also
+    # mutates ProjectStack internally. Keep that mutation locked and run the
+    # caller callback later through in_loaded_project/2.
+    Engine.with_lock(Engine.Mix.StackMutation, fn ->
+      Mix.Project.in_project(
+        Project.atom_name(project),
+        mix_exs_dir,
+        [prune_code_paths: false, build_path: build_path],
+        fn project_module ->
+          Project.set_project_module(project, project_module)
         end
+      )
+    end)
+  end
+
+  defp in_loaded_project(%Project{} = project, fun) do
+    File.cd!(Project.root_path(project), fn ->
+      # Push/pop mutate Mix.ProjectStack; the caller runs outside that lock so
+      # other Mix helpers can safely mutate the stack while this project is active.
+      push_project(project)
+
+      try do
+        fun.(project.project_module)
       after
-        File.cd!(old_cwd)
+        pop_project()
       end
     end)
+  end
+
+  defp push_project(%Project{} = project) do
+    Engine.with_lock(Engine.Mix.StackMutation, fn ->
+      Mix.ProjectStack.post_config(
+        prune_code_paths: false,
+        build_path: Project.versioned_build_path(project)
+      )
+
+      Mix.Project.push(
+        project.project_module,
+        Project.mix_exs_path(project),
+        Project.atom_name(project)
+      )
+    end)
+  end
+
+  defp pop_project do
+    Engine.with_lock(Engine.Mix.StackMutation, fn -> Mix.Project.pop() end)
+  end
+
+  defp run_and_normalize(fun) do
+    fun.()
+    |> normalize_result()
+  rescue
+    ex ->
+      exception_error(ex, __STACKTRACE__)
+  end
+
+  defp normalize_result(result) do
+    case result do
+      error when is_tuple(error) and elem(error, 0) == :error ->
+        error
+
+      ok when is_tuple(ok) and elem(ok, 0) == :ok ->
+        ok
+
+      other ->
+        {:ok, other}
+    end
+  end
+
+  defp exception_error(exception, stacktrace) do
+    blamed = Exception.blame(:error, exception, stacktrace)
+    {:error, {:exception, blamed, stacktrace}}
   end
 
   defp with_lock(fun) do

--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -28,12 +28,12 @@ defmodule Engine.Search.Indexer do
     :ok = ApplicationCache.clear()
 
     ProcessCache.with_cleanup do
-      deps_dir = deps_dir(project)
+      dependency_roots = dependency_index_roots(project)
 
       entries =
         project
         |> indexable_files()
-        |> async_chunks(&index_path(&1, deps_dir))
+        |> async_chunks(&index_path(&1, dependency_roots))
 
       {:ok, entries}
     end
@@ -71,7 +71,9 @@ defmodule Engine.Search.Indexer do
     new_paths = MapSet.difference(project_files, previously_indexed_paths)
 
     {paths_to_examine, paths_to_delete} =
-      Enum.split_with(path_to_ids, fn {path, _} -> File.regular?(path) end)
+      Enum.split_with(path_to_ids, fn {path, _id} ->
+        MapSet.member?(project_files, path) and File.regular?(path)
+      end)
 
     changed_paths =
       for {path, id} <- paths_to_examine,
@@ -82,19 +84,20 @@ defmodule Engine.Search.Indexer do
     paths_to_delete = Enum.map(paths_to_delete, &elem(&1, 0))
 
     paths_to_reindex = changed_paths ++ Enum.to_list(new_paths)
+    dependency_roots = dependency_index_roots(project)
 
-    entries = async_chunks(paths_to_reindex, &index_path(&1, deps_dir(project)))
+    entries = async_chunks(paths_to_reindex, &index_path(&1, dependency_roots))
 
     {:ok, entries, paths_to_delete}
   end
 
-  defp index_path(path, deps_dir) do
-    in_deps? = is_binary(deps_dir) and Forge.Path.contains?(path, deps_dir)
-    extractors = if in_deps?, do: @deps_extractors
+  defp index_path(path, dependency_roots) do
+    in_dependency? = contained_in_any?(path, dependency_roots)
+    extractors = if in_dependency?, do: @deps_extractors
 
     with {:ok, contents} <- File.read(path),
          {:ok, entries} <- Indexer.Source.index(path, contents, extractors) do
-      if in_deps? do
+      if in_dependency? do
         Enum.filter(entries, &(&1.subtype == :definition))
       else
         entries
@@ -204,36 +207,153 @@ defmodule Engine.Search.Indexer do
   end
 
   def indexable_files(%Project{} = project) do
-    root_dir = Project.root_path(project)
-    build_dir = build_dir(project)
+    roots = index_roots(project)
+    excluded_roots = build_exclusion_roots(project, roots)
 
-    [root_dir, "**", @indexable_extensions]
-    |> Forge.Path.glob()
-    |> Enum.reject(&Forge.Path.contains?(&1, build_dir))
+    roots
+    |> Enum.flat_map(&indexable_files_in/1)
+    |> Enum.uniq()
+    |> reject_paths_under(excluded_roots)
   end
+
+  defp indexable_files_in(root) do
+    Forge.Path.glob([root, "**", @indexable_extensions])
+  end
+
+  defp index_roots(%Project{} = project) do
+    [Project.root_path(project) | dependency_index_roots(project)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp reject_paths_under(paths, []), do: paths
+
+  defp reject_paths_under(paths, roots) do
+    Enum.reject(paths, &contained_in_any?(&1, roots))
+  end
+
+  defp contained_in_any?(path, roots) do
+    Enum.any?(roots, &Forge.Path.contains?(path, &1))
+  end
+
+  defp build_exclusion_roots(%Project{kind: :mix} = project, index_roots) do
+    {runtime_build_path, configured_build_root} = build_paths(project)
+    relative_build_root = Path.relative_to(configured_build_root, Project.root_path(project))
+
+    dependency_build_roots = Enum.map(index_roots, &Path.expand(relative_build_root, &1))
+
+    [runtime_build_path, configured_build_root | dependency_build_roots]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp build_exclusion_roots(%Project{}, _index_roots), do: []
 
   # stat(path) is here for testing so it can be mocked
   defp stat(path) do
     File.stat(path)
   end
 
-  defp deps_dir(%Project{kind: :mix}) do
-    case Engine.Mix.in_project(&Mix.Project.deps_path/0) do
+  defp dependency_index_roots(%Project{kind: :mix} = project) do
+    [deps_path(project) | path_dependency_source_roots(project)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp dependency_index_roots(%Project{}), do: []
+
+  defp deps_path(%Project{kind: :mix} = project) do
+    case Engine.Mix.in_project(project, fn _ -> Mix.Project.deps_path() end) do
       {:ok, path} -> path
       _ -> Mix.Project.deps_path()
     end
   end
 
-  defp deps_dir(%Project{}), do: nil
-
-  defp build_dir(%Project{kind: :mix}) do
-    case Engine.Mix.in_project(&Mix.Project.build_path/0) do
-      {:ok, path} -> path
-      _ -> Mix.Project.build_path()
+  defp path_dependency_source_roots(%Project{} = project) do
+    case Engine.Mix.in_project(project, fn _ ->
+           path_dependency_paths(Mix.Project.config(), Mix.env())
+         end) do
+      {:ok, roots} -> Enum.flat_map(roots, &mix_source_roots/1)
+      _ -> []
     end
   end
 
-  defp build_dir(%Project{} = project) do
-    Path.join(Project.root_path(project), "_build")
+  defp path_dependency_paths(config, env) do
+    config
+    |> Keyword.get(:deps, [])
+    |> Enum.flat_map(&path_dependency_path(&1, env))
   end
+
+  defp path_dependency_path({_app, opts}, env) when is_list(opts) do
+    path_dependency_path_from_opts(opts, env)
+  end
+
+  defp path_dependency_path({_app, _requirement, opts}, env) when is_list(opts) do
+    path_dependency_path_from_opts(opts, env)
+  end
+
+  defp path_dependency_path(_dep, _env), do: []
+
+  defp path_dependency_path_from_opts(opts, env) do
+    path = Keyword.get(opts, :path)
+    only_envs = opts |> Keyword.get(:only) |> List.wrap()
+
+    if is_binary(path) and dependency_active_in_env?(only_envs, env) do
+      [Path.expand(path, File.cwd!())]
+    else
+      []
+    end
+  end
+
+  defp dependency_active_in_env?([], _env), do: true
+  defp dependency_active_in_env?(envs, env), do: env in envs
+
+  defp mix_source_roots(root) do
+    project = root |> Forge.Document.Path.to_uri() |> Project.new()
+
+    source_paths =
+      case Engine.Mix.in_project(project, fn _ ->
+             Keyword.get(Mix.Project.config(), :elixirc_paths, ["lib"])
+           end) do
+        {:ok, paths} -> paths
+        _ -> ["lib"]
+      end
+
+    Enum.map(source_paths, &Path.expand(&1, root))
+  end
+
+  defp build_paths(%Project{kind: :mix} = project) do
+    case Engine.Mix.in_project(project, fn project_module ->
+           {Mix.Project.build_path(), configured_build_root(project, project_module.project())}
+         end) do
+      {:ok, paths} -> paths
+      _ -> {Mix.Project.build_path(), configured_build_root(project, [])}
+    end
+  end
+
+  defp configured_build_root(%Project{} = project, config) do
+    config = Keyword.put_new(config, :build_per_environment, true)
+
+    with_deleted_env("MIX_BUILD_PATH", fn ->
+      File.cd!(Project.root_path(project), fn ->
+        config
+        |> Mix.Project.build_path()
+        |> Path.dirname()
+      end)
+    end)
+  end
+
+  defp with_deleted_env(name, fun) do
+    original = System.fetch_env(name)
+    System.delete_env(name)
+
+    try do
+      fun.()
+    after
+      restore_env(name, original)
+    end
+  end
+
+  defp restore_env(name, {:ok, value}), do: System.put_env(name, value)
+  defp restore_env(name, :error), do: System.delete_env(name)
 end

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -43,6 +43,46 @@ defmodule Engine.Search.IndexerTest do
     {:ok, project: project}
   end
 
+  defp with_env(name, value) do
+    original = System.fetch_env(name)
+    System.put_env(name, value)
+
+    on_exit(fn -> restore_env(name, original) end)
+  end
+
+  defp restore_env(name, {:ok, value}), do: System.put_env(name, value)
+  defp restore_env(name, :error), do: System.delete_env(name)
+
+  defp write_file!(path, contents) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+    path
+  end
+
+  defp write_mix_project!(root, module_name, project_config) do
+    write_file!(Path.join(root, "mix.exs"), """
+    defmodule #{module_name} do
+      use Mix.Project
+
+      def project do
+        #{project_config}
+      end
+    end
+    """)
+  end
+
+  defp mix_build_file!(root, relative_path, config \\ []) do
+    build_root =
+      File.cd!(root, fn ->
+        config
+        |> Keyword.put_new(:build_per_environment, true)
+        |> Mix.Project.build_path()
+        |> Path.dirname()
+      end)
+
+    Path.join([build_root | List.wrap(relative_path)])
+  end
+
   describe "create_index/1" do
     test "returns a list of entries", %{project: project} do
       assert {:ok, entry_stream} = Indexer.create_index(project)
@@ -66,6 +106,95 @@ defmodule Engine.Search.IndexerTest do
 
       assert {:ok, entries} = Indexer.create_index(bare_project)
       assert Enum.any?(entries, &(&1.path == Path.join(bare_root, "bare_file.ex")))
+    end
+
+    test "does not index project-local default build files", %{project: project} do
+      with_env(
+        "MIX_BUILD_PATH",
+        Path.join([Project.root_path(project), ".expert", "build", "dev"])
+      )
+
+      build_file = mix_build_file!(Project.root_path(project), "generated.ex")
+
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      on_exit(fn -> File.rm_rf(Path.dirname(build_file)) end)
+
+      refute build_file in Indexer.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "does not index files under a configured build path", %{tmp_dir: tmp_dir} do
+      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = mix_build_file!(tmp_dir, "generated.ex", build_path: "custom_build")
+
+      write_mix_project!(
+        tmp_dir,
+        "ConfiguredBuildPathIndexerTest.MixProject",
+        ~s([app: :configured_build_path_indexer_test, version: "0.1.0", build_path: "custom_build"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert source_file in Indexer.indexable_files(project)
+      refute build_file in Indexer.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "does not index files under MIX_BUILD_ROOT", %{tmp_dir: tmp_dir} do
+      build_root = Path.join(tmp_dir, "custom_build_root")
+      with_env("MIX_BUILD_ROOT", build_root)
+      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = Path.join(build_root, "generated.ex")
+
+      write_mix_project!(
+        tmp_dir,
+        "MixBuildRootIndexerTest.MixProject",
+        ~s([app: :mix_build_root_indexer_test, version: "0.1.0"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert source_file in Indexer.indexable_files(project)
+      refute build_file in Indexer.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "indexes active path dependency sources", %{tmp_dir: tmp_dir} do
+      app_root = Path.join(tmp_dir, "app")
+      dep_root = Path.join(tmp_dir, "dep")
+      app_file = Path.join([app_root, "lib", "app_module.ex"])
+      dep_file = Path.join([dep_root, "lib", "dep_module.ex"])
+      dep_non_source_file = Path.join([dep_root, "generated.ex"])
+
+      write_mix_project!(
+        app_root,
+        "PathDependencyIndexerTest.MixProject",
+        ~s([app: :path_dependency_indexer_test, version: "0.1.0", deps: [{:dep, path: "../dep"}]])
+      )
+
+      write_file!(app_file, "defmodule AppModule do end")
+      write_file!(dep_file, "defmodule DepModule do end")
+      write_file!(dep_non_source_file, "defmodule GeneratedDependencyFile do end")
+
+      project = app_root |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert dep_file in Indexer.indexable_files(project)
+      refute dep_non_source_file in Indexer.indexable_files(project)
+
+      assert {:ok, entries} = Indexer.create_index(project)
+      assert Enum.any?(entries, &(&1.subject == DepModule and &1.subtype == :definition))
+      refute Enum.any?(entries, &(&1.subject == GeneratedDependencyFile))
     end
   end
 
@@ -95,6 +224,33 @@ defmodule Engine.Search.IndexerTest do
     entries = Enum.to_list(entry_stream)
     FakeBackend.set_entries(entries)
     {:ok, entries: entries}
+  end
+
+  describe "update_index/2 removes paths that became non-indexable" do
+    @tag :tmp_dir
+    test "deletes previously indexed configured build files even when they still exist", %{
+      tmp_dir: tmp_dir
+    } do
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = mix_build_file!(tmp_dir, "stale.ex", build_path: "custom_build")
+
+      write_mix_project!(
+        tmp_dir,
+        "StaleConfiguredBuildPathIndexerTest.MixProject",
+        ~s([app: :stale_configured_build_path_indexer_test, version: "0.1.0", build_path: "custom_build"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule StaleBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+      assert {:ok, entries} = Indexer.create_index(project)
+
+      FakeBackend.set_entries([%Entry{id: 1, path: build_file} | entries])
+
+      assert {:ok, entry_stream, [^build_file]} = Indexer.update_index(project, FakeBackend)
+      assert [] = Enum.to_list(entry_stream)
+    end
   end
 
   describe "update_index/2 encounters a new file" do


### PR DESCRIPTION
This drastically improves indexing times for expert itself for me(it normally takes 10-15 seconds)
<img width="440" height="79" alt="Screenshot 2026-04-30 at 3 57 23 AM" src="https://github.com/user-attachments/assets/490268f8-c8ed-4915-be6a-b7672653f418" />

I found two problems that thix fixes:
- `_build` directories were being indexed instead of source files only because we only excluded the `.expert` builds, not the user builds too. The `MIX_BUILD_PATH` set in `bootstrap.ex` took priority over anything else when determining the build path, which was wrong for the indexer in particular
- path dependencies weren't properly indexed with the fix for the above point, so workspace symbols wouldn't provide complete results

It's important to note that the reason this has such an impact for expect itself is because we were indexing the `priv/engine_source` directory with all its dependencies inside the `_build` directories and we weren't using them for anything. I do not expect this to have a big impact on other projects.