### PR TITLE
fix(engine): add project stack lock

### DIFF
--- a/apps/engine/lib/engine/build/document/compilers/quoted.ex
+++ b/apps/engine/lib/engine/build/document/compilers/quoted.ex
@@ -100,7 +100,9 @@ defmodule Engine.Build.Document.Compilers.Quoted do
       # `use Mix.Project` will blow up if we add the same project to the project stack
       # twice. Preemptively popping it prevents that error from occurring.
       if Path.basename(path) == "mix.exs" do
-        Mix.ProjectStack.pop()
+        Engine.with_lock(Engine.Mix.StackMutation, fn ->
+          Mix.ProjectStack.pop()
+        end)
       end
 
       Mix.Task.run(:loadconfig)

--- a/apps/engine/lib/engine/code_mod/format.ex
+++ b/apps/engine/lib/engine/code_mod/format.ex
@@ -246,11 +246,13 @@ defmodule Engine.CodeMod.Format do
     deps_paths = Engine.deps_paths()
 
     formatter_and_opts =
-      Mix.Tasks.Future.Format.formatter_for_file(file_path,
-        root: root_path,
-        deps_paths: deps_paths,
-        plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
-      )
+      Engine.with_lock(Engine.Mix.StackMutation, fn ->
+        Mix.Tasks.Future.Format.formatter_for_file(file_path,
+          root: root_path,
+          deps_paths: deps_paths,
+          plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
+        )
+      end)
 
     {:ok, formatter_and_opts}
   rescue

--- a/apps/engine/lib/engine/mix.ex
+++ b/apps/engine/lib/engine/mix.ex
@@ -18,33 +18,45 @@ defmodule Engine.Mix do
     # already defined
 
     old_cwd = File.cwd!()
+    project_root = Project.root_path(project)
+    build_path = Project.versioned_build_path(project)
+    app = Project.atom_name(project)
+    file = Project.mix_exs_path(project)
+
+    # We bypass Mix.Project.in_project/4 so we can release
+    # Engine.Mix.StackMutation between push and fun, allowing other callers
+    # (Format, Quoted.prepare_compile) to mutate the stack while fun runs.
 
     with_lock(fn ->
       try do
-        Mix.ProjectStack.post_config(prune_code_paths: false)
+        File.cd!(project_root)
 
-        build_path = Project.versioned_build_path(project)
-        project_root = Project.root_path(project)
+        Engine.with_lock(Engine.Mix.StackMutation, fn ->
+          Mix.ProjectStack.post_config(prune_code_paths: false, build_path: build_path)
+          Mix.Project.push(project.project_module, file, app)
+        end)
 
-        project
-        |> Project.atom_name()
-        |> Mix.Project.in_project(project_root, [build_path: build_path], fun)
-      rescue
-        ex ->
-          blamed = Exception.blame(:error, ex, __STACKTRACE__)
-          {:error, {:exception, blamed, __STACKTRACE__}}
-      else
-        result ->
-          case result do
-            error when is_tuple(error) and elem(error, 0) == :error ->
-              error
+        try do
+          fun.(project.project_module)
+        rescue
+          ex ->
+            blamed = Exception.blame(:error, ex, __STACKTRACE__)
+            {:error, {:exception, blamed, __STACKTRACE__}}
+        else
+          result ->
+            case result do
+              error when is_tuple(error) and elem(error, 0) == :error ->
+                error
 
-            ok when is_tuple(ok) and elem(ok, 0) == :ok ->
-              ok
+              ok when is_tuple(ok) and elem(ok, 0) == :ok ->
+                ok
 
-            other ->
-              {:ok, other}
-          end
+              other ->
+                {:ok, other}
+            end
+        after
+          Engine.with_lock(Engine.Mix.StackMutation, fn -> Mix.Project.pop() end)
+        end
       after
         File.cd!(old_cwd)
       end


### PR DESCRIPTION
My attempt to address #477 - adds additional lock around places that mutate `ProjectStack`, so they cannot step on each others feet. I'm not 100% sure about this, as I don't have a reproduction example for the bug reported. But the idea is based on Jose's comment in the issue.