### PR TITLE
feat(engine): expand engine builder error output

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -590,9 +590,14 @@ defmodule Expert do
   defp node_initialization_message(name, reason) do
     case reason do
       # Build script failed (exit status) or max retry attempts reached
-      {:error, message, last_line} when is_binary(message) and is_binary(last_line) ->
-        first_line = last_line |> String.split("\n") |> hd() |> String.trim()
-        "Engine build failed for #{name}.\n#{message}\n#{first_line}"
+      {:error, message, output} when is_binary(message) and is_binary(output) ->
+        details = output |> String.trim
+
+        if details == "" do
+          "Engine build failed for #{name}.\n#{message}"
+        else
+          "Engine build failed for #{name}.\n#{message}\n\n#{details}"
+        end
 
       # NOTE: ~c"could not compile dependency :elixir_sense..."
       {:error, :normal, message} ->

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -591,7 +591,7 @@ defmodule Expert do
     case reason do
       # Build script failed (exit status) or max retry attempts reached
       {:error, message, output} when is_binary(message) and is_binary(output) ->
-        details = output |> String.trim
+        details = output |> String.trim()
 
         if details == "" do
           "Engine build failed for #{name}.\n#{message}"

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -14,8 +14,7 @@ defmodule Expert.EngineNode.Builder do
 
   # Keep the most recent N non-empty output lines from the build subprocess.
   # On failure we forward this buffer to the user so the actual error message
-  # (e.g. "** (Mix.Error) httpc request failed with: ...") is visible instead
-  # of just the bottom of the stacktrace.
+  # is visible instead of just the bottom of the stacktrace.
   @max_output_lines 50
 
   @max_attempts 1

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -9,8 +9,14 @@ defmodule Expert.EngineNode.Builder do
   require Logger
 
   defmodule State do
-    defstruct [:project, :last_line, :from, :port, :mix_home, :buffer, attempts: 0]
+    defstruct [:project, :from, :port, :mix_home, :buffer, output_lines: [], attempts: 0]
   end
+
+  # Keep the most recent N non-empty output lines from the build subprocess.
+  # On failure we forward this buffer to the user so the actual error message
+  # (e.g. "** (Mix.Error) httpc request failed with: ...") is visible instead
+  # of just the bottom of the stacktrace.
+  @max_output_lines 50
 
   @max_attempts 1
 
@@ -26,7 +32,7 @@ defmodule Expert.EngineNode.Builder do
 
   @impl GenServer
   def init(project) do
-    {:ok, %State{project: project, last_line: "", buffer: ""}}
+    {:ok, %State{project: project, buffer: ""}}
   end
 
   @impl GenServer
@@ -57,7 +63,7 @@ defmodule Expert.EngineNode.Builder do
       if line == "" do
         state
       else
-        %State{state | last_line: line}
+        %State{state | output_lines: [line | state.output_lines]}
       end
 
     case parse_engine_meta(line) do
@@ -90,7 +96,7 @@ defmodule Expert.EngineNode.Builder do
 
     GenServer.reply(
       state.from,
-      {:error, "Build script exited with status: #{status}", state.last_line}
+      {:error, "Build script exited with status: #{status}", captured_output(state)}
     )
 
     {:stop, :normal, state}
@@ -101,7 +107,7 @@ defmodule Expert.EngineNode.Builder do
       project: state.project
     )
 
-    GenServer.reply(state.from, {:error, reason, state.last_line})
+    GenServer.reply(state.from, {:error, reason, captured_output(state)})
     {:stop, :normal, state}
   end
 
@@ -250,5 +256,16 @@ defmodule Expert.EngineNode.Builder do
   ]
   defp detect_deps_error(message) when is_binary(message) do
     Enum.any?(@deps_error_patterns, &String.contains?(message, &1))
+  end
+
+  defp captured_output(%State{output_lines: lines}) do
+    total = length(lines)
+    body = lines |> Enum.take(@max_output_lines) |> Enum.reverse() |> Enum.join("\n")
+
+    if total > @max_output_lines do
+      "...(#{total - @max_output_lines} earlier line(s) omitted)\n#{body}"
+    else
+      body
+    end
   end
 end

--- a/apps/expert/test/expert/engine_node/builder_test.exs
+++ b/apps/expert/test/expert/engine_node/builder_test.exs
@@ -125,6 +125,98 @@ defmodule Expert.EngineNode.BuilderTest do
     assert paths == Forge.Path.glob([engine_path, "lib/**/ebin"])
   end
 
+  test "forwards captured output when the build script exits non-zero", %{project: project} do
+    test_pid = self()
+
+    patch(Builder, :start_build, fn _project, _from, _opts ->
+      send(test_pid, :build_started)
+      {:ok, :fake_port}
+    end)
+
+    {:ok, builder_pid} = Builder.start_link(project)
+    task = Task.async(fn -> GenServer.call(builder_pid, :build, :infinity) end)
+
+    assert_receive :build_started, 1_000
+
+    output = [
+      "** (Mix.Error) httpc request failed with: {:failed_connect, ...}.",
+      "",
+      "Could not install Rebar because Mix could not download metadata at https://builds.hex.pm/installs/rebar.csv.",
+      "",
+      "    (mix 1.17.3) lib/mix.ex:647: Mix.raise/2",
+      "    .../priv/build_engine.exs:31: (file)"
+    ]
+
+    Enum.each(output, fn line ->
+      send(builder_pid, {nil, {:data, {:eol, line}}})
+    end)
+
+    send(builder_pid, {nil, {:exit_status, 1}})
+
+    assert {:error, "Build script exited with status: 1", captured} = Task.await(task, 5_000)
+    # The full multi-line output is forwarded so callers see the actual error
+    # instead of just the bottom of the stacktrace.
+    assert captured =~ "** (Mix.Error) httpc request failed with"
+    assert captured =~ "Could not install Rebar because Mix could not download metadata"
+    assert captured =~ "build_engine.exs:31: (file)"
+  end
+
+  test "forwards captured output when the port crashes", %{project: project} do
+    test_pid = self()
+    fake_port = make_ref()
+
+    patch(Builder, :start_build, fn _project, _from, _opts ->
+      send(test_pid, :build_started)
+      {:ok, fake_port}
+    end)
+
+    {:ok, builder_pid} = Builder.start_link(project)
+    task = Task.async(fn -> GenServer.call(builder_pid, :build, :infinity) end)
+
+    assert_receive :build_started, 1_000
+
+    # Set the port that the GenServer is monitoring so the {:EXIT, port, reason}
+    # clause matches.
+    :sys.replace_state(builder_pid, fn state -> %{state | port: fake_port} end)
+
+    send(builder_pid, {nil, {:data, {:eol, "** (RuntimeError) something went wrong"}}})
+    send(builder_pid, {nil, {:data, {:eol, "    .../build_engine.exs:33: (file)"}}})
+    send(builder_pid, {:EXIT, fake_port, :killed})
+
+    assert {:error, :killed, captured} = Task.await(task, 5_000)
+    assert captured =~ "** (RuntimeError) something went wrong"
+    assert captured =~ "build_engine.exs:33: (file)"
+  end
+
+  test "caps captured output at the configured maximum", %{project: project} do
+    test_pid = self()
+
+    patch(Builder, :start_build, fn _project, _from, _opts ->
+      send(test_pid, :build_started)
+      {:ok, :fake_port}
+    end)
+
+    {:ok, builder_pid} = Builder.start_link(project)
+    task = Task.async(fn -> GenServer.call(builder_pid, :build, :infinity) end)
+
+    assert_receive :build_started, 1_000
+
+    # Send 200 lines (well above the @max_output_lines cap of 50).
+    for n <- 1..200 do
+      send(builder_pid, {nil, {:data, {:eol, "line #{n}"}}})
+    end
+
+    send(builder_pid, {nil, {:exit_status, 1}})
+
+    assert {:error, _msg, captured} = Task.await(task, 5_000)
+    captured_lines = String.split(captured, "\n")
+    # 50 retained body lines preceded by a single marker line indicating omission.
+    assert length(captured_lines) == 51
+    assert List.first(captured_lines) == "...(150 earlier line(s) omitted)"
+    assert Enum.at(captured_lines, 1) == "line 151"
+    assert List.last(captured_lines) == "line 200"
+  end
+
   test "parses engine_meta across chunks", %{project: project} do
     patch(Builder, :start_build, fn _project, _from, _opts ->
       {:ok, :fake_port}

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -122,7 +122,6 @@ defmodule Expert.ExpertTest do
       # No trailing newlines / empty section when there is nothing to show.
       refute String.ends_with?(message, "\n\n")
     end
-
   end
 
   test "logs error when Task.Supervisor.start_child fails during initialization" do

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -66,6 +66,65 @@ defmodule Expert.ExpertTest do
                     }}
   end
 
+  describe "engine build failure messages" do
+    test "include captured build output" do
+      project = Fixtures.project()
+      lsp = initialize_lsp(project)
+
+      output = """
+      ** (Mix.Error) httpc request failed with: {:failed_connect, ...}.
+
+      Could not install Rebar because Mix could not download metadata at https://builds.hex.pm/installs/rebar.csv.
+
+          (mix  1.17.3) lib/mix.ex:647: Mix.raise/2
+          .../priv/build_engine.exs:31: (file)\
+      """
+
+      reason =
+        {:shutdown,
+         {:failed_to_start_child, {Expert.Project.Node, "demo::1"},
+          {:error, "Build script exited with status: 1", output}}}
+
+      assert {:noreply, ^lsp} =
+               Expert.handle_info({:engine_initialized, project, {:error, reason}}, lsp)
+
+      assert_receive {:transport,
+                      %GenLSP.Notifications.WindowShowMessage{
+                        params: %GenLSP.Structures.ShowMessageParams{message: message}
+                      }}
+
+      assert message =~ "Engine build failed for demo::1"
+      assert message =~ "Build script exited with status: 1"
+      # The actual error must be visible to the user, not just the script frame.
+      assert message =~ "** (Mix.Error) httpc request failed with"
+      assert message =~ "Could not install Rebar because Mix could not download metadata"
+    end
+
+    test "omit the details block when captured output is empty" do
+      project = Fixtures.project()
+      lsp = initialize_lsp(project)
+
+      reason =
+        {:shutdown,
+         {:failed_to_start_child, {Expert.Project.Node, "demo::1"},
+          {:error, "Build script exited with status: 1", ""}}}
+
+      assert {:noreply, ^lsp} =
+               Expert.handle_info({:engine_initialized, project, {:error, reason}}, lsp)
+
+      assert_receive {:transport,
+                      %GenLSP.Notifications.WindowShowMessage{
+                        params: %GenLSP.Structures.ShowMessageParams{message: message}
+                      }}
+
+      assert message =~ "Engine build failed for demo::1"
+      assert message =~ "Build script exited with status: 1"
+      # No trailing newlines / empty section when there is nothing to show.
+      refute String.ends_with?(message, "\n\n")
+    end
+
+  end
+
   test "logs error when Task.Supervisor.start_child fails during initialization" do
     project = Fixtures.project()
     lsp = initialize_lsp(project)


### PR DESCRIPTION
builds on #188
This PR expands the last line of the output into the last X lines of the failing build output (I guesstimated 50 lines should cover most cases, may need to be changed). 
I feel like it makes engine errors easier to understand and to debug