### PR TITLE
fix(engine): don't crash in EEx on hover

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/entity.ex
+++ b/apps/engine/lib/engine/code_intelligence/entity.ex
@@ -137,7 +137,8 @@ defmodule Engine.CodeIntelligence.Entity do
     end
   end
 
-  defp resolve({:struct, charlist}, {{start_line, start_col}, end_pos}, analysis, position) do
+  defp resolve({:struct, charlist}, {{start_line, start_col}, end_pos}, analysis, position)
+       when is_list(charlist) do
     # exclude the leading % from the node range so that it can be
     # resolved like a normal module alias
     node_range = {{start_line, start_col + 1}, end_pos}
@@ -146,6 +147,20 @@ defmodule Engine.CodeIntelligence.Entity do
       {:ok, {struct_or_module, struct}, range} -> {:ok, {struct_or_module, struct}, range}
       :error -> {:error, :not_found}
     end
+  end
+
+  # `Code.Fragment.surround_context` wraps a dot-call in `{:struct, ...}` when
+  # there's a `%` (with optional whitespace) before the alias on the same line.
+  # In valid Elixir `%Foo.bar()` isn't a struct, so this only fires from EEx's
+  # `<% Foo.bar() ... %>`. Drop the `:struct` wrapper and resolve as a dot call.
+  defp resolve(
+         {:struct, {:dot, _, _} = dot_context},
+         {{start_line, start_col}, end_pos},
+         analysis,
+         position
+       ) do
+    node_range = {{start_line, start_col + 1}, end_pos}
+    resolve(dot_context, node_range, analysis, position)
   end
 
   defp resolve({:dot, alias_node, fun_chars}, node_range, analysis, position) do

--- a/apps/engine/test/engine/code_intelligence/entity_test.exs
+++ b/apps/engine/test/engine/code_intelligence/entity_test.exs
@@ -1346,6 +1346,27 @@ defmodule Engine.CodeIntelligence.EntityTest do
 
       assert {:ok, {:call, SampleApp, :valid?, 0}, _} = resolve(code)
     end
+
+    test "resolves remote call inside a `cond` block in HEEx" do
+      code = ~q[
+        defmodule MyLiveView do
+          use Phoenix.Component
+
+          def render(assigns) do
+            ~H"""
+            <%= cond do %>
+              <% SampleApp.va|lid?() -> %>
+                Valid
+              <% true -> %>
+                Invalid
+            <% end %>
+            """
+          end
+        end
+      ]
+
+      assert {:ok, {:call, SampleApp, :valid?, 0}, _} = resolve(code)
+    end
   end
 
   describe "resolve/2 inside a string" do


### PR DESCRIPTION
Follow-up to #663 which actually fixes #653.

When we have EEx code like this, with cursor placed on "valid?", Code.Fragment.surround_context treats `% SampleApp` as a struct reference. This seems intentional, see this test that asserts on that behavior:
https://github.com/elixir-lang/elixir/blob/v1.20.0-rc.4/lib/elixir/test/elixir/code_fragment_test.exs#L260

In Expert, however, in Entity.resolve we assume that in {:struct, inner} inner is always a charlist and crashes because of that, because in the code in question it's actually `{:struct, {:dot, {:alias, ~c"SampleApp"}, ~c"valid?"}}`

This commit tightens up pattern matching in resolve, making sure that we either have a proper charlist, or we add a special case when it's something else. Surprisingly, just adding specific `{:dot, _, _}` handling fixed other potential cases as well.