### PR TITLE
perf: use beam metadata for dependencies

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -24,7 +24,7 @@ defmodule Engine.Application do
           Engine.Search.Store.Backends.Ets,
           {Engine.Search.Store,
            [
-             &Engine.Search.Indexer.create_index/1,
+             &Engine.Search.Indexer.create_index/2,
              &Engine.Search.Indexer.update_index/2
            ]}
         ]

--- a/apps/engine/lib/engine/code_intelligence/structs.ex
+++ b/apps/engine/lib/engine/code_intelligence/structs.ex
@@ -1,5 +1,4 @@
 defmodule Engine.CodeIntelligence.Structs do
-  alias Engine.Module.Loader
   alias Engine.Search.Store
   alias Forge.Project
   alias Forge.Search.Indexer.Entry
@@ -23,8 +22,7 @@ defmodule Engine.CodeIntelligence.Structs do
   defp structs_from_index do
     case Store.exact(type: :struct, subtype: :definition) do
       {:ok, entries} ->
-        for %Entry{subject: struct_module} <- entries,
-            Loader.ensure_loaded?(struct_module) do
+        for %Entry{subject: struct_module} <- entries do
           struct_module
         end
 

--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -147,17 +147,24 @@ defmodule Engine.Commands.Reindex do
 
     {elapsed_us, result} =
       :timer.tc(fn ->
-        with {:ok, entries} <- Search.Indexer.create_index(project) do
-          Search.Store.replace(entries)
-        end
+        Search.Store.rebuild_index(project)
       end)
 
     Engine.broadcast(
-      project_reindexed(project: project, elapsed_ms: round(elapsed_us / 1000), status: :success)
+      project_reindexed(
+        project: project,
+        elapsed_ms: round(elapsed_us / 1000),
+        status: reindex_status(result)
+      )
     )
 
     result
   end
+
+  defp reindex_status(:ok), do: :success
+  defp reindex_status({:ok, _}), do: :success
+  defp reindex_status({:error, reason}), do: {:error, reason}
+  defp reindex_status(other), do: {:error, other}
 
   defp schedule_gc do
     Process.send_after(self(), :gc, :timer.seconds(5))

--- a/apps/engine/lib/engine/completion.ex
+++ b/apps/engine/lib/engine/completion.ex
@@ -3,6 +3,7 @@ defmodule Engine.Completion do
   import Forge.Logging
 
   alias Engine.CodeMod.Format
+  alias Engine.Module.Loader
   alias Forge.Ast.Analysis
   alias Forge.Ast.Env
   alias Forge.Completion.Candidate
@@ -73,6 +74,7 @@ defmodule Engine.Completion do
 
     with {:ok, struct_module} <-
            Engine.Analyzer.expand_alias(container_struct_module, analysis, position),
+         true <- Loader.ensure_loaded?(struct_module),
          true <- function_exported?(struct_module, :__struct__, 0) do
       struct_module
       |> struct()

--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -1,359 +1,191 @@
 defmodule Engine.Search.Indexer do
   alias Engine.ApplicationCache
-  alias Engine.Progress
-  alias Engine.Search.Indexer
-  alias Engine.Search.Indexer.Extractors
-  alias Forge.Identifier
+  alias Engine.Search.Indexer.Beams
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.ManifestStore
+  alias Engine.Search.Indexer.Paths
+  alias Engine.Search.Indexer.Sources
   alias Forge.ProcessCache
   alias Forge.Project
-  alias Forge.Search.Indexer.Entry
 
+  require Logger
   require ProcessCache
 
-  @indexable_extensions "*.{ex,exs}"
+  def create_index(%Project{} = project, backend) when is_atom(backend) do
+    with_indexer_context(fn ->
+      {entries, manifest} = create_index_data(project)
 
-  # Deps files only contribute definitions to the index, so we skip pure-reference
-  # extractors (the most expensive one being FunctionReference, which resolves
-  # aliases and arity on every call site). ModuleAttribute stays because it
-  # produces both definitions and references; the post-filter drops its references.
-  @deps_extractors [
-    Extractors.Module,
-    Extractors.ModuleAttribute,
-    Extractors.FunctionDefinition,
-    Extractors.StructDefinition,
-    Extractors.EctoSchema
-  ]
-
-  def create_index(%Project{} = project) do
-    :ok = ApplicationCache.clear()
-
-    ProcessCache.with_cleanup do
-      dependency_roots = dependency_index_roots(project)
-
-      entries =
-        project
-        |> indexable_files()
-        |> async_chunks(&index_path(&1, dependency_roots))
-
-      {:ok, entries}
-    end
-  after
-    ApplicationCache.clear()
+      replace_index(project, backend, entries, manifest)
+    end)
   end
 
   def update_index(%Project{} = project, backend) do
+    with_indexer_context(fn ->
+      case ManifestStore.load(project) do
+        {:ok, %Manifest{} = manifest} -> refresh_index(project, manifest, backend)
+        :missing -> replace_index(project, backend)
+      end
+    end)
+  end
+
+  defp create_index_data(%Project{} = project) do
+    paths = Paths.for_project(project)
+    {entries, manifest_entries} = index_paths(paths.source_paths, paths.beam_paths)
+
+    {entries, Manifest.new(manifest_entries)}
+  end
+
+  defp replace_index(%Project{} = project, backend) do
+    {entries, manifest} = create_index_data(project)
+
+    replace_index(project, backend, entries, manifest)
+  end
+
+  defp refresh_index(%Project{} = project, %Manifest{} = manifest, backend) do
+    {entries, paths_to_clear, manifest} = update_index_data(project, manifest, backend)
+
+    with :ok <- apply_index_update(project, backend, entries, paths_to_clear) do
+      ManifestStore.commit(project, manifest)
+    end
+  end
+
+  defp replace_index(%Project{} = project, backend, entries, %Manifest{} = manifest) do
+    with :ok <- backend.replace_all(entries),
+         :ok <- maybe_sync(project, backend) do
+      ManifestStore.commit(project, manifest)
+    end
+  end
+
+  defp apply_index_update(project, backend, updated_entries, deleted_paths) do
+    with :ok <- apply_updated_entries(backend, updated_entries),
+         :ok <- apply_deleted_paths(backend, deleted_paths) do
+      maybe_sync(project, backend)
+    end
+  end
+
+  defp apply_updated_entries(backend, updated_entries) do
+    updated_entries
+    |> Enum.group_by(& &1.path)
+    |> Enum.reduce_while(:ok, fn {path, entry_list}, :ok ->
+      apply_index_path(backend, path, entry_list)
+    end)
+  end
+
+  defp apply_deleted_paths(backend, deleted_paths) do
+    Enum.reduce_while(deleted_paths, :ok, fn path, :ok ->
+      apply_index_path(backend, path, [])
+    end)
+  end
+
+  defp apply_index_path(backend, path, entries) do
+    case replace_backend_path(backend, path, entries) do
+      :ok -> {:cont, :ok}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
+  end
+
+  defp replace_backend_path(backend, path, entries) do
+    with {:ok, _deleted_ids} <- backend.delete_by_path(path) do
+      backend.insert(entries)
+    end
+  catch
+    :exit, {:timeout, _} ->
+      Logger.warning("Timeout updating index for path: #{path}")
+      :ok
+  end
+
+  defp update_index_data(%Project{} = project, %Manifest{} = manifest, backend) do
+    paths = Paths.for_project(project)
+
+    plan =
+      manifest
+      |> Manifest.plan(paths)
+      |> include_missing_backend_outputs(manifest, paths, backend)
+
+    {entries, manifest_entries} =
+      index_paths(plan.source_paths_to_index, plan.beam_paths_to_index)
+
+    paths_to_clear = Manifest.output_paths_to_clear(manifest, plan, manifest_entries)
+    manifest = Manifest.apply_update(manifest, plan, manifest_entries)
+
+    {entries, paths_to_clear, manifest}
+  end
+
+  defp include_missing_backend_outputs(
+         %Manifest.Plan{} = plan,
+         %Manifest{} = manifest,
+         paths,
+         backend
+       ) do
+    backend_paths = backend_indexed_paths(backend)
+    source_paths = MapSet.new(paths.source_paths)
+    beam_paths = MapSet.new(paths.beam_paths)
+
+    {missing_source_paths, missing_beam_paths} =
+      manifest
+      |> Manifest.entries()
+      |> Enum.reduce({[], []}, fn
+        %Manifest.Entry{input_path: input_path, output_path: output_path, kind: :source},
+        {source_acc, beam_acc}
+        when is_binary(output_path) ->
+          if MapSet.member?(source_paths, input_path) and
+               not MapSet.member?(backend_paths, output_path) do
+            {[input_path | source_acc], beam_acc}
+          else
+            {source_acc, beam_acc}
+          end
+
+        %Manifest.Entry{input_path: input_path, output_path: output_path, kind: :beam},
+        {source_acc, beam_acc}
+        when is_binary(output_path) ->
+          if MapSet.member?(beam_paths, input_path) and
+               not MapSet.member?(backend_paths, output_path) do
+            {source_acc, [input_path | beam_acc]}
+          else
+            {source_acc, beam_acc}
+          end
+
+        _entry, acc ->
+          acc
+      end)
+
+    %Manifest.Plan{
+      plan
+      | source_paths_to_index: Enum.uniq(plan.source_paths_to_index ++ missing_source_paths),
+        beam_paths_to_index: Enum.uniq(plan.beam_paths_to_index ++ missing_beam_paths)
+    }
+  end
+
+  defp index_paths(source_paths, beam_paths) do
+    {source_entries, source_manifest_entries} = Sources.index(source_paths)
+    {beam_entries, beam_manifest_entries} = Beams.index(beam_paths)
+
+    {source_entries ++ beam_entries, source_manifest_entries ++ beam_manifest_entries}
+  end
+
+  defp backend_indexed_paths(backend) do
+    MapSet.new()
+    |> backend.reduce(fn
+      %{path: path}, paths when is_binary(path) -> MapSet.put(paths, path)
+      _entry, paths -> paths
+    end)
+  end
+
+  defp with_indexer_context(fun) when is_function(fun, 0) do
     :ok = ApplicationCache.clear()
 
     ProcessCache.with_cleanup do
-      do_update_index(project, backend)
+      fun.()
     end
   after
     ApplicationCache.clear()
   end
 
-  defp do_update_index(%Project{} = project, backend) do
-    path_to_ids =
-      backend.reduce(%{}, fn
-        %Entry{path: path} = entry, path_to_ids when is_integer(entry.id) ->
-          Map.update(path_to_ids, path, entry.id, &max(&1, entry.id))
-
-        _entry, path_to_ids ->
-          path_to_ids
-      end)
-
-    project_files =
-      project
-      |> indexable_files()
-      |> MapSet.new()
-
-    previously_indexed_paths = MapSet.new(path_to_ids, fn {path, _} -> path end)
-
-    new_paths = MapSet.difference(project_files, previously_indexed_paths)
-
-    {paths_to_examine, paths_to_delete} =
-      Enum.split_with(path_to_ids, fn {path, _id} ->
-        MapSet.member?(project_files, path) and File.regular?(path)
-      end)
-
-    changed_paths =
-      for {path, id} <- paths_to_examine,
-          newer_than?(path, id) do
-        path
-      end
-
-    paths_to_delete = Enum.map(paths_to_delete, &elem(&1, 0))
-
-    paths_to_reindex = changed_paths ++ Enum.to_list(new_paths)
-    dependency_roots = dependency_index_roots(project)
-
-    entries = async_chunks(paths_to_reindex, &index_path(&1, dependency_roots))
-
-    {:ok, entries, paths_to_delete}
-  end
-
-  defp index_path(path, dependency_roots) do
-    in_dependency? = contained_in_any?(path, dependency_roots)
-    extractors = if in_dependency?, do: @deps_extractors
-
-    with {:ok, contents} <- File.read(path),
-         {:ok, entries} <- Indexer.Source.index(path, contents, extractors) do
-      if in_dependency? do
-        Enum.filter(entries, &(&1.subtype == :definition))
-      else
-        entries
-      end
+  defp maybe_sync(project, backend) do
+    if function_exported?(backend, :sync, 1) do
+      backend.sync(project)
     else
-      _ ->
-        []
+      :ok
     end
   end
-
-  # 128 K blocks indexed expert in 5.3 seconds
-  @bytes_per_block 1024 * 128
-
-  defp async_chunks(file_paths, processor, timeout \\ :infinity) do
-    # this function tries to even out the amount of data processed by
-    # async stream by making each chunk emitted by the initial stream to
-    # be roughly equivalent
-
-    # Shuffling the results helps speed in some projects, as larger files tend to clump
-    # together, like when there are auto-generated elixir modules.
-    paths_to_sizes =
-      file_paths
-      |> path_to_sizes()
-      |> Enum.shuffle()
-
-    total_bytes = paths_to_sizes |> Enum.map(&elem(&1, 1)) |> Enum.sum()
-
-    if total_bytes > 0 do
-      process_chunks(paths_to_sizes, total_bytes, processor, timeout)
-    else
-      []
-    end
-  end
-
-  defp process_chunks(paths_to_sizes, total_bytes, processor, timeout) do
-    path_to_size_map = Map.new(paths_to_sizes)
-
-    Progress.with_tracked_progress("Indexing source code", total_bytes, fn report ->
-      start_time = System.monotonic_time(:millisecond)
-      result = do_process_chunks(paths_to_sizes, path_to_size_map, processor, timeout, report)
-      elapsed = System.monotonic_time(:millisecond) - start_time
-      {:done, result, "Completed in #{format_duration(elapsed)}"}
-    end)
-  end
-
-  defp do_process_chunks(paths_to_sizes, path_to_size_map, processor, timeout, report) do
-    initial_state = {0, []}
-
-    chunk_fn = fn {path, file_size}, {block_size, paths} ->
-      new_block_size = file_size + block_size
-      new_paths = [path | paths]
-
-      if new_block_size >= @bytes_per_block do
-        {:cont, new_paths, initial_state}
-      else
-        {:cont, {new_block_size, new_paths}}
-      end
-    end
-
-    after_fn = fn
-      {_, []} -> {:cont, []}
-      {_, paths} -> {:cont, paths, []}
-    end
-
-    paths_to_sizes
-    |> Stream.chunk_while(initial_state, chunk_fn, after_fn)
-    |> Task.async_stream(
-      fn chunk ->
-        block_bytes = chunk |> Enum.map(&Map.get(path_to_size_map, &1)) |> Enum.sum()
-
-        report.(message: "Indexing", add: block_bytes)
-
-        Enum.flat_map(chunk, processor)
-      end,
-      timeout: timeout
-    )
-    |> Stream.flat_map(fn
-      {:ok, entries} -> entries
-      _ -> []
-    end)
-    |> Enum.to_list()
-  end
-
-  defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
-  defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
-
-  defp path_to_sizes(paths) do
-    Enum.reduce(paths, [], fn file_path, acc ->
-      case File.stat(file_path) do
-        {:ok, %File.Stat{} = stat} ->
-          [{file_path, stat.size} | acc]
-
-        _ ->
-          acc
-      end
-    end)
-  end
-
-  defp newer_than?(path, entry_id) do
-    case stat(path) do
-      {:ok, %File.Stat{} = stat} ->
-        stat.mtime > Identifier.to_erl(entry_id)
-
-      _ ->
-        false
-    end
-  end
-
-  def indexable_files(%Project{} = project) do
-    roots = index_roots(project)
-    excluded_roots = build_exclusion_roots(project, roots)
-
-    roots
-    |> Enum.flat_map(&indexable_files_in/1)
-    |> Enum.uniq()
-    |> reject_paths_under(excluded_roots)
-  end
-
-  defp indexable_files_in(root) do
-    Forge.Path.glob([root, "**", @indexable_extensions])
-  end
-
-  defp index_roots(%Project{} = project) do
-    [Project.root_path(project) | dependency_index_roots(project)]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-  end
-
-  defp reject_paths_under(paths, []), do: paths
-
-  defp reject_paths_under(paths, roots) do
-    Enum.reject(paths, &contained_in_any?(&1, roots))
-  end
-
-  defp contained_in_any?(path, roots) do
-    Enum.any?(roots, &Forge.Path.contains?(path, &1))
-  end
-
-  defp build_exclusion_roots(%Project{kind: :mix} = project, index_roots) do
-    {runtime_build_path, configured_build_root} = build_paths(project)
-    relative_build_root = Path.relative_to(configured_build_root, Project.root_path(project))
-
-    dependency_build_roots = Enum.map(index_roots, &Path.expand(relative_build_root, &1))
-
-    [runtime_build_path, configured_build_root | dependency_build_roots]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-  end
-
-  defp build_exclusion_roots(%Project{}, _index_roots), do: []
-
-  # stat(path) is here for testing so it can be mocked
-  defp stat(path) do
-    File.stat(path)
-  end
-
-  defp dependency_index_roots(%Project{kind: :mix} = project) do
-    [deps_path(project) | path_dependency_source_roots(project)]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-  end
-
-  defp dependency_index_roots(%Project{}), do: []
-
-  defp deps_path(%Project{kind: :mix} = project) do
-    case Engine.Mix.in_project(project, fn _ -> Mix.Project.deps_path() end) do
-      {:ok, path} -> path
-      _ -> Mix.Project.deps_path()
-    end
-  end
-
-  defp path_dependency_source_roots(%Project{} = project) do
-    case Engine.Mix.in_project(project, fn _ ->
-           path_dependency_paths(Mix.Project.config(), Mix.env())
-         end) do
-      {:ok, roots} -> Enum.flat_map(roots, &mix_source_roots/1)
-      _ -> []
-    end
-  end
-
-  defp path_dependency_paths(config, env) do
-    config
-    |> Keyword.get(:deps, [])
-    |> Enum.flat_map(&path_dependency_path(&1, env))
-  end
-
-  defp path_dependency_path({_app, opts}, env) when is_list(opts) do
-    path_dependency_path_from_opts(opts, env)
-  end
-
-  defp path_dependency_path({_app, _requirement, opts}, env) when is_list(opts) do
-    path_dependency_path_from_opts(opts, env)
-  end
-
-  defp path_dependency_path(_dep, _env), do: []
-
-  defp path_dependency_path_from_opts(opts, env) do
-    path = Keyword.get(opts, :path)
-    only_envs = opts |> Keyword.get(:only) |> List.wrap()
-
-    if is_binary(path) and dependency_active_in_env?(only_envs, env) do
-      [Path.expand(path, File.cwd!())]
-    else
-      []
-    end
-  end
-
-  defp dependency_active_in_env?([], _env), do: true
-  defp dependency_active_in_env?(envs, env), do: env in envs
-
-  defp mix_source_roots(root) do
-    project = root |> Forge.Document.Path.to_uri() |> Project.new()
-
-    source_paths =
-      case Engine.Mix.in_project(project, fn _ ->
-             Keyword.get(Mix.Project.config(), :elixirc_paths, ["lib"])
-           end) do
-        {:ok, paths} -> paths
-        _ -> ["lib"]
-      end
-
-    Enum.map(source_paths, &Path.expand(&1, root))
-  end
-
-  defp build_paths(%Project{kind: :mix} = project) do
-    case Engine.Mix.in_project(project, fn project_module ->
-           {Mix.Project.build_path(), configured_build_root(project, project_module.project())}
-         end) do
-      {:ok, paths} -> paths
-      _ -> {Mix.Project.build_path(), configured_build_root(project, [])}
-    end
-  end
-
-  defp configured_build_root(%Project{} = project, config) do
-    config = Keyword.put_new(config, :build_per_environment, true)
-
-    with_deleted_env("MIX_BUILD_PATH", fn ->
-      File.cd!(Project.root_path(project), fn ->
-        config
-        |> Mix.Project.build_path()
-        |> Path.dirname()
-      end)
-    end)
-  end
-
-  defp with_deleted_env(name, fun) do
-    original = System.fetch_env(name)
-    System.delete_env(name)
-
-    try do
-      fun.()
-    after
-      restore_env(name, original)
-    end
-  end
-
-  defp restore_env(name, {:ok, value}), do: System.put_env(name, value)
-  defp restore_env(name, :error), do: System.delete_env(name)
 end

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -1,0 +1,708 @@
+defmodule Engine.Search.Indexer.Beams do
+  alias Engine.ApplicationCache
+  alias Engine.Progress
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Subject
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+  alias Forge.Search.Indexer.Entry
+  alias Forge.Search.Indexer.Source.Block
+
+  @beam_index_concurrency 16
+  @beam_index_chunk_bytes 128 * 1024
+
+  def index(paths) when is_list(paths) do
+    {beams, total_bytes} = stat_beams(paths)
+
+    beams
+    |> index_beam_chunks(total_bytes)
+    |> entries_and_manifest_entries()
+  end
+
+  defp stat_beams(paths) do
+    Enum.reduce(paths, {[], 0}, fn path, {beams, total_bytes} ->
+      case File.stat(path) do
+        {:ok, %File.Stat{} = stat} ->
+          {[{path, stat} | beams], total_bytes + stat.size}
+
+        _ ->
+          {beams, total_bytes}
+      end
+    end)
+  end
+
+  defp index_beam_chunks([], _total_bytes), do: []
+
+  defp index_beam_chunks(beams, total_bytes) do
+    Progress.with_tracked_progress("Indexing dependencies metadata", total_bytes, fn report ->
+      start_time = System.monotonic_time(:millisecond)
+
+      results =
+        beams
+        |> beam_chunks()
+        |> Task.async_stream(&index_beam_chunk(&1, report),
+          max_concurrency: @beam_index_concurrency,
+          ordered: false,
+          timeout: :infinity
+        )
+        |> Enum.flat_map(&task_result!/1)
+
+      elapsed = System.monotonic_time(:millisecond) - start_time
+      {:done, results, "Completed in #{format_duration(elapsed)}"}
+    end)
+  end
+
+  defp beam_chunks(beams) do
+    {chunks, current_chunk} =
+      Enum.reduce(beams, {[], {0, []}}, fn beam, {chunks, {chunk_bytes, chunk_beams}} ->
+        chunk_bytes = chunk_bytes + beam_size(beam)
+        chunk_beams = [beam | chunk_beams]
+
+        if chunk_bytes >= @beam_index_chunk_bytes do
+          {[{chunk_bytes, chunk_beams} | chunks], {0, []}}
+        else
+          {chunks, {chunk_bytes, chunk_beams}}
+        end
+      end)
+
+    case current_chunk do
+      {0, []} -> chunks
+      {_chunk_bytes, [_ | _]} = chunk -> [chunk | chunks]
+    end
+  end
+
+  defp beam_size({_path, %File.Stat{size: size}}), do: size
+
+  defp index_beam_chunk({chunk_bytes, beams}, report) do
+    report.(message: "Indexing dependencies", add: chunk_bytes)
+    Enum.flat_map(beams, &metadata_from_beam/1)
+  end
+
+  defp entries_and_manifest_entries(results) do
+    {indexed_results, skipped_results} = Enum.split_with(results, &indexed_result?/1)
+    entries = entries_from_indexed_results(indexed_results)
+    manifest_entries = manifest_entries_from_results(indexed_results ++ skipped_results)
+
+    {entries, manifest_entries}
+  end
+
+  defp indexed_result?({:indexed, _source_path, _metadata, _manifest_entry}), do: true
+  defp indexed_result?(_result), do: false
+
+  defp manifest_entries_from_results(results) do
+    Enum.map(results, fn
+      {:indexed, _source_path, _metadata, manifest_entry} -> manifest_entry
+      {:skipped, manifest_entry} -> manifest_entry
+    end)
+  end
+
+  defp entries_from_indexed_results([]), do: []
+
+  defp entries_from_indexed_results(results) do
+    source_lines_by_path = source_lines_by_path(results)
+
+    results
+    |> Enum.group_by(fn {:indexed, source_path, _metadata, _manifest_entry} -> source_path end)
+    |> Enum.flat_map(fn {source_path, results} ->
+      entries_from_group(source_path, results, source_lines_by_path)
+    end)
+  end
+
+  defp entries_from_group(source_path, results, source_lines_by_path) do
+    entries =
+      Enum.flat_map(results, fn {:indexed, _source_path, metadata, _manifest_entry} ->
+        entries_from_metadata(metadata, Map.get(source_lines_by_path, source_path, %{}))
+      end)
+
+    [Entry.block_structure(source_path, %{root: %{}}) | entries]
+  end
+
+  defp metadata_from_beam({beam_path, beam_stat}) do
+    case debug_metadata(beam_path) do
+      {:ok, metadata} -> metadata_result_from_beam(beam_path, beam_stat, metadata)
+      :error -> skipped_result_from_beam(beam_path, beam_stat, nil, nil)
+    end
+  end
+
+  defp metadata_result_from_beam(beam_path, beam_stat, metadata) do
+    source_path = Map.get(metadata, :file)
+    source_stat_result = stat_source(source_path)
+
+    if fresh_beam?(beam_stat, source_stat_result) do
+      {:ok, manifest_entry} =
+        Manifest.Entry.beam(beam_path, source_path, beam_stat, source_stat_result)
+
+      [{:indexed, source_path, metadata, manifest_entry}]
+    else
+      skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result)
+    end
+  end
+
+  defp stat_source(source_path) when is_binary(source_path) do
+    case File.stat(source_path) do
+      {:ok, %File.Stat{} = stat} -> {:ok, stat}
+      _ -> :error
+    end
+  end
+
+  defp stat_source(_source_path), do: :error
+
+  defp fresh_beam?(%File.Stat{} = beam_stat, {:ok, %File.Stat{} = source_stat}) do
+    beam_stat.mtime >= source_stat.mtime
+  end
+
+  defp fresh_beam?(_beam_stat, _source_stat), do: false
+
+  defp skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result) do
+    {:ok, manifest_entry} =
+      Manifest.Entry.skipped_beam(
+        beam_path,
+        source_path,
+        beam_stat,
+        source_stat_result
+      )
+
+    [{:skipped, manifest_entry}]
+  end
+
+  # The debug-info chunk data is backend-owned and opaque. The public contract is
+  # to ask the backend to decode it into the Elixir debug-info format we consume.
+  defp debug_metadata(beam_path) do
+    with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
+           :beam_lib.chunks(String.to_charlist(beam_path), [:debug_info]),
+         {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
+      {:ok, metadata}
+    else
+      _ -> :error
+    end
+  catch
+    _kind, _reason -> :error
+  end
+
+  defp entries_from_metadata(metadata, source_lines) do
+    context = entry_context(metadata)
+
+    module_entries(metadata, context, module_range(metadata, source_lines)) ++
+      public_definition_entries(metadata, context)
+  end
+
+  defp entry_context(metadata) do
+    module = Map.fetch!(metadata, :module)
+
+    %{
+      app: ApplicationCache.application(module),
+      module: module,
+      root_block: Block.root(),
+      source_path: Map.fetch!(metadata, :file)
+    }
+  end
+
+  defp module_entries(metadata, context, module_range) do
+    case protocol_implementation(metadata) do
+      {:ok, protocol} ->
+        [
+          module_definition(context, :module, module_range),
+          protocol_implementation_definition(context, protocol, module_range)
+        ]
+
+      :error ->
+        case Map.get(metadata, :struct) do
+          nil ->
+            [module_definition(context, module_type(metadata), module_range)]
+
+          _struct ->
+            [
+              module_definition(context, module_type(metadata), module_range),
+              module_definition(context, :struct, module_range)
+            ]
+        end
+    end
+  end
+
+  defp module_definition(context, type, range) do
+    Entry.definition(
+      context.source_path,
+      context.root_block,
+      Subject.module(context.module),
+      type,
+      range,
+      context.app
+    )
+  end
+
+  defp protocol_implementation_definition(context, protocol, range) do
+    Entry.definition(
+      context.source_path,
+      context.root_block,
+      Subject.module(protocol),
+      {:protocol, :implementation},
+      range,
+      ApplicationCache.application(protocol)
+    )
+  end
+
+  defp public_definition_entries(metadata, context) do
+    definitions = Map.get(metadata, :definitions, [])
+    protocol_callbacks = protocol_callbacks(metadata)
+    delegate_specs = delegate_specs_from_metadata(metadata)
+    default_wrappers = default_wrapper_identities(definitions)
+
+    Enum.flat_map(
+      definitions,
+      &public_definition_entries(
+        &1,
+        context,
+        protocol_callbacks,
+        delegate_specs,
+        default_wrappers
+      )
+    )
+  end
+
+  defp public_definition_entries(
+         {{name, arity}, definition, metadata, clauses},
+         context,
+         protocol_callbacks,
+         delegate_specs,
+         default_wrappers
+       )
+       when definition in [:def, :defmacro] do
+    cond do
+      default_wrapper?(name, arity, definition, clauses, default_wrappers) ->
+        []
+
+      Keyword.get(metadata, :generated, false) and not Keyword.has_key?(metadata, :context) ->
+        []
+
+      true ->
+        name
+        |> public_arities(
+          arity,
+          Keyword.get(metadata, :defaults, 0),
+          metadata,
+          protocol_callbacks
+        )
+        |> Enum.flat_map(
+          &public_definition_entries(context, name, &1, definition, metadata, delegate_specs)
+        )
+    end
+  end
+
+  defp public_definition_entries(
+         _definition,
+         _context,
+         _protocol_callbacks,
+         _delegate_specs,
+         _default_wrappers
+       ),
+       do: []
+
+  defp default_wrapper_identities(definitions) do
+    definitions
+    |> Enum.flat_map(fn
+      {{name, arity}, definition, metadata, _clauses} when definition in [:def, :defmacro] ->
+        case Keyword.get(metadata, :defaults, 0) do
+          defaults when defaults > 0 ->
+            for wrapper_arity <- (arity - defaults)..(arity - 1),
+                do: {name, wrapper_arity, definition}
+
+          _defaults ->
+            []
+        end
+
+      _definition ->
+        []
+    end)
+    |> MapSet.new()
+  end
+
+  defp default_wrapper?(name, arity, definition, clauses, default_wrappers) do
+    MapSet.member?(default_wrappers, {name, arity, definition}) and
+      default_wrapper_clauses?(clauses, definition, name)
+  end
+
+  defp default_wrapper_clauses?([_clause | _rest] = clauses, definition, name) do
+    Enum.all?(clauses, &default_wrapper_clause?(&1, definition, name))
+  end
+
+  defp default_wrapper_clauses?(_clauses, _definition, _name), do: false
+
+  defp default_wrapper_clause?(
+         {_metadata, _args, [], {:super, metadata, _defaults}},
+         definition,
+         name
+       ) do
+    Keyword.get(metadata, :super) == {definition, name}
+  end
+
+  defp default_wrapper_clause?(_clause, _definition, _name), do: false
+
+  defp public_definition_entries(context, name, arity, definition, metadata, delegate_specs) do
+    case Map.get(delegate_specs, {name, arity}) do
+      nil ->
+        [public_definition_entry(context, name, arity, definition, metadata)]
+
+      delegate_spec ->
+        [delegate_definition_entry(context, name, arity, delegate_spec)]
+    end
+  end
+
+  defp public_definition_entry(context, name, arity, definition, metadata) do
+    type = if definition == :def, do: {:function, :public}, else: {:macro, :public}
+
+    Entry.definition(
+      context.source_path,
+      context.root_block,
+      Subject.mfa(context.module, name, arity),
+      type,
+      definition_range(metadata, name),
+      context.app
+    )
+  end
+
+  defp delegate_definition_entry(context, name, arity, delegate_spec) do
+    context.source_path
+    |> Entry.definition(
+      context.root_block,
+      Subject.mfa(context.module, name, arity),
+      {:function, :delegate},
+      delegate_spec.range,
+      context.app
+    )
+    |> Entry.put_metadata(%{
+      original_mfa: Subject.mfa(delegate_spec.module, delegate_spec.name, delegate_spec.arity)
+    })
+  end
+
+  defp delegate_specs_from_metadata(metadata) do
+    metadata
+    |> Map.get(:definitions, [])
+    |> Enum.flat_map(&delegate_specs/1)
+    |> Map.new()
+  end
+
+  defp delegate_specs({{name, arity}, :def, metadata, clauses}) do
+    with true <- delegate_metadata?(metadata),
+         {:ok, module, target_name, target_arity} <- delegate_target(clauses) do
+      defaults = Keyword.get(metadata, :defaults, 0)
+
+      spec = %{
+        module: module,
+        name: target_name,
+        arity: target_arity,
+        range: definition_range(metadata, name)
+      }
+
+      for local_arity <- (arity - defaults)..arity do
+        {{name, local_arity}, spec}
+      end
+    else
+      _ -> []
+    end
+  end
+
+  defp delegate_specs(_definition), do: []
+
+  defp delegate_metadata?(metadata) do
+    Keyword.has_key?(metadata, :line) and not Keyword.has_key?(metadata, :column) and
+      not Keyword.has_key?(metadata, :context)
+  end
+
+  defp delegate_target([{_metadata, args, [], body}]) do
+    with {{:., _dot_metadata, [module, name]}, _call_metadata, call_args} <- body,
+         true <- is_atom(module),
+         true <- is_atom(name),
+         true <- same_variables?(args, call_args) do
+      {:ok, module, name, length(call_args)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp delegate_target(_clauses), do: :error
+
+  defp same_variables?(args, call_args) when length(args) == length(call_args) do
+    args
+    |> Enum.zip(call_args)
+    |> Enum.all?(fn {arg, call_arg} -> variable_identity(arg) == variable_identity(call_arg) end)
+  end
+
+  defp same_variables?(_args, _call_args), do: false
+
+  defp variable_identity({name, metadata, context}) when is_atom(name) and is_list(metadata) do
+    {name, Keyword.get(metadata, :version), context}
+  end
+
+  defp variable_identity(_ast), do: :error
+
+  defp module_type(%{attributes: attributes}) do
+    if Keyword.has_key?(attributes, :__protocol__), do: {:protocol, :definition}, else: :module
+  end
+
+  defp module_type(_), do: :module
+
+  defp protocol_implementation(%{attributes: attributes}) do
+    with impl when is_list(impl) <- Keyword.get(attributes, :__impl__),
+         protocol when is_atom(protocol) <- Keyword.get(impl, :protocol) do
+      {:ok, protocol}
+    else
+      _ -> :error
+    end
+  end
+
+  defp protocol_implementation(_metadata), do: :error
+
+  defp protocol_callbacks(metadata) do
+    metadata
+    |> Map.get(:definitions, [])
+    |> Enum.find_value([], fn
+      {{:__protocol__, 1}, :def, _definition_metadata, clauses} ->
+        protocol_callback_clauses(clauses)
+
+      _definition ->
+        nil
+    end)
+    |> MapSet.new()
+  end
+
+  defp protocol_callback_clauses(clauses) do
+    clauses
+    |> Enum.find_value([], fn
+      {_metadata, [:functions], [], functions} when is_list(functions) -> functions
+      _clause -> nil
+    end)
+    |> Enum.flat_map(fn
+      {name, arity} when is_atom(name) and is_integer(arity) -> [{name, arity}]
+      _function -> []
+    end)
+  end
+
+  defp public_arities(name, arity, defaults, definition_metadata, protocol_callbacks) do
+    arities = Enum.to_list((arity - defaults)..arity)
+
+    if Keyword.has_key?(definition_metadata, :context) do
+      Enum.filter(arities, &MapSet.member?(protocol_callbacks, {name, &1}))
+    else
+      arities
+    end
+  end
+
+  defp definition_range(metadata, name) do
+    line = Keyword.get(metadata, :line, 1)
+    column = Keyword.get(metadata, :column, 1)
+
+    range(line, column, name |> Atom.to_string() |> String.length())
+  end
+
+  # BEAM debug metadata stores nested modules under their expanded names, but the
+  # source often only contains the visible suffix (`defmodule Child`). Scan the
+  # definition line for the source spelling before falling back to compiler data.
+  defp module_range(metadata, source_lines) do
+    {line, fallback_column} = metadata_position(metadata)
+    module_name = metadata |> Map.fetch!(:module) |> Forge.Formats.module()
+
+    fallback_span = {fallback_column, String.length(module_name)}
+
+    {column, length} =
+      case source_definition_span(metadata, source_lines, line, module_name) do
+        {:ok, span} -> span
+        :error -> fallback_span
+      end
+
+    range(line, column, length)
+  end
+
+  defp source_definition_span(metadata, source_lines, line, module_name) do
+    case Map.get(source_lines, line) do
+      line_text when is_binary(line_text) -> definition_span(metadata, line_text, module_name)
+      _ -> :error
+    end
+  end
+
+  defp definition_span(metadata, line_text, module_name) do
+    if protocol_implementation?(metadata) do
+      defimpl_span(line_text)
+    else
+      module_definition_name_span(line_text, module_name)
+    end
+  end
+
+  defp defimpl_span(line_text) do
+    with {start_byte, _length} <- :binary.match(line_text, "defimpl"),
+         {:ok, end_byte} <- defimpl_end_byte(line_text, start_byte) do
+      byte_span_to_column_span(line_text, start_byte, end_byte - start_byte)
+    else
+      _ -> :error
+    end
+  end
+
+  defp defimpl_end_byte(line_text, start_byte) do
+    rest = binary_part(line_text, start_byte, byte_size(line_text) - start_byte)
+
+    case :binary.match(rest, " do") do
+      {do_byte, do_length} -> {:ok, start_byte + do_byte + do_length}
+      :nomatch -> {:ok, line_text |> String.trim_trailing() |> byte_size()}
+    end
+  end
+
+  defp protocol_implementation?(metadata) do
+    match?({:ok, _protocol}, protocol_implementation(metadata))
+  end
+
+  defp module_definition_name_span(line_text, module_name) do
+    with {:ok, search_start_byte} <- module_name_search_start(line_text),
+         {:ok, start_byte, length} <-
+           module_name_match(line_text, search_start_byte, module_name) do
+      byte_span_to_column_span(line_text, start_byte, length)
+    end
+  end
+
+  defp module_name_search_start(line_text) do
+    ["defmodule", "defprotocol"]
+    |> Enum.flat_map(&:binary.matches(line_text, &1))
+    |> Enum.min_by(&elem(&1, 0), fn -> nil end)
+    |> case do
+      {byte_index, length} -> {:ok, byte_index + length}
+      nil -> :error
+    end
+  end
+
+  defp module_name_match(line_text, search_start, module_name) do
+    line_text
+    |> module_name_suffixes(module_name)
+    |> Enum.find_value(:error, fn candidate ->
+      match =
+        line_text
+        |> :binary.matches(candidate, scope: {search_start, byte_size(line_text) - search_start})
+        |> Enum.find(fn {byte_index, length} ->
+          module_name_boundary?(line_text, byte_index, length)
+        end)
+
+      case match do
+        {byte_index, length} -> {:ok, byte_index, length}
+        nil -> false
+      end
+    end)
+  end
+
+  defp module_name_boundary?(line_text, byte_index, length) do
+    not module_name_character_before?(line_text, byte_index) and
+      not module_name_character_at?(line_text, byte_index + length)
+  end
+
+  defp module_name_character_before?(_line_text, 0), do: false
+
+  defp module_name_character_before?(line_text, byte_index) do
+    module_name_character_at?(line_text, byte_index - 1)
+  end
+
+  defp module_name_character_at?(line_text, byte_index) when byte_index >= byte_size(line_text) do
+    false
+  end
+
+  defp module_name_character_at?(line_text, byte_index) do
+    character = :binary.at(line_text, byte_index)
+
+    character in ?A..?Z or character in ?a..?z or character in ?0..?9 or character in [?_, ?.]
+  end
+
+  defp module_name_suffixes(line_text, module_name) do
+    segments = String.split(module_name, ".")
+
+    suffixes =
+      for index <- 0..(length(segments) - 1), do: segments |> Enum.drop(index) |> Enum.join(".")
+
+    module_alias_suffixes = Enum.map(suffixes, &"__MODULE__.#{&1}")
+
+    Enum.filter(module_alias_suffixes ++ suffixes, &String.contains?(line_text, &1))
+  end
+
+  defp byte_span_to_column_span(line_text, start_byte, byte_length) when byte_length > 0 do
+    column = line_text |> binary_part(0, start_byte) |> String.length()
+    length = line_text |> binary_part(start_byte, byte_length) |> String.length()
+
+    {:ok, {column + 1, length}}
+  end
+
+  defp byte_span_to_column_span(_line_text, _start_byte, _byte_length), do: :error
+
+  defp source_lines_by_path(results) do
+    results
+    |> Enum.group_by(
+      fn {:indexed, source_path, _metadata, _manifest_entry} -> source_path end,
+      fn {:indexed, _source_path, metadata, _manifest_entry} ->
+        metadata |> metadata_position() |> elem(0)
+      end
+    )
+    |> Map.new(fn {source_path, lines} -> {source_path, source_lines(source_path, lines)} end)
+  end
+
+  defp source_lines(source_path, lines) do
+    source_lines = lines |> Enum.filter(&valid_line?/1) |> Enum.uniq() |> Enum.sort()
+
+    read_source_lines(source_path, source_lines)
+  end
+
+  defp read_source_lines(_source_path, []), do: %{}
+
+  defp read_source_lines(source_path, lines) do
+    source_path
+    |> File.stream!(:line, [])
+    |> Stream.with_index(1)
+    |> Enum.reduce_while({lines, %{}}, &collect_source_line/2)
+    |> elem(1)
+  rescue
+    _ -> %{}
+  end
+
+  defp collect_source_line(_source_line, {[], lines_by_number}) do
+    {:halt, {[], lines_by_number}}
+  end
+
+  defp collect_source_line({line_text, line_number}, {[next_line], lines_by_number})
+       when line_number == next_line do
+    {:halt, {[], Map.put(lines_by_number, line_number, line_text)}}
+  end
+
+  defp collect_source_line({line_text, line_number}, {[next_line | rest], lines_by_number})
+       when line_number == next_line do
+    {:cont, {rest, Map.put(lines_by_number, line_number, line_text)}}
+  end
+
+  defp collect_source_line(
+         {_line_text, line_number},
+         {[next_line | _rest] = lines, lines_by_number}
+       )
+       when line_number < next_line do
+    {:cont, {lines, lines_by_number}}
+  end
+
+  defp collect_source_line(_source_line, {[_next_line | rest], lines_by_number}) do
+    {:cont, {rest, lines_by_number}}
+  end
+
+  defp valid_line?(line), do: is_integer(line) and line > 0
+
+  defp metadata_position(metadata) do
+    case Map.get(metadata, :anno) || Map.get(metadata, :line) do
+      {line, column} -> {line, column}
+      line when is_integer(line) -> {line, 1}
+      _ -> {1, 1}
+    end
+  end
+
+  defp range(line, column, length) do
+    Range.new(
+      %Position{line: line, character: column, starting_index: 1},
+      %Position{line: line, character: column + max(length, 1), starting_index: 1}
+    )
+  end
+
+  defp task_result!({:ok, items}), do: items
+
+  defp task_result!({:exit, reason}),
+    do: raise("Indexing task failed: #{Exception.format_exit(reason)}")
+
+  defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
+  defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
+end

--- a/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
+++ b/apps/engine/lib/engine/search/indexer/extractors/function_definition.ex
@@ -49,17 +49,20 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinition do
       arity = length(args)
       metadata = %{original_mfa: Subject.mfa(delegated_module, delegated_name, arity)}
 
-      entry =
-        Entry.definition(
-          document.path,
-          Reducer.current_block(reducer),
-          Subject.mfa(module, delegate_name, arity),
-          {:function, :delegate},
-          detail_range,
-          Engine.ApplicationCache.application(module)
-        )
+      entries =
+        for a <- (arity - count_defaults(extract_args(call)))..arity do
+          document.path
+          |> Entry.definition(
+            Reducer.current_block(reducer),
+            Subject.mfa(module, delegate_name, a),
+            {:function, :delegate},
+            detail_range,
+            Engine.ApplicationCache.application(module)
+          )
+          |> Entry.put_metadata(metadata)
+        end
 
-      {:ok, Entry.put_metadata(entry, metadata)}
+      {:ok, entries}
     else
       _ ->
         :ignored

--- a/apps/engine/lib/engine/search/indexer/manifest.ex
+++ b/apps/engine/lib/engine/search/indexer/manifest.ex
@@ -1,0 +1,402 @@
+defmodule Engine.Search.Indexer.Manifest do
+  @moduledoc """
+  Registry of indexed input files used to plan incremental indexing.
+  """
+
+  alias Engine.Search.Indexer.Paths
+
+  defmodule Entry do
+    @moduledoc false
+
+    defstruct [
+      :input_path,
+      :output_path,
+      :kind,
+      :mtime,
+      :size,
+      :source_path,
+      :source_mtime,
+      :source_size
+    ]
+
+    @type kind :: :source | :beam
+    @type file_time :: :calendar.datetime() | integer()
+
+    @type t :: %__MODULE__{
+            input_path: Path.t(),
+            output_path: Path.t() | nil,
+            kind: kind(),
+            mtime: file_time(),
+            size: non_neg_integer(),
+            source_path: Path.t() | nil,
+            source_mtime: file_time() | nil,
+            source_size: non_neg_integer() | nil
+          }
+
+    def source(path) when is_binary(path) do
+      from_file(path, path, :source)
+    end
+
+    def beam(path, output_path) when is_binary(path) and is_binary(output_path) do
+      with {:ok, entry} <- from_file(path, output_path, :beam),
+           {:ok, source_stat} <- File.stat(output_path) do
+        {:ok,
+         %__MODULE__{
+           entry
+           | source_path: output_path,
+             source_mtime: source_stat.mtime,
+             source_size: source_stat.size
+         }}
+      end
+    end
+
+    def beam(path, output_path, %File.Stat{} = beam_stat, {:ok, %File.Stat{} = source_stat})
+        when is_binary(path) and is_binary(output_path) do
+      {:ok,
+       %__MODULE__{
+         input_path: path,
+         output_path: output_path,
+         kind: :beam,
+         mtime: beam_stat.mtime,
+         size: beam_stat.size,
+         source_path: output_path,
+         source_mtime: source_stat.mtime,
+         source_size: source_stat.size
+       }}
+    end
+
+    def beam(_path, _output_path, %File.Stat{}, :error), do: :error
+
+    def skipped_beam(path, source_path \\ nil) when is_binary(path) do
+      with {:ok, entry} <- from_file(path, nil, :beam) do
+        {:ok, put_source_snapshot(entry, source_path)}
+      end
+    end
+
+    def skipped_beam(
+          path,
+          source_path,
+          %File.Stat{} = beam_stat,
+          {:ok, %File.Stat{} = source_stat}
+        )
+        when is_binary(path) and is_binary(source_path) do
+      {:ok,
+       %__MODULE__{
+         input_path: path,
+         output_path: nil,
+         kind: :beam,
+         mtime: beam_stat.mtime,
+         size: beam_stat.size,
+         source_path: source_path,
+         source_mtime: source_stat.mtime,
+         source_size: source_stat.size
+       }}
+    end
+
+    def skipped_beam(path, source_path, %File.Stat{} = beam_stat, :error)
+        when is_binary(path) and is_binary(source_path) do
+      {:ok,
+       %__MODULE__{
+         input_path: path,
+         output_path: nil,
+         kind: :beam,
+         mtime: beam_stat.mtime,
+         size: beam_stat.size,
+         source_path: source_path
+       }}
+    end
+
+    def skipped_beam(path, _source_path, %File.Stat{} = beam_stat, _source_stat_result)
+        when is_binary(path) do
+      {:ok,
+       %__MODULE__{
+         input_path: path,
+         output_path: nil,
+         kind: :beam,
+         mtime: beam_stat.mtime,
+         size: beam_stat.size
+       }}
+    end
+
+    def matches_file?(%__MODULE__{} = entry) do
+      matches_input_file?(entry) and matches_source_file?(entry)
+    end
+
+    defp from_file(path, output_path, kind) do
+      case File.stat(path) do
+        {:ok, %File.Stat{} = stat} ->
+          {:ok, from_stat(path, output_path, kind, stat)}
+
+        _ ->
+          :error
+      end
+    end
+
+    defp from_stat(path, output_path, kind, %File.Stat{} = stat) do
+      %__MODULE__{
+        input_path: path,
+        output_path: output_path,
+        kind: kind,
+        mtime: stat.mtime,
+        size: stat.size
+      }
+    end
+
+    defp put_source_snapshot(%__MODULE__{} = entry, source_path) when is_binary(source_path) do
+      case File.stat(source_path) do
+        {:ok, %File.Stat{} = stat} ->
+          %__MODULE__{
+            entry
+            | source_path: source_path,
+              source_mtime: stat.mtime,
+              source_size: stat.size
+          }
+
+        _ ->
+          %__MODULE__{entry | source_path: source_path}
+      end
+    end
+
+    defp put_source_snapshot(%__MODULE__{} = entry, _source_path), do: entry
+
+    defp matches_input_file?(%__MODULE__{input_path: path, mtime: mtime, size: size}) do
+      case File.stat(path) do
+        {:ok, %File.Stat{mtime: ^mtime, size: ^size}} -> true
+        _ -> false
+      end
+    end
+
+    defp matches_source_file?(%__MODULE__{source_path: nil}), do: true
+
+    defp matches_source_file?(%__MODULE__{
+           source_path: path,
+           source_mtime: nil,
+           source_size: nil
+         }) do
+      match?({:error, _}, File.stat(path))
+    end
+
+    defp matches_source_file?(%__MODULE__{
+           source_path: path,
+           source_mtime: mtime,
+           source_size: size
+         }) do
+      case File.stat(path) do
+        {:ok, %File.Stat{mtime: ^mtime, size: ^size}} -> true
+        _ -> false
+      end
+    end
+  end
+
+  defmodule Plan do
+    @moduledoc false
+
+    defstruct source_paths_to_index: [],
+              beam_paths_to_index: [],
+              input_paths_to_remove: [],
+              output_paths_to_clear: []
+  end
+
+  defstruct entries_by_input_path: %{}
+
+  @type t :: %__MODULE__{entries_by_input_path: %{Path.t() => Entry.t()}}
+
+  def new(entries \\ []) when is_list(entries) do
+    Enum.reduce(entries, %__MODULE__{}, &put/2)
+  end
+
+  def entries(%__MODULE__{} = manifest) do
+    Map.values(manifest.entries_by_input_path)
+  end
+
+  def fetch(%__MODULE__{} = manifest, input_path) do
+    Map.fetch(manifest.entries_by_input_path, input_path)
+  end
+
+  def plan(%__MODULE__{} = manifest, %Paths{} = paths) do
+    source_paths = MapSet.new(paths.source_paths)
+    beam_paths = MapSet.new(paths.beam_paths)
+    current_paths = MapSet.union(source_paths, beam_paths)
+    known_paths = manifest.entries_by_input_path |> Map.keys() |> MapSet.new()
+
+    {source_paths_to_index, beam_paths_to_index, dirty_outputs, input_paths_to_remove,
+     output_paths_to_clear} =
+      manifest
+      |> entries()
+      |> Enum.reduce({[], [], MapSet.new(), [], MapSet.new()}, fn entry, acc ->
+        plan_entry(entry, source_paths, beam_paths, current_paths, acc)
+      end)
+
+    new_source_paths =
+      source_paths
+      |> MapSet.difference(known_paths)
+      |> Enum.reject(&empty_file?/1)
+
+    new_beam_paths = beam_paths |> MapSet.difference(known_paths) |> Enum.to_list()
+
+    beam_paths_to_index =
+      beam_paths_to_index
+      |> include_known_beams_for_dirty_outputs(manifest, beam_paths, dirty_outputs)
+      |> include_new_beams(new_beam_paths, beam_paths)
+
+    %Plan{
+      source_paths_to_index: Enum.uniq(source_paths_to_index ++ new_source_paths),
+      beam_paths_to_index: beam_paths_to_index,
+      input_paths_to_remove: Enum.uniq(input_paths_to_remove),
+      output_paths_to_clear: output_paths_to_clear |> MapSet.to_list()
+    }
+  end
+
+  def apply_update(%__MODULE__{} = manifest, %Plan{} = plan, entries) when is_list(entries) do
+    indexed_input_paths = plan.source_paths_to_index ++ plan.beam_paths_to_index
+    paths_to_remove = plan.input_paths_to_remove ++ indexed_input_paths
+
+    manifest
+    |> remove(paths_to_remove)
+    |> put_all(entries)
+  end
+
+  def output_paths_to_clear(%__MODULE__{} = manifest, %Plan{} = plan, entries)
+      when is_list(entries) do
+    indexed_input_paths = plan.source_paths_to_index ++ plan.beam_paths_to_index
+    old_outputs = output_paths_for_inputs(manifest, indexed_input_paths)
+    new_outputs = output_paths(entries)
+
+    old_outputs
+    |> MapSet.difference(new_outputs)
+    |> MapSet.union(MapSet.new(plan.output_paths_to_clear))
+    |> Enum.to_list()
+  end
+
+  def output_paths(entries) when is_list(entries) do
+    entries
+    |> Enum.flat_map(fn
+      %Entry{output_path: output_path} when is_binary(output_path) -> [output_path]
+      _entry -> []
+    end)
+    |> MapSet.new()
+  end
+
+  defp plan_entry(
+         %Entry{input_path: input_path} = entry,
+         source_paths,
+         beam_paths,
+         current_paths,
+         {source_to_index, beam_to_index, dirty_outputs, remove_inputs, clear_outputs}
+       ) do
+    cond do
+      not MapSet.member?(current_paths, input_path) ->
+        {source_to_index, beam_to_index, dirty_outputs, [input_path | remove_inputs],
+         put_output(clear_outputs, entry)}
+
+      source_entry?(entry, source_paths) ->
+        if Entry.matches_file?(entry) do
+          {source_to_index, beam_to_index, dirty_outputs, remove_inputs, clear_outputs}
+        else
+          {[input_path | source_to_index], beam_to_index, put_output(dirty_outputs, entry),
+           remove_inputs, clear_outputs}
+        end
+
+      beam_entry?(entry, beam_paths) ->
+        if Entry.matches_file?(entry) do
+          {source_to_index, beam_to_index, dirty_outputs, remove_inputs, clear_outputs}
+        else
+          {source_to_index, [input_path | beam_to_index], put_output(dirty_outputs, entry),
+           remove_inputs, clear_outputs}
+        end
+
+      MapSet.member?(source_paths, input_path) ->
+        {[input_path | source_to_index], beam_to_index, put_output(dirty_outputs, entry),
+         remove_inputs, clear_outputs}
+
+      MapSet.member?(beam_paths, input_path) ->
+        {source_to_index, [input_path | beam_to_index], put_output(dirty_outputs, entry),
+         remove_inputs, clear_outputs}
+    end
+  end
+
+  defp source_entry?(%Entry{kind: :source, input_path: input_path}, source_paths) do
+    MapSet.member?(source_paths, input_path)
+  end
+
+  defp source_entry?(_entry, _source_paths), do: false
+
+  defp beam_entry?(%Entry{kind: :beam, input_path: input_path}, beam_paths) do
+    MapSet.member?(beam_paths, input_path)
+  end
+
+  defp beam_entry?(_entry, _beam_paths), do: false
+
+  defp include_known_beams_for_dirty_outputs(
+         beam_paths_to_index,
+         manifest,
+         beam_paths,
+         dirty_outputs
+       ) do
+    dirty_beam_paths =
+      manifest
+      |> entries()
+      |> Enum.flat_map(fn
+        %Entry{kind: :beam, input_path: input_path, output_path: output_path}
+        when is_binary(output_path) ->
+          if MapSet.member?(beam_paths, input_path) and MapSet.member?(dirty_outputs, output_path) do
+            [input_path]
+          else
+            []
+          end
+
+        _entry ->
+          []
+      end)
+
+    Enum.uniq(beam_paths_to_index ++ dirty_beam_paths)
+  end
+
+  defp include_new_beams(beam_paths_to_index, [], _beam_paths), do: Enum.uniq(beam_paths_to_index)
+
+  defp include_new_beams(_beam_paths_to_index, _new_beam_paths, beam_paths) do
+    MapSet.to_list(beam_paths)
+  end
+
+  defp output_paths_for_inputs(%__MODULE__{} = manifest, input_paths) do
+    input_paths
+    |> Enum.flat_map(fn input_path ->
+      case fetch(manifest, input_path) do
+        {:ok, %Entry{output_path: output_path}} when is_binary(output_path) -> [output_path]
+        _ -> []
+      end
+    end)
+    |> MapSet.new()
+  end
+
+  defp put_all(%__MODULE__{} = manifest, entries) do
+    Enum.reduce(entries, manifest, &put/2)
+  end
+
+  defp put(%Entry{input_path: input_path} = entry, %__MODULE__{} = manifest) do
+    %__MODULE__{
+      manifest
+      | entries_by_input_path: Map.put(manifest.entries_by_input_path, input_path, entry)
+    }
+  end
+
+  defp remove(%__MODULE__{} = manifest, input_paths) do
+    %__MODULE__{
+      manifest
+      | entries_by_input_path: Map.drop(manifest.entries_by_input_path, input_paths)
+    }
+  end
+
+  defp put_output(outputs, %Entry{output_path: output_path}) when is_binary(output_path) do
+    MapSet.put(outputs, output_path)
+  end
+
+  defp put_output(outputs, _entry), do: outputs
+
+  defp empty_file?(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: 0}} -> true
+      _ -> false
+    end
+  end
+end

--- a/apps/engine/lib/engine/search/indexer/manifest_store.ex
+++ b/apps/engine/lib/engine/search/indexer/manifest_store.ex
@@ -1,0 +1,139 @@
+defmodule Engine.Search.Indexer.ManifestStore do
+  @moduledoc """
+  Persists the indexer's incremental input registry.
+  """
+
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.Manifest.Entry
+  alias Forge.Project
+
+  @file_name "index_manifest.etf"
+
+  @doc false
+  def load(%Project{} = project) do
+    with {:ok, binary} <- File.read(manifest_path(project)),
+         {:ok, %{entries: entries}} when is_list(entries) <- safe_binary_to_term(binary),
+         {:ok, manifest} <- decode_entries(entries) do
+      {:ok, manifest}
+    else
+      {:error, :enoent} ->
+        :missing
+
+      _ ->
+        invalidate(project)
+        :missing
+    end
+  end
+
+  def commit(%Project{} = project, %Manifest{} = manifest) do
+    path = manifest_path(project)
+
+    with :ok <- File.mkdir_p(Path.dirname(path)) do
+      write_file(path, encode(manifest))
+    end
+  end
+
+  def invalidate(%Project{} = project) do
+    File.rm(manifest_path(project))
+    :ok
+  end
+
+  defp write_file(path, binary) do
+    tmp_path = path <> ".tmp"
+
+    with :ok <- File.write(tmp_path, binary),
+         :ok <- File.rename(tmp_path, path) do
+      :ok
+    else
+      error ->
+        File.rm(tmp_path)
+        error
+    end
+  end
+
+  defp encode(%Manifest{} = manifest) do
+    %{entries: encode_entries(manifest)}
+    |> :erlang.term_to_binary()
+  end
+
+  defp encode_entries(%Manifest{} = manifest) do
+    manifest
+    |> Manifest.entries()
+    |> Enum.map(&encode_entry/1)
+  end
+
+  defp encode_entry(%Entry{} = entry) do
+    %{
+      input_path: entry.input_path,
+      output_path: entry.output_path,
+      kind: Atom.to_string(entry.kind),
+      mtime: entry.mtime,
+      size: entry.size,
+      source_path: entry.source_path,
+      source_mtime: entry.source_mtime,
+      source_size: entry.source_size
+    }
+  end
+
+  defp decode_entries(entries) when is_list(entries) do
+    {:ok, Manifest.new(Enum.map(entries, &decode_entry/1))}
+  rescue
+    _ -> :error
+  end
+
+  defp decode_entry(%{input_path: input_path, kind: kind, mtime: mtime, size: size} = entry) do
+    %Entry{
+      input_path: input_path,
+      output_path: Map.get(entry, :output_path),
+      kind: decode_kind(kind),
+      mtime: mtime,
+      size: size,
+      source_path: Map.get(entry, :source_path),
+      source_mtime: Map.get(entry, :source_mtime),
+      source_size: Map.get(entry, :source_size)
+    }
+  end
+
+  defp decode_kind("source"), do: :source
+  defp decode_kind("beam"), do: :beam
+  defp decode_kind(:source), do: :source
+  defp decode_kind(:beam), do: :beam
+
+  defp safe_binary_to_term(binary) do
+    seed_legacy_atoms()
+
+    {:ok, :erlang.binary_to_term(binary, [:safe])}
+  rescue
+    _ -> :error
+  end
+
+  defp seed_legacy_atoms do
+    atoms = [
+      :backend,
+      :beam,
+      :entries,
+      :input_path,
+      :kind,
+      :mtime,
+      nil,
+      :output_path,
+      :schema_version,
+      :size,
+      :source,
+      :source_mtime,
+      :source_path,
+      :source_size
+    ]
+
+    Enum.each(atoms, fn
+      atom when is_atom(atom) -> atom
+      _ -> :ok
+    end)
+  end
+
+  defp manifest_path(%Project{} = project), do: Path.join(root_path(project), @file_name)
+
+  defp root_path(%Project{} = project) do
+    Project.workspace_path(project, ["indexes", "manifest"])
+  end
+end

--- a/apps/engine/lib/engine/search/indexer/paths.ex
+++ b/apps/engine/lib/engine/search/indexer/paths.ex
@@ -1,0 +1,285 @@
+defmodule Engine.Search.Indexer.Paths do
+  alias Forge.Project
+
+  @indexable_extensions "*.{ex,exs}"
+
+  defstruct source_paths: [], beam_paths: []
+
+  @type t :: %__MODULE__{
+          source_paths: [Path.t()],
+          beam_paths: [Path.t()]
+        }
+
+  def for_project(%Project{} = project) do
+    %__MODULE__{
+      source_paths: source_paths(project),
+      beam_paths: beam_paths(project)
+    }
+  end
+
+  def indexable_files(%Project{} = project) do
+    source_paths(project)
+  end
+
+  defp source_paths(%Project{} = project) do
+    source_roots = source_index_roots(project)
+    dependency_roots = dependency_roots(project)
+    roots_with_build_outputs = source_roots ++ dependency_roots
+    excluded_roots = dependency_roots ++ build_exclusion_roots(project, roots_with_build_outputs)
+
+    source_roots
+    |> Enum.flat_map(&indexable_files_in/1)
+    |> Enum.uniq()
+    |> reject_paths_under(excluded_roots)
+  end
+
+  defp indexable_files_in(root) do
+    Forge.Path.glob([root, "**", @indexable_extensions])
+  end
+
+  defp source_index_roots(%Project{} = project) do
+    project
+    |> Project.root_path()
+    |> List.wrap()
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp reject_paths_under(paths, []), do: paths
+
+  defp reject_paths_under(paths, roots) do
+    Enum.reject(paths, &contained_in_any?(&1, roots))
+  end
+
+  defp contained_in_any?(path, roots) do
+    Enum.any?(roots, &Forge.Path.contains?(path, &1))
+  end
+
+  defp beam_paths(%Project{kind: :mix} = project) do
+    build_dir = build_dir(project)
+    dependency_app_names = dependency_app_names(project)
+
+    build_dir
+    |> beam_app_paths()
+    |> Enum.filter(fn app_path ->
+      MapSet.member?(dependency_app_names, Path.basename(app_path))
+    end)
+    |> Enum.flat_map(&beam_files/1)
+  end
+
+  defp beam_paths(%Project{}), do: []
+
+  defp dependency_app_names(%Project{} = project) do
+    project
+    |> mix_dependency_app_names()
+    |> MapSet.union(configured_dependency_app_names(project))
+  end
+
+  defp mix_dependency_app_names(%Project{} = project) do
+    case Engine.Mix.in_project(project, fn _ ->
+           Mix.Dep.clear_cached()
+           Mix.Project.clear_deps_cache()
+           Mix.Project.deps_apps()
+         end) do
+      {:ok, app_names} -> MapSet.new(app_names, &Atom.to_string/1)
+      _ -> MapSet.new()
+    end
+  end
+
+  defp configured_dependency_app_names(%Project{} = project) do
+    configured_dependency_app_names(project, MapSet.new())
+  end
+
+  defp configured_dependency_app_names(%Project{} = project, seen_roots) do
+    root = Project.root_path(project)
+
+    if MapSet.member?(seen_roots, root) do
+      MapSet.new()
+    else
+      seen_roots = MapSet.put(seen_roots, root)
+
+      case Engine.Mix.in_project(project, fn _ ->
+             config = Mix.Project.config()
+             env = Mix.env()
+             target = Mix.target()
+
+             {dependency_app_names(config, env, target),
+              path_dependency_paths(config, env, target)}
+           end) do
+        {:ok, {app_names, path_roots}} ->
+          Enum.reduce(path_roots, app_names, fn path_root, app_names ->
+            path_root
+            |> project_for_path()
+            |> configured_dependency_app_names(seen_roots)
+            |> MapSet.union(app_names)
+          end)
+
+        _ ->
+          MapSet.new()
+      end
+    end
+  end
+
+  defp dependency_app_names(config, env, target) do
+    config
+    |> Keyword.get(:deps, [])
+    |> Enum.flat_map(&dependency_app_name(&1, env, target))
+    |> MapSet.new(&Atom.to_string/1)
+  end
+
+  defp dependency_app_name({app, opts}, env, target) when is_atom(app) and is_list(opts) do
+    dependency_app_name_from_opts(app, opts, env, target)
+  end
+
+  defp dependency_app_name({app, _requirement, opts}, env, target)
+       when is_atom(app) and is_list(opts) do
+    dependency_app_name_from_opts(app, opts, env, target)
+  end
+
+  defp dependency_app_name(_dep, _env, _target), do: []
+
+  defp dependency_app_name_from_opts(app, opts, env, target) do
+    app = Keyword.get(opts, :app, app)
+
+    if app != false and is_atom(app) and dependency_active?(opts, env, target) do
+      [app]
+    else
+      []
+    end
+  end
+
+  defp dependency_roots(%Project{kind: :mix} = project) do
+    [deps_path(project) | path_dependency_paths(project)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp dependency_roots(%Project{}), do: []
+
+  defp project_for_path(path) do
+    path
+    |> Forge.Document.Path.to_uri()
+    |> Project.new()
+  end
+
+  defp deps_path(%Project{kind: :mix} = project) do
+    case Engine.Mix.in_project(project, fn _ -> Mix.Project.deps_path() end) do
+      {:ok, path} -> path
+      _ -> Path.join(Project.root_path(project), "deps")
+    end
+  end
+
+  defp path_dependency_paths(%Project{} = project) do
+    case Engine.Mix.in_project(project, fn _ ->
+           path_dependency_paths(Mix.Project.config(), Mix.env(), Mix.target())
+         end) do
+      {:ok, roots} -> roots
+      _ -> []
+    end
+  end
+
+  defp path_dependency_paths(config, env, target) do
+    config
+    |> Keyword.get(:deps, [])
+    |> Enum.flat_map(&path_dependency_path(&1, env, target))
+  end
+
+  defp path_dependency_path({_app, opts}, env, target) when is_list(opts) do
+    path_dependency_path_from_opts(opts, env, target)
+  end
+
+  defp path_dependency_path({_app, _requirement, opts}, env, target) when is_list(opts) do
+    path_dependency_path_from_opts(opts, env, target)
+  end
+
+  defp path_dependency_path(_dep, _env, _target), do: []
+
+  defp path_dependency_path_from_opts(opts, env, target) do
+    path = Keyword.get(opts, :path)
+
+    if is_binary(path) and dependency_active?(opts, env, target) do
+      [Path.expand(path, File.cwd!())]
+    else
+      []
+    end
+  end
+
+  defp dependency_active?(opts, env, target) do
+    only_envs = opts |> Keyword.get(:only) |> List.wrap()
+    targets = opts |> Keyword.get(:targets) |> List.wrap()
+
+    dependency_active_in_env?(only_envs, env) and dependency_active_for_target?(targets, target)
+  end
+
+  defp dependency_active_in_env?([], _env), do: true
+  defp dependency_active_in_env?(envs, env), do: env in envs
+
+  defp dependency_active_for_target?([], _target), do: true
+  defp dependency_active_for_target?(targets, target), do: target in targets
+
+  defp build_exclusion_roots(%Project{kind: :mix} = project, roots) do
+    {runtime_build_path, configured_build_root} = build_paths(project)
+    relative_build_root = Path.relative_to(configured_build_root, Project.root_path(project))
+
+    dependency_build_roots = Enum.map(roots, &Path.expand(relative_build_root, &1))
+
+    [runtime_build_path, configured_build_root | dependency_build_roots]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp build_exclusion_roots(%Project{}, _roots), do: []
+
+  defp build_dir(%Project{kind: :mix} = project) do
+    project
+    |> build_paths()
+    |> elem(0)
+  end
+
+  defp build_paths(%Project{kind: :mix} = project) do
+    case Engine.Mix.in_project(project, fn project_module ->
+           {Mix.Project.build_path(), configured_build_root(project, project_module.project())}
+         end) do
+      {:ok, paths} -> paths
+      _ -> {source_build_dir(project), configured_build_root(project, [])}
+    end
+  end
+
+  defp configured_build_root(%Project{} = project, config) do
+    config = Keyword.put_new(config, :build_per_environment, true)
+
+    with_deleted_env("MIX_BUILD_PATH", fn ->
+      File.cd!(Project.root_path(project), fn ->
+        config
+        |> Mix.Project.build_path()
+        |> Path.dirname()
+      end)
+    end)
+  end
+
+  defp source_build_dir(%Project{} = project) do
+    Path.join(Project.root_path(project), "_build")
+  end
+
+  defp with_deleted_env(name, fun) do
+    original = System.fetch_env(name)
+    System.delete_env(name)
+
+    try do
+      fun.()
+    after
+      restore_env(name, original)
+    end
+  end
+
+  defp restore_env(name, {:ok, value}), do: System.put_env(name, value)
+  defp restore_env(name, :error), do: System.delete_env(name)
+
+  defp beam_app_paths(build_dir) do
+    Path.wildcard(Path.join([build_dir, "lib", "*"]))
+  end
+
+  defp beam_files(app_path) do
+    Path.wildcard(Path.join([app_path, "ebin", "*.beam"]))
+  end
+end

--- a/apps/engine/lib/engine/search/indexer/sources.ex
+++ b/apps/engine/lib/engine/search/indexer/sources.ex
@@ -1,0 +1,63 @@
+defmodule Engine.Search.Indexer.Sources do
+  alias Engine.Progress
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.Source
+
+  def index(paths) when is_list(paths) do
+    paths
+    |> map_paths("Indexing source code", "Indexing", &index_path/1)
+    |> entries_and_manifest_entries()
+  end
+
+  defp index_path(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, [_ | _] = entries} <- Source.index(path, contents),
+         true <- has_search_entries?(entries),
+         {:ok, manifest_entry} <- Manifest.Entry.source(path) do
+      [{entries, manifest_entry}]
+    else
+      _ -> []
+    end
+  end
+
+  defp has_search_entries?(entries) do
+    Enum.any?(entries, fn entry -> entry.subtype != :block_structure end)
+  end
+
+  defp entries_and_manifest_entries(results) do
+    entries = Enum.flat_map(results, fn {entries, _manifest_entry} -> entries end)
+    manifest_entries = Enum.map(results, fn {_entries, manifest_entry} -> manifest_entry end)
+
+    {entries, manifest_entries}
+  end
+
+  defp map_paths([], _title, _message, _processor), do: []
+
+  defp map_paths(paths, title, message, processor) do
+    Progress.with_tracked_progress(title, length(paths), fn report ->
+      start_time = System.monotonic_time(:millisecond)
+
+      results =
+        paths
+        |> Task.async_stream(
+          fn path ->
+            report.(message: message, add: 1)
+            processor.(path)
+          end,
+          timeout: :infinity
+        )
+        |> Enum.flat_map(&task_result!/1)
+
+      elapsed = System.monotonic_time(:millisecond) - start_time
+      {:done, results, "Completed in #{format_duration(elapsed)}"}
+    end)
+  end
+
+  defp task_result!({:ok, items}), do: items
+
+  defp task_result!({:exit, reason}),
+    do: raise("Indexing task failed: #{Exception.format_exit(reason)}")
+
+  defp format_duration(ms) when ms < 1000, do: "#{ms}ms"
+  defp format_duration(ms), do: "#{Float.round(ms / 1000, 1)}s"
+end

--- a/apps/engine/lib/engine/search/store.ex
+++ b/apps/engine/lib/engine/search/store.ex
@@ -16,23 +16,19 @@ defmodule Engine.Search.Store do
   require Logger
 
   @type index_state :: :empty | :stale
-  @type existing_entries :: [Entry.t()]
-  @type new_entries :: [Entry.t()]
-  @type updated_entries :: [Entry.t()]
-  @type paths_to_delete :: [Path.t()]
+  @type index_result :: :ok | {:error, term()}
+
   @typedoc """
   A function that creates indexes when none is detected
   """
   @type create_index ::
-          (project :: Project.t() ->
-             {:ok, new_entries} | {:error, term()})
+          (project :: Project.t(), backend :: module() -> index_result())
 
   @typedoc """
-  A function that takes existing entries and refreshes them if necessary
+  A function that uses the store backend to refresh the index if necessary.
   """
   @type refresh_index ::
-          (project :: Project.t(), entries :: existing_entries ->
-             {:ok, new_entries, paths_to_delete} | {:error, term()})
+          (project :: Project.t(), backend :: module() -> index_result())
 
   @backend Application.compile_env(:engine, :search_store_backend, Store.Backends.Ets)
   @flush_interval_ms Application.compile_env(
@@ -51,6 +47,16 @@ defmodule Engine.Search.Store do
 
   def replace(entries) do
     GenServer.call(__MODULE__, {:replace, entries})
+  end
+
+  @doc false
+  def refresh_index(%Project{}) do
+    GenServer.call(__MODULE__, :refresh_index, :infinity)
+  end
+
+  @doc false
+  def rebuild_index(%Project{}) do
+    GenServer.call(__MODULE__, :rebuild_index, :infinity)
   end
 
   @spec exact(Entry.subject_query(), Entry.constraints()) :: {:ok, [Entry.t()]} | {:error, term()}
@@ -108,7 +114,7 @@ defmodule Engine.Search.Store do
     GenServer.call(__MODULE__, :enable)
   end
 
-  @spec start_link(Project.t(), create_index, refresh_index, module()) :: GenServer.on_start()
+  @spec start_link(Project.t(), create_index(), refresh_index(), module()) :: GenServer.on_start()
   def start_link(%Project{} = project, create_index, refresh_index, backend) do
     GenServer.start_link(__MODULE__, [project, create_index, refresh_index, backend],
       name: __MODULE__
@@ -131,7 +137,7 @@ defmodule Engine.Search.Store do
   end
 
   defp normalize_init_args([%Project{}, create_index, refresh_index, backend] = args)
-       when is_function(create_index, 1) and is_function(refresh_index, 2) and is_atom(backend) do
+       when is_function(create_index, 2) and is_function(refresh_index, 2) and is_atom(backend) do
     args
   end
 
@@ -196,6 +202,50 @@ defmodule Engine.Search.Store do
       case State.replace(state, entities) do
         {:ok, new_state} ->
           {:ok, State.drop_buffered_updates(new_state)}
+
+        {:error, _} = error ->
+          {error, state}
+      end
+
+    {:reply, reply, {ref, new_state}}
+  end
+
+  def handle_call(
+        message,
+        _from,
+        {ref, %State{loaded?: false} = state}
+      )
+      when message in [:refresh_index, :rebuild_index] do
+    {:reply, {:error, :loading}, {ref, state}}
+  end
+
+  def handle_call(
+        message,
+        _from,
+        {ref, %State{async_load_ref: async_load_ref} = state}
+      )
+      when message in [:refresh_index, :rebuild_index] and is_reference(async_load_ref) do
+    {:reply, {:error, :loading}, {ref, state}}
+  end
+
+  def handle_call(:refresh_index, _from, {ref, %State{} = state}) do
+    {reply, new_state} =
+      case State.refresh_index(state) do
+        {:ok, new_state} ->
+          {:ok, new_state}
+
+        {:error, _} = error ->
+          {error, state}
+      end
+
+    {:reply, reply, {ref, new_state}}
+  end
+
+  def handle_call(:rebuild_index, _from, {ref, %State{} = state}) do
+    {reply, new_state} =
+      case State.rebuild_index(state) do
+        {:ok, new_state} ->
+          {:ok, new_state}
 
         {:error, _} = error ->
           {error, state}

--- a/apps/engine/lib/engine/search/store/backend.ex
+++ b/apps/engine/lib/engine/search/store/backend.ex
@@ -5,18 +5,10 @@ defmodule Engine.Search.Store.Backend do
   alias Forge.Project
   alias Forge.Search.Indexer.Entry
 
-  @type version :: pos_integer()
-
   @type priv_state :: term()
   @type load_state :: :empty | :stale
   @type field_name :: atom()
   @type name :: term
-  @type metadata :: %{
-          schema_version: version(),
-          types: [Entry.entry_type()],
-          subtypes: [Entry.entry_subtype()]
-        }
-
   @type wildcard :: :_
   @type subject_query :: Entry.subject() | wildcard()
   @type type_query :: Entry.entry_type() | wildcard()
@@ -37,7 +29,7 @@ defmodule Engine.Search.Store.Backend do
   This receives the result of `new/1`, and sets up the store for use. When this function
   returns, the backend is considered ready for use.
   """
-  @callback prepare(priv_state()) :: {:ok, load_state()}
+  @callback prepare(priv_state()) :: {:ok, load_state()} | {:error, any()}
 
   @doc """
   Synchronizes the backend to the file system (optional)
@@ -67,7 +59,7 @@ defmodule Engine.Search.Store.Backend do
   @doc """
   Replaces all the entries in the store with those passed in
   """
-  @callback replace_all([Entry.t()]) :: :ok
+  @callback replace_all(Enumerable.t(Entry.t())) :: :ok
 
   @doc """
   Deletes all entries whose path is equal to the one passed in.

--- a/apps/engine/lib/engine/search/store/state.ex
+++ b/apps/engine/lib/engine/search/store/state.ex
@@ -83,6 +83,26 @@ defmodule Engine.Search.Store.State do
     end
   end
 
+  def refresh_index(%__MODULE__{} = state) do
+    case state.update_index.(state.project, state.backend) do
+      :ok ->
+        {:ok, initialize_fuzzy(state)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  def rebuild_index(%__MODULE__{} = state) do
+    case state.create_index.(state.project, state.backend) do
+      :ok ->
+        {:ok, state |> initialize_fuzzy() |> drop_buffered_updates()}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
   def exact(%__MODULE__{loaded?: false}, _subject, _constraints) do
     {:error, :loading}
   end
@@ -259,7 +279,7 @@ defmodule Engine.Search.Store.State do
         case state.backend.prepare(backend_result) do
           {:ok, :empty} ->
             Logger.info("backend reports empty")
-            {:create_index, state.create_index.(state.project)}
+            {:create_index, state.create_index.(state.project, state.backend)}
 
           {:ok, :stale} ->
             Logger.info("backend reports stale")
@@ -277,15 +297,8 @@ defmodule Engine.Search.Store.State do
     %__MODULE__{state | async_load_ref: task.ref}
   end
 
-  defp create_index_complete(%__MODULE__{} = state, {:ok, entries}) do
-    case replace(state, entries) do
-      {:ok, state} ->
-        state
-
-      {:error, _} ->
-        Logger.warning("Could not replace entries")
-        state
-    end
+  defp create_index_complete(%__MODULE__{} = state, :ok) do
+    initialize_fuzzy(state)
   end
 
   defp create_index_complete(%__MODULE__{} = state, {:error, _} = error) do
@@ -293,21 +306,8 @@ defmodule Engine.Search.Store.State do
     state
   end
 
-  defp update_index_complete(%__MODULE__{} = state, {:ok, updated_entries, deleted_paths}) do
-    starting_state = initialize_fuzzy(%__MODULE__{state | loaded?: true})
-
-    new_state =
-      updated_entries
-      |> Enum.group_by(& &1.path)
-      |> Enum.reduce(starting_state, fn {path, entry_list}, state ->
-        {:ok, new_state} = update_nosync(state, path, entry_list)
-        new_state
-      end)
-
-    Enum.reduce(deleted_paths, new_state, fn path, state ->
-      {:ok, new_state} = update_nosync(state, path, [])
-      new_state
-    end)
+  defp update_index_complete(%__MODULE__{} = state, :ok) do
+    initialize_fuzzy(state)
   end
 
   defp update_index_complete(%__MODULE__{} = state, {:error, _} = error) do

--- a/apps/engine/test/engine/code_intelligence/references_test.exs
+++ b/apps/engine/test/engine/code_intelligence/references_test.exs
@@ -25,7 +25,7 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
     start_supervised!(Backends.Ets)
 
     start_supervised!(
-      {Search.Store, [project, fn _ -> {:ok, []} end, fn _, _ -> {:ok, [], []} end, Backends.Ets]}
+      {Search.Store, [project, fn _, _ -> :ok end, fn _, _ -> :ok end, Backends.Ets]}
     )
 
     Search.Store.enable()

--- a/apps/engine/test/engine/code_intelligence/structs_test.exs
+++ b/apps/engine/test/engine/code_intelligence/structs_test.exs
@@ -1,0 +1,21 @@
+defmodule Engine.CodeIntelligence.StructsTest do
+  use ExUnit.Case
+  use Patch
+
+  alias Engine.CodeIntelligence.Structs
+  alias Engine.Search.Store
+  alias Forge.Project
+  alias Forge.Search.Indexer.Entry
+
+  test "returns indexed struct definitions without requiring loaded modules" do
+    struct_module = Module.concat(__MODULE__, IndexedOnlyStruct)
+
+    patch(Engine, :get_project, fn -> %Project{kind: :bare} end)
+
+    patch(Store, :exact, fn [type: :struct, subtype: :definition] ->
+      {:ok, [%Entry{subject: struct_module}]}
+    end)
+
+    assert Structs.for_project() == {:ok, [struct_module]}
+  end
+end

--- a/apps/engine/test/engine/commands/reindex_test.exs
+++ b/apps/engine/test/engine/commands/reindex_test.exs
@@ -3,6 +3,7 @@ defmodule Engine.Commands.ReindexTest do
   use Patch
 
   import Engine.Test.Entry.Builder
+  import Forge.EngineApi.Messages
   import Forge.Test.EventualAssertions
   import Forge.Test.Fixtures
 
@@ -10,12 +11,17 @@ defmodule Engine.Commands.ReindexTest do
   alias Engine.Search
   alias Forge.Document
 
-  setup do
-    reindex_fun = fn _ ->
-      Process.sleep(20)
-    end
+  setup context do
+    case Map.get(context, :reindex_fun, :sleep) do
+      :default ->
+        start_supervised!(Reindex)
 
-    start_supervised!({Reindex, reindex_fun: reindex_fun})
+      :sleep ->
+        start_supervised!({Reindex, reindex_fun: fn _ -> Process.sleep(20) end})
+
+      :none ->
+        :ok
+    end
 
     {:ok, project: project()}
   end
@@ -38,10 +44,6 @@ defmodule Engine.Commands.ReindexTest do
   test "another reindex can be enqueued", %{project: project} do
     assert :ok = Reindex.perform(project)
     assert_eventually :ok = Reindex.perform(project)
-  end
-
-  def put_entries(uri, entries) do
-    Process.put(uri, entries)
   end
 
   describe "uri/1" do
@@ -71,7 +73,7 @@ defmodule Engine.Commands.ReindexTest do
     test "reindexes a specific uri" do
       uri = "file:///file.ex"
       entries = [reference()]
-      put_entries(uri, entries)
+      Process.put(uri, entries)
       Reindex.uri(uri)
       assert_receive {:entries, "/file.ex", ^entries}
     end
@@ -79,11 +81,59 @@ defmodule Engine.Commands.ReindexTest do
     test "buffers updates if a reindex is in progress", %{project: project} do
       uri = "file:///file.ex"
       new_entries = [reference(), definition()]
-      put_entries(uri, new_entries)
+      Process.put(uri, new_entries)
       Reindex.perform(project)
       Reindex.uri(uri)
 
       assert_receive {:entries, "/file.ex", ^new_entries}
+    end
+  end
+
+  describe "perform/1 with the default reindexer" do
+    @tag reindex_fun: :default
+    test "broadcasts success when rebuilding the search index succeeds", %{project: project} do
+      test_pid = self()
+
+      patch(Search.Store, :rebuild_index, fn ^project ->
+        send(test_pid, :rebuild_index)
+        :ok
+      end)
+
+      patch(Search.Store, :refresh_index, fn ^project ->
+        send(test_pid, :refresh_index)
+        :ok
+      end)
+
+      patch(Engine, :broadcast, fn message ->
+        send(test_pid, {:broadcast, message})
+        :ok
+      end)
+
+      assert :ok = Reindex.perform(project)
+
+      assert_receive {:broadcast, project_reindex_requested(project: ^project)}
+      assert_receive :rebuild_index
+      assert_receive {:broadcast, project_reindexed(project: ^project, status: :success)}
+      refute_receive :refresh_index
+    end
+
+    @tag reindex_fun: :default
+    test "broadcasts the error when rebuilding the search index fails", %{project: project} do
+      test_pid = self()
+
+      patch(Search.Store, :rebuild_index, fn ^project -> {:error, :rebuild_failed} end)
+
+      patch(Engine, :broadcast, fn message ->
+        send(test_pid, {:broadcast, message})
+        :ok
+      end)
+
+      assert :ok = Reindex.perform(project)
+
+      assert_receive {:broadcast, project_reindex_requested(project: ^project)}
+
+      assert_receive {:broadcast,
+                      project_reindexed(project: ^project, status: {:error, :rebuild_failed})}
     end
   end
 end

--- a/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
+++ b/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
@@ -15,7 +15,7 @@ defmodule Engine.Dispatch.Handlers.IndexingTest do
   setup do
     project = project()
     Engine.set_project(project)
-    create_index = &Search.Indexer.create_index/1
+    create_index = &Search.Indexer.create_index/2
     update_index = &Search.Indexer.update_index/2
 
     # Mock the broadcast so progress reporting doesn't fail

--- a/apps/engine/test/engine/search/indexer/beams_test.exs
+++ b/apps/engine/test/engine/search/indexer/beams_test.exs
@@ -1,0 +1,545 @@
+defmodule Engine.Search.Indexer.BeamsTest do
+  use ExUnit.Case
+  use Patch
+
+  import Forge.Test.RangeSupport
+
+  alias Engine.Search.Indexer.Beams
+  alias Forge.Formats
+  alias Forge.Search.Indexer.Entry
+
+  @moduletag :tmp_dir
+
+  setup do
+    start_supervised!(Engine.ApplicationCache)
+
+    patch(Engine.Dispatch, :erpc_call, fn
+      Expert.Progress, :begin, [_title, _opts] ->
+        {:ok, System.unique_integer([:positive])}
+
+      Expert.Progress, :report, _args ->
+        :ok
+    end)
+
+    patch(Engine.Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
+
+    :ok
+  end
+
+  describe "index/1" do
+    test "indexes public functions and macros from beam metadata", %{tmp_dir: tmp_dir} do
+      module = unique_module("Definitions")
+      public_fun = Formats.mfa(module, :public_fun, 0)
+      with_default_0 = Formats.mfa(module, :with_default, 0)
+      with_default_1 = Formats.mfa(module, :with_default, 1)
+      with_default_2 = Formats.mfa(module, :with_default, 2)
+      guarded_0 = Formats.mfa(module, :guarded, 0)
+      guarded_1 = Formats.mfa(module, :guarded, 1)
+      public_macro = Formats.mfa(module, :public_macro, 1)
+
+      source = """
+      defmodule #{inspect(module)} do
+        def public_fun, do: private_fun()
+        def with_default(a \\\\ :ok, b \\\\ :ok), do: {a, b}
+        def guarded(value \\\\ :ok) when is_atom(value), do: value
+        defmacro public_macro(expr), do: expr
+        defp private_fun, do: :ok
+      end
+      """
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          source,
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == module and &1.type == :module and &1.subtype == :definition)
+             )
+
+      refute Enum.any?(
+               entries,
+               &(&1.subject == module and &1.type == :struct and &1.subtype == :definition)
+             )
+
+      for {subject, type} <- [
+            {public_fun, {:function, :public}},
+            {with_default_0, {:function, :public}},
+            {with_default_1, {:function, :public}},
+            {with_default_2, {:function, :public}},
+            {guarded_0, {:function, :public}},
+            {guarded_1, {:function, :public}},
+            {public_macro, {:macro, :public}}
+          ] do
+        assert Enum.any?(
+                 entries,
+                 &(&1.subject == subject and &1.type == type and &1.subtype == :definition)
+               )
+      end
+
+      for subject <- [with_default_0, with_default_1, with_default_2, guarded_0, guarded_1] do
+        assert [%Entry{}] =
+                 Enum.filter(
+                   entries,
+                   &(&1.subject == subject and &1.type == {:function, :public} and
+                       &1.subtype == :definition)
+                 )
+      end
+
+      private_fun = Formats.mfa(module, :private_fun, 0)
+      refute Enum.any?(entries, &(&1.subject == private_fun and &1.subtype == :definition))
+    end
+
+    test "does not run the source indexer for BEAM-backed entries", %{tmp_dir: tmp_dir} do
+      patch(Engine.Search.Indexer.Source, :index, fn _path, _source, _extractors ->
+        flunk("BEAM indexing must not call the source indexer")
+      end)
+
+      module = unique_module("NoSourceIndexer")
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          "defmodule #{inspect(module)} do\n  def value, do: :ok\nend\n",
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == module and &1.type == :module and &1.subtype == :definition)
+             )
+    end
+
+    test "preserves defdelegate metadata without dangling block ids", %{tmp_dir: tmp_dir} do
+      module = unique_module("Delegate")
+
+      %{entries: entries, source_path: source_path} =
+        index_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(module)} do
+            defdelegate trim(value), to: String
+          end
+          """,
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      trim_mfa = Formats.mfa(module, :trim, 1)
+
+      assert %Entry{
+               type: {:function, :delegate},
+               block_id: :root,
+               metadata: %{original_mfa: original_mfa}
+             } =
+               Enum.find(
+                 entries,
+                 &(&1.subject == trim_mfa and &1.type == {:function, :delegate} and
+                     &1.subtype == :definition)
+               )
+
+      assert original_mfa == Formats.mfa(String, :trim, 1)
+
+      refute Enum.any?(
+               entries,
+               &(&1.subject == trim_mfa and &1.type == {:function, :public} and
+                   &1.subtype == :definition)
+             )
+
+      assert %Entry{subject: %{root: %{}}} =
+               Enum.find(
+                 entries,
+                 &(&1.path == source_path and &1.type == :metadata and
+                     &1.subtype == :block_structure)
+               )
+    end
+
+    test "preserves all callable defdelegate arities from default arguments", %{tmp_dir: tmp_dir} do
+      module = unique_module("DelegateDefaults")
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(module)} do
+            defdelegate trim(value \\\\ " default "), to: String
+          end
+          """,
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      for arity <- 0..1 do
+        trim_mfa = Formats.mfa(module, :trim, arity)
+
+        assert [
+                 %Entry{
+                   type: {:function, :delegate},
+                   block_id: :root,
+                   metadata: %{original_mfa: original_mfa}
+                 }
+               ] =
+                 Enum.filter(
+                   entries,
+                   &(&1.subject == trim_mfa and &1.type == {:function, :delegate} and
+                       &1.subtype == :definition)
+                 )
+
+        assert original_mfa == Formats.mfa(String, :trim, 1)
+
+        refute Enum.any?(
+                 entries,
+                 &(&1.subject == trim_mfa and &1.type == {:function, :public} and
+                     &1.subtype == :definition)
+               )
+      end
+    end
+
+    test "does not import delegates for modules whose beams were not indexed", %{tmp_dir: tmp_dir} do
+      indexed_module = unique_module("IndexedDelegate")
+      skipped_module = unique_module("SkippedDelegate")
+
+      %{beam_paths_by_module: beam_paths_by_module} =
+        compile_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(indexed_module)} do
+            defdelegate trim(value), to: String
+          end
+
+          defmodule #{inspect(skipped_module)} do
+            defdelegate downcase(value), to: String
+          end
+          """,
+          expected_modules: [indexed_module, skipped_module],
+          rewrite_source?: false
+        )
+
+      {entries, _manifest_entries} =
+        Beams.index([Map.fetch!(beam_paths_by_module, indexed_module)])
+
+      indexed_trim = Formats.mfa(indexed_module, :trim, 1)
+      skipped_downcase = Formats.mfa(skipped_module, :downcase, 1)
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == indexed_trim and &1.type == {:function, :delegate} and
+                   &1.subtype == :definition)
+             )
+
+      refute Enum.any?(entries, &(&1.subject == skipped_module and &1.subtype == :definition))
+
+      refute Enum.any?(
+               entries,
+               &(&1.subject == skipped_downcase and &1.type == {:function, :delegate} and
+                   &1.subtype == :definition)
+             )
+    end
+
+    test "does not import nested module delegates when only parent beam was indexed", %{
+      tmp_dir: tmp_dir
+    } do
+      parent_module = unique_module("ParentDelegate")
+      child_module = Module.concat(parent_module, Child)
+
+      %{beam_paths_by_module: beam_paths_by_module} =
+        compile_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(parent_module)} do
+            def value, do: :ok
+
+            defmodule Child do
+              defdelegate downcase(value), to: String
+            end
+          end
+          """,
+          expected_modules: [parent_module, child_module],
+          rewrite_source?: false
+        )
+
+      {entries, _manifest_entries} =
+        Beams.index([Map.fetch!(beam_paths_by_module, parent_module)])
+
+      child_downcase = Formats.mfa(child_module, :downcase, 1)
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == parent_module and &1.type == :module and &1.subtype == :definition)
+             )
+
+      refute Enum.any?(entries, &(&1.subject == child_module and &1.subtype == :definition))
+
+      refute Enum.any?(
+               entries,
+               &(&1.subject == child_downcase and &1.type == {:function, :delegate} and
+                   &1.subtype == :definition)
+             )
+    end
+
+    test "reports progress per beam chunk instead of per beam", %{tmp_dir: tmp_dir} do
+      test_pid = self()
+
+      patch(Engine.Dispatch, :erpc_call, fn
+        Expert.Progress, :begin, ["Indexing dependencies metadata", _opts] ->
+          {:ok, System.unique_integer([:positive])}
+
+        Expert.Progress, :begin, [_title, _opts] ->
+          {:ok, System.unique_integer([:positive])}
+
+        Expert.Progress, :report, [_token, opts] ->
+          send(test_pid, {:dependency_progress_report, opts})
+          :ok
+      end)
+
+      modules = for index <- 1..4, do: unique_module("Progress#{index}")
+
+      source =
+        Enum.map_join(modules, "\n", fn module ->
+          """
+          defmodule #{inspect(module)} do
+            def value, do: :ok
+          end
+          """
+        end)
+
+      %{beam_paths: beam_paths} =
+        compile_source!(tmp_dir, source,
+          expected_modules: modules,
+          rewrite_source?: false
+        )
+
+      assert [_first, _second | _rest] = beam_paths
+
+      {entries, _manifest_entries} = Beams.index(beam_paths)
+
+      for module <- modules do
+        assert Enum.any?(
+                 entries,
+                 &(&1.subject == module and &1.type == :module and &1.subtype == :definition)
+               )
+      end
+
+      assert_receive {:dependency_progress_report, _opts}
+      refute_receive {:dependency_progress_report, _opts}, 100
+    end
+
+    test "indexes struct definitions from beam metadata", %{tmp_dir: tmp_dir} do
+      module = unique_module("Struct")
+
+      source = """
+      defmodule #{inspect(module)} do
+        defstruct [:name]
+      end
+      """
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          source,
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == module and &1.type == :module and &1.subtype == :definition)
+             )
+
+      assert Enum.any?(
+               entries,
+               &(&1.subject == module and &1.type == :struct and &1.subtype == :definition)
+             )
+    end
+
+    test "indexes protocols and implementations from beam metadata", %{tmp_dir: tmp_dir} do
+      protocol = unique_module("Protocol")
+      implementation = Module.concat(protocol, Atom)
+
+      source = """
+      defprotocol #{inspect(protocol)} do
+        def to_value(value)
+      end
+
+      defimpl #{inspect(protocol)}, for: Atom do
+        def to_value(value), do: Atom.to_string(value)
+      end
+      """
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          source,
+          expected_modules: [protocol, implementation],
+          rewrite_source?: false
+        )
+
+      protocol_fun = Formats.mfa(protocol, :to_value, 1)
+
+      for {subject, type} <- [
+            {protocol, {:protocol, :definition}},
+            {protocol_fun, {:function, :public}},
+            {protocol, {:protocol, :implementation}},
+            {implementation, :module}
+          ] do
+        assert Enum.any?(
+                 entries,
+                 &(&1.subject == subject and &1.type == type and &1.subtype == :definition)
+               )
+      end
+
+      assert %Entry{range: range} =
+               Enum.find(
+                 entries,
+                 &(&1.subject == protocol and &1.type == {:protocol, :definition} and
+                     &1.subtype == :definition)
+               )
+
+      assert extract(source, range) == inspect(protocol)
+
+      for {subject, type} <- [
+            {protocol, {:protocol, :implementation}},
+            {implementation, :module}
+          ] do
+        assert %Entry{range: range} =
+                 Enum.find(
+                   entries,
+                   &(&1.subject == subject and &1.type == type and &1.subtype == :definition)
+                 )
+
+        assert extract(source, range) == "defimpl #{inspect(protocol)}, for: Atom do"
+      end
+    end
+
+    test "uses source spans for module definition ranges", %{tmp_dir: tmp_dir} do
+      module = unique_module("Range")
+
+      %{entries: entries} =
+        index_source!(
+          tmp_dir,
+          "defmodule #{inspect(module)} do\nend\n",
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      assert %Entry{range: range} =
+               Enum.find(
+                 entries,
+                 &(&1.subject == module and &1.type == :module and &1.subtype == :definition)
+               )
+
+      assert range.start.line == 1
+      assert range.start.character == 11
+      assert range.end.character == 11 + String.length(Formats.module(module))
+    end
+
+    test "uses source-visible ranges for nested module definitions", %{tmp_dir: tmp_dir} do
+      parent = unique_module("NestedRange")
+      child = Module.concat(parent, Child)
+      sibling = Module.concat(parent, Sibling)
+
+      source = """
+      defmodule #{inspect(parent)} do
+        defmodule Child do
+        end
+
+        defmodule __MODULE__.Sibling do
+        end
+      end
+      """
+
+      %{entries: entries} =
+        index_source!(tmp_dir, source,
+          expected_modules: [parent, child, sibling],
+          rewrite_source?: false
+        )
+
+      assert %Entry{range: range} =
+               Enum.find(
+                 entries,
+                 &(&1.subject == child and &1.type == :module and &1.subtype == :definition)
+               )
+
+      assert extract(source, range) == "Child"
+
+      assert %Entry{range: range} =
+               Enum.find(
+                 entries,
+                 &(&1.subject == sibling and &1.type == :module and &1.subtype == :definition)
+               )
+
+      assert extract(source, range) == "__MODULE__.Sibling"
+    end
+  end
+
+  defp index_source!(tmp_dir, source, opts) do
+    context = compile_source!(tmp_dir, source, opts)
+    {entries, manifest_entries} = Beams.index(context.beam_paths)
+
+    context
+    |> Map.put(:entries, entries)
+    |> Map.put(:manifest_entries, manifest_entries)
+  end
+
+  defp compile_source!(tmp_dir, source, opts) do
+    source_path =
+      Path.join([tmp_dir, "lib", "beam_source_#{System.unique_integer([:positive])}.ex"])
+
+    ebin_path =
+      Path.join([tmp_dir, "ebin", Integer.to_string(System.unique_integer([:positive]))])
+
+    File.mkdir_p!(Path.dirname(source_path))
+    File.mkdir_p!(ebin_path)
+    File.write!(source_path, source)
+
+    compiler_options = Code.compiler_options()
+
+    compiled_modules =
+      try do
+        Code.compiler_options(debug_info: Keyword.get(opts, :debug_info?, true))
+
+        assert {:ok, compiled_modules, %{compile_warnings: [], runtime_warnings: []}} =
+                 Kernel.ParallelCompiler.compile_to_path([source_path], ebin_path,
+                   return_diagnostics: true
+                 )
+
+        compiled_modules
+      after
+        Code.compiler_options(compiler_options)
+      end
+
+    case Keyword.fetch(opts, :expected_modules) do
+      {:ok, expected_modules} ->
+        assert Enum.sort(compiled_modules) == Enum.sort(expected_modules)
+
+      :error ->
+        :ok
+    end
+
+    if Keyword.get(opts, :rewrite_source?, true) do
+      File.write!(source_path, "defmodule")
+      File.touch!(source_path, {{2000, 1, 1}, {0, 0, 0}})
+    end
+
+    beam_paths_by_module =
+      Map.new(compiled_modules, fn module ->
+        {module, Path.join(ebin_path, Atom.to_string(module) <> ".beam")}
+      end)
+
+    %{
+      beam_paths: Map.values(beam_paths_by_module),
+      beam_paths_by_module: beam_paths_by_module,
+      compiled_modules: compiled_modules,
+      ebin_path: ebin_path,
+      source_path: source_path
+    }
+  end
+
+  defp unique_module(prefix) do
+    Module.concat(__MODULE__, :"#{prefix}#{System.unique_integer([:positive])}")
+  end
+end

--- a/apps/engine/test/engine/search/indexer/extractors/function_definition_test.exs
+++ b/apps/engine/test/engine/search/indexer/extractors/function_definition_test.exs
@@ -228,6 +228,25 @@ defmodule Engine.Search.Indexer.Extractors.FunctionDefinitionTest do
                "  defdelegate «collect(enumerable, other)», to: Enum, as: :map"
     end
 
+    test "indexes all callable arities for defdelegate with default arguments" do
+      code =
+        ~q[
+          defmodule MyModule do
+            defdelegate trim(value \\ " default "), to: String
+          end
+        ]
+
+      {:ok, entries, _doc} = index(code)
+
+      assert Enum.map(entries, & &1.subject) == [
+               "MyModule.trim/0",
+               "MyModule.trim/1"
+             ]
+
+      assert Enum.all?(entries, &(&1.type == {:function, :delegate}))
+      assert Enum.all?(entries, &(&1.metadata.original_mfa == "String.trim/1"))
+    end
+
     test "skips public functions defined in quote blocks" do
       code =
         ~q[

--- a/apps/engine/test/engine/search/indexer/manifest_store_test.exs
+++ b/apps/engine/test/engine/search/indexer/manifest_store_test.exs
@@ -1,0 +1,234 @@
+defmodule Engine.Search.Indexer.ManifestStoreTest do
+  use ExUnit.Case, async: true
+
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.Manifest.Entry, as: ManifestEntry
+  alias Engine.Search.Indexer.ManifestStore
+  alias Forge.Project
+
+  @moduletag :tmp_dir
+
+  describe "load/1" do
+    test "returns missing when no manifest has been committed", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+
+      assert ManifestStore.load(project) == :missing
+    end
+
+    test "returns missing for corrupt manifests", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      write_committed_manifest!(project, "not an erlang term")
+
+      assert ManifestStore.load(project) == :missing
+    end
+
+    test "loads committed records", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      manifest = manifest(tmp_dir)
+
+      :ok = ManifestStore.commit(project, manifest)
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+      assert Manifest.entries(loaded_manifest) == Manifest.entries(manifest)
+    end
+
+    test "loads manifests with legacy backend metadata", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+
+      write_committed_manifest!(
+        project,
+        :erlang.term_to_binary(%{
+          backend: "legacy",
+          schema_version: 1,
+          entries: encode_entries(manifest(tmp_dir))
+        })
+      )
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+      assert Manifest.entries(loaded_manifest) == Manifest.entries(manifest(tmp_dir))
+    end
+
+    test "loads manifests with legacy schema metadata", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+
+      write_committed_manifest!(
+        project,
+        :erlang.term_to_binary(%{
+          schema_version: 2,
+          entries: encode_entries(manifest(tmp_dir))
+        })
+      )
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+      assert Manifest.entries(loaded_manifest) == Manifest.entries(manifest(tmp_dir))
+    end
+
+    test "loads beam entries without requiring module atoms", %{
+      tmp_dir: tmp_dir
+    } do
+      project = project(tmp_dir)
+      source_path = Path.join(tmp_dir, "source.ex")
+      beam_path = Path.join(tmp_dir, "Elixir.Unloaded.beam")
+
+      write_committed_manifest!(
+        project,
+        :erlang.term_to_binary(%{
+          entries: [
+            %{
+              input_path: beam_path,
+              output_path: source_path,
+              kind: :beam,
+              mtime: {{2026, 5, 18}, {0, 0, 0}},
+              size: 10
+            }
+          ]
+        })
+      )
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+
+      assert [
+               %ManifestEntry{input_path: ^beam_path, output_path: ^source_path, kind: :beam}
+             ] = Manifest.entries(loaded_manifest)
+    end
+
+    test "loads legacy atom manifests written by another VM", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      source_path = Path.join(tmp_dir, "legacy.ex")
+
+      write_legacy_manifest_from_external_vm!(project, source_path)
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+
+      assert [
+               %ManifestEntry{input_path: ^source_path, output_path: ^source_path, kind: :source}
+             ] = Manifest.entries(loaded_manifest)
+    end
+  end
+
+  describe "commit/2" do
+    test "writes a committed manifest", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      manifest = manifest(tmp_dir, "source.ex")
+
+      :ok = ManifestStore.commit(project, manifest)
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+      assert Manifest.entries(loaded_manifest) == Manifest.entries(manifest)
+    end
+
+    test "encodes artifact kinds without persisted atoms", %{
+      tmp_dir: tmp_dir
+    } do
+      project = project(tmp_dir)
+      manifest = manifest(tmp_dir, "source.ex")
+
+      :ok = ManifestStore.commit(project, manifest)
+
+      assert %{
+               entries: [
+                 %{
+                   kind: "source"
+                 }
+               ]
+             } =
+               project
+               |> manifest_path()
+               |> File.read!()
+               |> :erlang.binary_to_term()
+    end
+
+    test "replaces the previous committed manifest", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      first_manifest = manifest(tmp_dir, "first.ex")
+      second_manifest = manifest(tmp_dir, "second.ex")
+
+      :ok = ManifestStore.commit(project, first_manifest)
+      :ok = ManifestStore.commit(project, second_manifest)
+
+      assert {:ok, loaded_manifest} = ManifestStore.load(project)
+      assert Manifest.entries(loaded_manifest) == Manifest.entries(second_manifest)
+    end
+  end
+
+  describe "invalidate/1" do
+    test "removes the committed manifest", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+
+      :ok = ManifestStore.commit(project, manifest(tmp_dir))
+      :ok = ManifestStore.invalidate(project)
+
+      assert ManifestStore.load(project) == :missing
+    end
+  end
+
+  defp project(tmp_dir) do
+    tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+  end
+
+  defp manifest(tmp_dir, file_name \\ "source.ex") do
+    file_path = Path.join(tmp_dir, file_name)
+
+    Manifest.new([
+      %ManifestEntry{
+        input_path: file_path,
+        output_path: file_path,
+        kind: :source,
+        mtime: {{2026, 5, 18}, {0, 0, 0}},
+        size: 10
+      }
+    ])
+  end
+
+  defp encode_entries(%Manifest{} = manifest) do
+    manifest
+    |> Manifest.entries()
+    |> Enum.map(fn entry ->
+      %{
+        input_path: entry.input_path,
+        output_path: entry.output_path,
+        kind: Atom.to_string(entry.kind),
+        mtime: entry.mtime,
+        size: entry.size,
+        source_path: entry.source_path,
+        source_mtime: entry.source_mtime,
+        source_size: entry.source_size
+      }
+    end)
+  end
+
+  defp write_committed_manifest!(project, contents) do
+    path = manifest_path(project)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+  end
+
+  defp write_legacy_manifest_from_external_vm!(project, source_path) do
+    path = manifest_path(project)
+
+    code = """
+    data = %{
+      entries: [
+        %{
+          input_path: #{inspect(source_path)},
+          output_path: #{inspect(source_path)},
+          kind: :source,
+          mtime: {{2026, 5, 18}, {0, 0, 0}},
+          size: 10
+        }
+      ]
+    }
+
+    File.mkdir_p!(Path.dirname(#{inspect(path)}))
+    File.write!(#{inspect(path)}, :erlang.term_to_binary(data))
+    """
+
+    elixir = System.find_executable("elixir") || raise "could not find elixir executable"
+    {output, status} = System.cmd(elixir, ["-e", code], stderr_to_stdout: true)
+    assert status == 0, output
+  end
+
+  defp manifest_path(project) do
+    Path.join(Project.workspace_path(project, ["indexes", "manifest"]), "index_manifest.etf")
+  end
+end

--- a/apps/engine/test/engine/search/indexer/paths_test.exs
+++ b/apps/engine/test/engine/search/indexer/paths_test.exs
@@ -1,0 +1,146 @@
+defmodule Engine.Search.Indexer.PathsTest do
+  use ExUnit.Case, async: false
+
+  alias Engine.Search.Indexer.Paths
+  alias Forge.Project
+
+  describe "indexable_files/1" do
+    @tag :tmp_dir
+    test "does not include project-local default build files", %{tmp_dir: tmp_dir} do
+      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = mix_build_file!(tmp_dir, "generated.ex")
+
+      write_mix_project!(
+        tmp_dir,
+        "DefaultBuildPathIndexerTest.MixProject",
+        ~s([app: :default_build_path_indexer_test, version: "0.1.0"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert source_file in Paths.indexable_files(project)
+      refute build_file in Paths.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "does not include files under a configured build path", %{tmp_dir: tmp_dir} do
+      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = mix_build_file!(tmp_dir, "generated.ex", build_path: "custom_build")
+
+      write_mix_project!(
+        tmp_dir,
+        "ConfiguredBuildPathIndexerTest.MixProject",
+        ~s([app: :configured_build_path_indexer_test, version: "0.1.0", build_path: "custom_build"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert source_file in Paths.indexable_files(project)
+      refute build_file in Paths.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "does not include files under MIX_BUILD_ROOT", %{tmp_dir: tmp_dir} do
+      build_root = Path.join(tmp_dir, "custom_build_root")
+      with_env("MIX_BUILD_ROOT", build_root)
+      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      build_file = Path.join(build_root, "generated.ex")
+
+      write_mix_project!(
+        tmp_dir,
+        "MixBuildRootIndexerTest.MixProject",
+        ~s([app: :mix_build_root_indexer_test, version: "0.1.0"])
+      )
+
+      write_file!(source_file, "defmodule SourceFile do end")
+      write_file!(build_file, "defmodule GeneratedBuildFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert source_file in Paths.indexable_files(project)
+      refute build_file in Paths.indexable_files(project)
+    end
+
+    @tag :tmp_dir
+    test "does not include active path dependency source files", %{tmp_dir: tmp_dir} do
+      app_root = Path.join(tmp_dir, "app")
+      dep_root = Path.join(tmp_dir, "dep")
+      app_file = Path.join([app_root, "lib", "app_module.ex"])
+      dep_file = Path.join([dep_root, "lib", "dep_module.ex"])
+
+      write_mix_project!(
+        app_root,
+        "PathDependencyPathsTest.MixProject",
+        ~s([app: :path_dependency_paths_test, version: "0.1.0", deps: [{:dep, path: "../dep"}]])
+      )
+
+      write_mix_project!(
+        dep_root,
+        "PathDependencyPathsTest.DepMixProject",
+        ~s([app: :dep, version: "0.1.0"])
+      )
+
+      write_file!(app_file, "defmodule AppModule do end")
+      write_file!(dep_file, "defmodule DepModule do end")
+
+      project = app_root |> Forge.Document.Path.to_uri() |> Project.new()
+
+      assert app_file in Paths.indexable_files(project)
+      refute dep_file in Paths.indexable_files(project)
+    end
+  end
+
+  defp with_env(name, value) do
+    original = System.fetch_env(name)
+    System.put_env(name, value)
+
+    on_exit(fn ->
+      case original do
+        {:ok, value} -> System.put_env(name, value)
+        :error -> System.delete_env(name)
+      end
+    end)
+  end
+
+  defp write_file!(path, contents) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+    path
+  end
+
+  defp write_mix_project!(root, module_name, project_config) do
+    write_file!(Path.join(root, "mix.exs"), """
+    defmodule #{module_name} do
+      use Mix.Project
+
+      def project do
+        #{project_config}
+      end
+    end
+    """)
+  end
+
+  defp mix_build_file!(root, relative_path, config \\ []) do
+    build_root =
+      File.cd!(root, fn ->
+        config
+        |> Keyword.put_new(:build_per_environment, true)
+        |> Mix.Project.build_path()
+        |> Path.dirname()
+      end)
+
+    Path.join([build_root | List.wrap(relative_path)])
+  end
+end

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -6,22 +6,72 @@ defmodule Engine.Search.IndexerTest do
 
   alias Engine.Dispatch
   alias Engine.Search.Indexer
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.Manifest.Entry, as: ManifestEntry
+  alias Engine.Search.Indexer.ManifestStore
   alias Forge.Project
   alias Forge.Search.Indexer.Entry
 
   defmodule FakeBackend do
+    @behaviour Engine.Search.Store.Backend
+
+    def new(_project), do: {:ok, :new}
+
+    def prepare(_backend_result) do
+      if entries() == [] do
+        {:ok, :empty}
+      else
+        {:ok, :stale}
+      end
+    end
+
     def set_entries(entries) when is_list(entries) do
       :persistent_term.put({__MODULE__, :entries}, entries)
+    end
+
+    def entries do
+      :persistent_term.get({__MODULE__, :entries}, [])
+    end
+
+    def replace_all(entries) when is_list(entries) do
+      set_entries(entries)
+      :ok
+    end
+
+    def delete_by_path(path) do
+      {deleted_entries, kept_entries} =
+        {__MODULE__, :entries}
+        |> :persistent_term.get([])
+        |> Enum.split_with(&(&1.path == path))
+
+      set_entries(kept_entries)
+
+      {:ok, Enum.flat_map(deleted_entries, &List.wrap(&1.id))}
+    end
+
+    def insert(entries) when is_list(entries) do
+      current_entries = :persistent_term.get({__MODULE__, :entries}, [])
+      set_entries(current_entries ++ entries)
+      :ok
     end
 
     def reduce(accumulator, reducer_fun) do
       {__MODULE__, :entries}
       |> :persistent_term.get([])
       |> Enum.reduce(accumulator, fn
-        %{id: id} = entry, acc when is_integer(id) -> reducer_fun.(entry, acc)
+        %Entry{} = entry, acc -> reducer_fun.(entry, acc)
         _, acc -> acc
       end)
     end
+
+    def find_by_subject(_subject, _type, _subtype), do: []
+    def find_by_prefix(_prefix, _type, _subtype), do: []
+    def find_by_ids(_ids, _type, _subtype), do: []
+    def siblings(_entry), do: []
+    def parent(_entry), do: nil
+    def structure_for_path(_path), do: :error
+    def drop, do: set_entries([])
+    def destroy(_project), do: :ok
   end
 
   setup do
@@ -40,18 +90,54 @@ defmodule Engine.Search.IndexerTest do
     end)
 
     patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
+    FakeBackend.set_entries([])
+    ManifestStore.invalidate(project)
     {:ok, project: project}
   end
 
-  defp with_env(name, value) do
-    original = System.fetch_env(name)
-    System.put_env(name, value)
-
-    on_exit(fn -> restore_env(name, original) end)
+  defp create_index(project) do
+    assert :ok = Indexer.create_index(project, FakeBackend)
+    FakeBackend.entries()
   end
 
-  defp restore_env(name, {:ok, value}), do: System.put_env(name, value)
-  defp restore_env(name, :error), do: System.delete_env(name)
+  defp update_index(project, backend \\ FakeBackend) do
+    before_entries = backend.entries()
+
+    assert :ok = Indexer.update_index(project, backend)
+
+    after_entries = backend.entries()
+
+    {changed_entries(before_entries, after_entries), deleted_paths(before_entries, after_entries)}
+  end
+
+  defp changed_entries(before_entries, after_entries) do
+    before_by_path = entries_by_path(before_entries)
+
+    after_entries
+    |> entries_by_path()
+    |> Enum.flat_map(fn {path, entries} ->
+      if Map.get(before_by_path, path, []) == entries do
+        []
+      else
+        entries
+      end
+    end)
+  end
+
+  defp deleted_paths(before_entries, after_entries) do
+    before_paths = before_entries |> entries_by_path() |> Map.keys() |> MapSet.new()
+    after_paths = after_entries |> entries_by_path() |> Map.keys() |> MapSet.new()
+
+    before_paths
+    |> MapSet.difference(after_paths)
+    |> Enum.to_list()
+  end
+
+  defp entries_by_path(entries) do
+    entries
+    |> Enum.reject(&is_nil(&1.path))
+    |> Enum.group_by(& &1.path)
+  end
 
   defp write_file!(path, contents) do
     File.mkdir_p!(Path.dirname(path))
@@ -71,7 +157,7 @@ defmodule Engine.Search.IndexerTest do
     """)
   end
 
-  defp mix_build_file!(root, relative_path, config \\ []) do
+  defp mix_build_file!(root, relative_path, config) do
     build_root =
       File.cd!(root, fn ->
         config
@@ -83,9 +169,9 @@ defmodule Engine.Search.IndexerTest do
     Path.join([build_root | List.wrap(relative_path)])
   end
 
-  describe "create_index/1" do
+  describe "create_index/2" do
     test "returns a list of entries", %{project: project} do
-      assert {:ok, entry_stream} = Indexer.create_index(project)
+      entry_stream = create_index(project)
       entries = Enum.to_list(entry_stream)
       project_root = Project.root_path(project)
 
@@ -94,7 +180,7 @@ defmodule Engine.Search.IndexerTest do
     end
 
     test "entries are either .ex or .exs files", %{project: project} do
-      assert {:ok, entries} = Indexer.create_index(project)
+      entries = create_index(project)
       assert Enum.all?(entries, fn entry -> Path.extname(entry.path) in [".ex", ".exs"] end)
     end
 
@@ -104,97 +190,104 @@ defmodule Engine.Search.IndexerTest do
 
       patch(Engine, :get_project, fn -> bare_project end)
 
-      assert {:ok, entries} = Indexer.create_index(bare_project)
+      entries = create_index(bare_project)
       assert Enum.any?(entries, &(&1.path == Path.join(bare_root, "bare_file.ex")))
     end
 
-    test "does not index project-local default build files", %{project: project} do
-      with_env(
-        "MIX_BUILD_PATH",
-        Path.join([Project.root_path(project), ".expert", "build", "dev"])
-      )
+    @tag :tmp_dir
+    test "indexes active path dependency beams", %{tmp_dir: tmp_dir} do
+      %{module: module, project: project} = with_beam_dependency(tmp_dir)
 
-      build_file = mix_build_file!(Project.root_path(project), "generated.ex")
+      entries = create_index(project)
+      entries = Enum.to_list(entries)
 
-      write_file!(build_file, "defmodule GeneratedBuildFile do end")
-
-      on_exit(fn -> File.rm_rf(Path.dirname(build_file)) end)
-
-      refute build_file in Indexer.indexable_files(project)
+      assert Enum.any?(entries, &(&1.subject == module and &1.subtype == :definition))
     end
 
     @tag :tmp_dir
-    test "does not index files under a configured build path", %{tmp_dir: tmp_dir} do
-      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+    test "does not index dependency beams when the dependency has app false", %{tmp_dir: tmp_dir} do
+      %{module: module, project: project} =
+        with_beam_dependency(tmp_dir, dep_opts: [path: "deps/beam_dep", app: false])
 
-      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
-      build_file = mix_build_file!(tmp_dir, "generated.ex", build_path: "custom_build")
+      entries = create_index(project)
+      entries = Enum.to_list(entries)
 
-      write_mix_project!(
-        tmp_dir,
-        "ConfiguredBuildPathIndexerTest.MixProject",
-        ~s([app: :configured_build_path_indexer_test, version: "0.1.0", build_path: "custom_build"])
-      )
-
-      write_file!(source_file, "defmodule SourceFile do end")
-      write_file!(build_file, "defmodule GeneratedBuildFile do end")
-
-      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
-
-      assert source_file in Indexer.indexable_files(project)
-      refute build_file in Indexer.indexable_files(project)
+      refute Enum.any?(entries, &(&1.subject == module and &1.subtype == :definition))
     end
 
     @tag :tmp_dir
-    test "does not index files under MIX_BUILD_ROOT", %{tmp_dir: tmp_dir} do
-      build_root = Path.join(tmp_dir, "custom_build_root")
-      with_env("MIX_BUILD_ROOT", build_root)
-      with_env("MIX_BUILD_PATH", Path.join([tmp_dir, ".expert", "build", "dev"]))
+    test "caches dependency beams with no debug metadata", %{tmp_dir: tmp_dir} do
+      %{beam_path: beam_path, module: module, project: project} =
+        with_beam_dependency(tmp_dir, debug_info?: false, rewrite_source?: false)
 
-      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
-      build_file = Path.join(build_root, "generated.ex")
+      assert {entries, []} = update_index(project)
+      entries = Enum.to_list(entries)
+      assert {:ok, manifest} = ManifestStore.load(project)
 
-      write_mix_project!(
-        tmp_dir,
-        "MixBuildRootIndexerTest.MixProject",
-        ~s([app: :mix_build_root_indexer_test, version: "0.1.0"])
-      )
+      refute Enum.any?(entries, &(&1.subject == module))
 
-      write_file!(source_file, "defmodule SourceFile do end")
-      write_file!(build_file, "defmodule GeneratedBuildFile do end")
-
-      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
-
-      assert source_file in Indexer.indexable_files(project)
-      refute build_file in Indexer.indexable_files(project)
+      assert {:ok, %ManifestEntry{kind: :beam, output_path: nil}} =
+               Manifest.fetch(manifest, beam_path)
     end
 
     @tag :tmp_dir
-    test "indexes active path dependency sources", %{tmp_dir: tmp_dir} do
-      app_root = Path.join(tmp_dir, "app")
-      dep_root = Path.join(tmp_dir, "dep")
-      app_file = Path.join([app_root, "lib", "app_module.ex"])
-      dep_file = Path.join([dep_root, "lib", "dep_module.ex"])
-      dep_non_source_file = Path.join([dep_root, "generated.ex"])
+    test "caches stale dependency beams without entries", %{tmp_dir: tmp_dir} do
+      %{beam_path: beam_path, dep_file: dep_file, module: module, project: project} =
+        with_beam_dependency(tmp_dir, rewrite_source?: false)
 
-      write_mix_project!(
-        app_root,
-        "PathDependencyIndexerTest.MixProject",
-        ~s([app: :path_dependency_indexer_test, version: "0.1.0", deps: [{:dep, path: "../dep"}]])
-      )
+      File.touch!(dep_file, {{2100, 1, 1}, {0, 0, 0}})
 
-      write_file!(app_file, "defmodule AppModule do end")
-      write_file!(dep_file, "defmodule DepModule do end")
-      write_file!(dep_non_source_file, "defmodule GeneratedDependencyFile do end")
+      assert {entries, []} = update_index(project)
+      entries = Enum.to_list(entries)
+      assert {:ok, manifest} = ManifestStore.load(project)
 
-      project = app_root |> Forge.Document.Path.to_uri() |> Project.new()
+      refute Enum.any?(entries, &(&1.subject == module))
 
-      assert dep_file in Indexer.indexable_files(project)
-      refute dep_non_source_file in Indexer.indexable_files(project)
+      assert {:ok, %ManifestEntry{kind: :beam, output_path: nil, source_path: ^dep_file}} =
+               Manifest.fetch(manifest, beam_path)
+    end
 
-      assert {:ok, entries} = Indexer.create_index(project)
-      assert Enum.any?(entries, &(&1.subject == DepModule and &1.subtype == :definition))
-      refute Enum.any?(entries, &(&1.subject == GeneratedDependencyFile))
+    @tag :tmp_dir
+    test "does not reindex unchanged skipped dependency beams after caching them", %{
+      tmp_dir: tmp_dir
+    } do
+      %{beam_path: beam_path, project: project} =
+        with_beam_dependency(tmp_dir, debug_info?: false, rewrite_source?: false)
+
+      assert {entries, []} = update_index(project)
+      FakeBackend.set_entries(Enum.to_list(entries))
+      assert {:ok, manifest} = ManifestStore.load(project)
+
+      old_manifest_entries =
+        manifest
+        |> Manifest.entries()
+        |> Enum.reject(&(&1.input_path == beam_path))
+
+      assert :ok =
+               ManifestStore.commit(project, Manifest.new(old_manifest_entries))
+
+      test_pid = self()
+
+      patch(Dispatch, :erpc_call, fn
+        Expert.Progress, :begin, ["Indexing dependencies metadata", _opts] ->
+          send(test_pid, :dependency_progress_begin)
+          {:ok, System.unique_integer([:positive])}
+
+        Expert.Progress, :begin, [_title, _opts] ->
+          {:ok, System.unique_integer([:positive])}
+
+        Expert.Progress, :report, _args ->
+          :ok
+      end)
+
+      assert {entries, []} = update_index(project)
+      assert [] = Enum.to_list(entries)
+      assert_receive :dependency_progress_begin
+      refute_receive :dependency_progress_begin, 0
+
+      assert {entries, []} = update_index(project)
+      assert [] = Enum.to_list(entries)
+      refute_receive :dependency_progress_begin
     end
   end
 
@@ -220,9 +313,10 @@ defmodule Engine.Search.IndexerTest do
   end
 
   def with_an_existing_index(%{project: project}) do
-    {:ok, entry_stream} = Indexer.create_index(project)
-    entries = Enum.to_list(entry_stream)
+    {entries, []} = update_index(project)
+    entries = Enum.to_list(entries)
     FakeBackend.set_entries(entries)
+
     {:ok, entries: entries}
   end
 
@@ -244,12 +338,38 @@ defmodule Engine.Search.IndexerTest do
       write_file!(build_file, "defmodule StaleBuildFile do end")
 
       project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.new()
-      assert {:ok, entries} = Indexer.create_index(project)
+      entries = create_index(project)
+      entries = Enum.to_list(entries)
 
       FakeBackend.set_entries([%Entry{id: 1, path: build_file} | entries])
+      ManifestStore.invalidate(project)
 
-      assert {:ok, entry_stream, [^build_file]} = Indexer.update_index(project, FakeBackend)
-      assert [] = Enum.to_list(entry_stream)
+      assert {entry_stream, [^build_file]} = update_index(project)
+      refute Enum.any?(entry_stream, &(&1.path == build_file))
+    end
+  end
+
+  describe "update_index/2 manifest commits" do
+    @tag :tmp_dir
+    test "keeps the previous manifest if committing a refresh fails", %{tmp_dir: tmp_dir} do
+      source_file = Path.join([tmp_dir, "lib", "source_file.ex"])
+      write_file!(source_file, "defmodule SourceFile do end")
+
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.bare()
+
+      assert {entries, []} = update_index(project)
+      assert [_ | _] = Enum.to_list(entries)
+      assert {:ok, old_manifest} = ManifestStore.load(project)
+
+      write_file!(source_file, "defmodule ChangedSourceFile do end")
+      File.touch!(source_file, {{2100, 1, 1}, {0, 0, 0}})
+
+      patch(ManifestStore, :commit, fn ^project, _manifest ->
+        {:error, :commit_failed}
+      end)
+
+      assert {:error, :commit_failed} = Indexer.update_index(project, FakeBackend)
+      assert {:ok, ^old_manifest} = ManifestStore.load(project)
     end
   end
 
@@ -261,9 +381,30 @@ defmodule Engine.Search.IndexerTest do
     end
 
     test "the ephemeral file is listed in the updated index", %{project: project} do
-      {:ok, entry_stream, []} = Indexer.update_index(project, FakeBackend)
-      assert [_structure, updated_entry] = Enum.to_list(entry_stream)
+      assert {entries, []} = update_index(project)
+      assert [_structure, updated_entry] = Enum.to_list(entries)
+
       assert Path.basename(updated_entry.path) == @ephemeral_file_name
+      assert updated_entry.subject == Ephemeral
+    end
+
+    test "writes updated entries into the backend", %{project: project} do
+      assert {entries, []} = update_index(project)
+      assert [_structure, updated_entry] = Enum.to_list(entries)
+
+      assert Enum.any?(FakeBackend.entries(), &(&1.subject == updated_entry.subject))
+    end
+
+    test "reindexes a manifest output missing from the backend", %{
+      project: project,
+      file_path: file_path
+    } do
+      FakeBackend.set_entries(Enum.reject(FakeBackend.entries(), &(&1.path == file_path)))
+
+      assert {entries, []} = update_index(project)
+      assert [_structure, updated_entry] = Enum.to_list(entries)
+
+      assert updated_entry.path == file_path
       assert updated_entry.subject == Ephemeral
     end
   end
@@ -276,8 +417,8 @@ defmodule Engine.Search.IndexerTest do
     setup [:with_an_existing_index, :with_an_ephemeral_empty_file]
 
     test "and does nothing", %{project: project} do
-      {:ok, entry_stream, []} = Indexer.update_index(project, FakeBackend)
-      assert [] = Enum.to_list(entry_stream)
+      assert {entries, []} = update_index(project)
+      assert [] = Enum.to_list(entries)
     end
 
     test "there is no progress", %{project: project} do
@@ -285,8 +426,8 @@ defmodule Engine.Search.IndexerTest do
       # cause an ArithmeticError
 
       Dispatch.register_listener(self(), :all)
-      {:ok, entry_stream, []} = Indexer.update_index(project, FakeBackend)
-      assert [] = Enum.to_list(entry_stream)
+      assert {entries, []} = update_index(project)
+      assert [] = Enum.to_list(entries)
       refute_receive _
     end
   end
@@ -300,47 +441,164 @@ defmodule Engine.Search.IndexerTest do
 
     test "returns the file paths of deleted files", %{project: project, file_path: file_path} do
       File.rm(file_path)
-      assert {:ok, entry_stream, [^file_path]} = Indexer.update_index(project, FakeBackend)
-      assert [] = Enum.to_list(entry_stream)
+
+      assert {entries, [^file_path]} = update_index(project)
+      assert [] = Enum.to_list(entries)
     end
 
     test "updates files that have changed since the last index", %{
       project: project,
-      entries: entries,
       file_path: file_path
     } do
-      entries = Enum.reject(entries, &is_nil(&1.id))
-      path_to_mtime = Map.new(entries, fn entry -> {entry.path, Entry.updated_at(entry)} end)
-
-      [entry | _] = entries
-      {{year, month, day}, hms} = Entry.updated_at(entry)
-      old_mtime = {{year - 1, month, day}, hms}
-
-      patch(Indexer, :stat, fn path ->
-        {ymd, {hour, minute, second}} =
-          Map.get_lazy(path_to_mtime, file_path, &:calendar.universal_time/0)
-
-        mtime =
-          if path == file_path do
-            {ymd, {hour, minute, second + 1}}
-          else
-            old_mtime
-          end
-
-        {:ok, %File.Stat{mtime: mtime}}
-      end)
-
       new_contents = ~s[
         defmodule Brand.Spanking.New do
         end
       ]
 
       File.write!(file_path, new_contents)
+      File.touch!(file_path, {{2100, 1, 1}, {0, 0, 0}})
 
-      assert {:ok, entry_stream, []} = Indexer.update_index(project, FakeBackend)
-      assert [_structure, entry] = Enum.to_list(entry_stream)
+      assert {entries, []} = update_index(project)
+      assert [_structure, entry] = Enum.to_list(entries)
+
       assert entry.path == file_path
       assert entry.subject == Brand.Spanking.New
     end
+
+    test "clears files that now index to no entries", %{
+      project: project,
+      file_path: file_path
+    } do
+      File.write!(file_path, "")
+      File.touch!(file_path, {{2100, 1, 1}, {0, 0, 0}})
+
+      assert {entries, [^file_path]} = update_index(project)
+      assert [] = Enum.to_list(entries)
+    end
+  end
+
+  defp with_beam_dependency(tmp_dir, opts \\ []) do
+    module =
+      Keyword.get_lazy(opts, :module, fn ->
+        Module.concat(BeamDependencyIndexerTest, :"Dep#{System.unique_integer([:positive])}")
+      end)
+
+    dep_source =
+      case Keyword.get(opts, :dep_source) do
+        nil ->
+          """
+          defmodule #{inspect(module)} do
+            def public_fun, do: private_fun()
+            defp private_fun, do: :ok
+          end
+          """
+
+        source when is_binary(source) ->
+          source
+
+        source_fun when is_function(source_fun, 1) ->
+          source_fun.(module)
+      end
+
+    app_root = Path.join(tmp_dir, "beam_app")
+
+    project_module =
+      Module.concat(BeamDependencyIndexerTest, :"MixProject#{System.unique_integer([:positive])}")
+
+    dep_project_module =
+      Module.concat(
+        BeamDependencyIndexerTest,
+        :"DepMixProject#{System.unique_integer([:positive])}"
+      )
+
+    dep_app = Keyword.get(opts, :dep_app, :beam_dep)
+    dep_opts = Keyword.get(opts, :dep_opts, path: "deps/beam_dep")
+    dep_tuple = {:beam_dep, dep_opts}
+
+    File.mkdir_p!(app_root)
+    mix_exs_path = Path.join(app_root, "mix.exs")
+
+    File.write!(mix_exs_path, """
+    defmodule #{inspect(project_module)} do
+      use Mix.Project
+
+      def project do
+        [app: :beam_dependency_indexer_test, version: "0.1.0", deps: deps()]
+      end
+
+      defp deps do
+        #{inspect([dep_tuple])}
+      end
+    end
+    """)
+
+    Module.create(
+      project_module,
+      quote do
+        def project do
+          [app: :beam_dependency_indexer_test, version: "0.1.0", deps: deps()]
+        end
+
+        defp deps do
+          unquote(Macro.escape([dep_tuple]))
+        end
+      end,
+      Macro.Env.location(__ENV__)
+    )
+
+    project =
+      app_root
+      |> Forge.Document.Path.to_uri()
+      |> Project.new()
+      |> Project.set_project_module(project_module)
+
+    {:ok, deps_root} = Engine.Mix.in_project(project, fn _ -> Mix.Project.deps_path() end)
+    {:ok, build_path} = Engine.Mix.in_project(project, fn _ -> Mix.Project.build_path() end)
+    dep_root = Path.join(deps_root, "beam_dep")
+    dep_file = Path.join([dep_root, "lib", "beam_dep_module.ex"])
+    ebin_path = Path.join([build_path, "lib", Atom.to_string(dep_app), "ebin"])
+
+    File.mkdir_p!(Path.dirname(dep_file))
+    File.mkdir_p!(ebin_path)
+
+    File.write!(Path.join(dep_root, "mix.exs"), """
+    defmodule #{inspect(dep_project_module)} do
+      use Mix.Project
+
+      def project do
+        [app: #{inspect(dep_app)}, version: "0.1.0"]
+      end
+    end
+    """)
+
+    File.write!(dep_file, dep_source)
+
+    compiler_options = Code.compiler_options()
+    Code.compiler_options(debug_info: Keyword.get(opts, :debug_info?, true))
+    on_exit(fn -> Code.compiler_options(compiler_options) end)
+
+    assert {:ok, compiled_modules, %{compile_warnings: [], runtime_warnings: []}} =
+             Kernel.ParallelCompiler.compile_to_path([dep_file], ebin_path,
+               return_diagnostics: true
+             )
+
+    expected_modules = Keyword.get(opts, :expected_modules, [module])
+
+    assert Enum.sort(compiled_modules) == Enum.sort(expected_modules)
+
+    if Keyword.get(opts, :rewrite_source?, true) do
+      File.write!(dep_file, "defmodule")
+      File.touch!(dep_file, {{2000, 1, 1}, {0, 0, 0}})
+    end
+
+    %{
+      beam_path: Path.join(ebin_path, Atom.to_string(module) <> ".beam"),
+      beam_paths:
+        Enum.map(compiled_modules, &Path.join(ebin_path, Atom.to_string(&1) <> ".beam")),
+      compiled_modules: compiled_modules,
+      dep_file: dep_file,
+      module: module,
+      project: project
+    }
   end
 end

--- a/apps/engine/test/engine/search/store/backends/ets_test.exs
+++ b/apps/engine/test/engine/search/store/backends/ets_test.exs
@@ -49,12 +49,12 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     backend.destroy(project)
   end
 
-  def default_create(_project) do
-    {:ok, []}
+  def default_create(_project, _backend) do
+    :ok
   end
 
-  def default_update(_project, _entities) do
-    {:ok, [], []}
+  def default_update(_project, _backend) do
+    :ok
   end
 
   defp start_supervised_store(%Project{} = project, create_fn, update_fn, backend) do
@@ -67,7 +67,7 @@ defmodule Engine.Search.Store.Backend.EtsTest do
   end
 
   def with_a_started_store(%{project: project, backend: backend}) do
-    start_supervised_store(project, &default_create/1, &default_update/2, backend)
+    start_supervised_store(project, &default_create/2, &default_update/2, backend)
 
     :ok
   end
@@ -79,14 +79,14 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     } do
       me = self()
 
-      create_fn = fn ^project ->
+      create_fn = fn ^project, ^backend ->
         send(me, :create)
-        {:ok, []}
+        :ok
       end
 
       update_fn = fn _, _ ->
         send(me, :update)
-        {:ok, [], []}
+        :ok
       end
 
       start_supervised_store(project, create_fn, update_fn, backend)
@@ -101,11 +101,11 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     } do
       me = self()
 
-      create_fn = fn ^project -> {:ok, [reference()]} end
+      create_fn = fn ^project, ^backend -> backend.replace_all([reference(id: 1)]) end
 
       update_fn = fn _, _ ->
         send(me, :update)
-        {:ok, [], []}
+        :ok
       end
 
       start_supervised_store(project, create_fn, update_fn, backend)
@@ -116,7 +116,7 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     end
 
     test "starts empty if there are no disk files", %{project: project, backend: backend} do
-      start_supervised_store(project, &default_create/1, &default_update/2, backend)
+      start_supervised_store(project, &default_create/2, &default_update/2, backend)
 
       assert [] = all_entries(backend)
 
@@ -126,13 +126,13 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     end
 
     test "incorporates any indexed files in an empty index", %{project: project, backend: backend} do
-      create = fn _ ->
+      create = fn _, backend ->
         entries = [
           reference(path: "/foo/bar/baz.ex"),
           reference(path: "/foo/bar/quux.ex")
         ]
 
-        {:ok, entries}
+        backend.replace_all(entries)
       end
 
       start_supervised_store(project, create, &default_update/2, backend)
@@ -146,7 +146,7 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     end
 
     test "fails if the reindex fails on an empty index", %{project: project, backend: backend} do
-      create = fn _ -> {:error, :broken} end
+      create = fn _, _ -> {:error, :broken} end
       start_supervised_store(project, create, &default_update/2, backend)
 
       assert_eventually ready?(project)
@@ -155,22 +155,22 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     end
 
     test "incorporates any indexed files in a stale index", %{project: project, backend: backend} do
-      create = fn
-        _ ->
-          {:ok,
-           [
-             reference(id: 1, path: "/foo/bar/baz.ex"),
-             reference(id: 2, path: "/foo/bar/quux.ex")
-           ]}
+      create = fn _, backend ->
+        backend.replace_all([
+          reference(id: 1, path: "/foo/bar/baz.ex"),
+          reference(id: 2, path: "/foo/bar/quux.ex")
+        ])
       end
 
-      update = fn _, _ ->
+      update = fn _, backend ->
         entries = [
           reference(id: 3, path: "/foo/bar/baz.ex"),
           reference(id: 4, path: "/foo/bar/other.ex")
         ]
 
-        {:ok, entries, []}
+        with {:ok, _} <- backend.delete_by_path("/foo/bar/baz.ex") do
+          backend.insert(entries)
+        end
       end
 
       start_supervised_store(project, create, update, backend)
@@ -184,19 +184,19 @@ defmodule Engine.Search.Store.Backend.EtsTest do
     end
 
     test "fails if the reinder fails on an stale index", %{project: project, backend: backend} do
-      create = fn _ -> {:ok, []} end
+      create = fn _, backend -> backend.replace_all([reference(id: 1)]) end
       update = fn _, _ -> {:error, :bad} end
 
       start_supervised_store(project, create, update, backend)
       restart_store(project)
 
-      assert [] = all_entries(backend)
+      assert [%{id: 1}] = all_entries(backend)
     end
 
     test "the updater allows you to delete paths", %{project: project, backend: backend} do
       kept_structure = %{root: %{3 => %{4 => %{}}}}
 
-      create = fn _ ->
+      create = fn _, backend ->
         entries = [
           structure(path: "/path/to/keep.ex", structure: kept_structure),
           definition(path: "/path/to/keep.ex"),
@@ -207,11 +207,14 @@ defmodule Engine.Search.Store.Backend.EtsTest do
           definition(path: "/another/path/to/delete.ex")
         ]
 
-        {:ok, entries}
+        backend.replace_all(entries)
       end
 
-      update = fn _, _ ->
-        {:ok, [], ["/path/to/delete.ex", "/another/path/to/delete.ex"]}
+      update = fn _, backend ->
+        with {:ok, _} <- backend.delete_by_path("/path/to/delete.ex"),
+             {:ok, _} <- backend.delete_by_path("/another/path/to/delete.ex") do
+          :ok
+        end
       end
 
       start_supervised_store(project, create, update, backend)

--- a/apps/engine/test/engine/search/store/state_test.exs
+++ b/apps/engine/test/engine/search/store/state_test.exs
@@ -5,6 +5,7 @@ defmodule Engine.Search.Store.StateTest do
   import Forge.Test.Fixtures
 
   alias Engine.Search.Store.State
+  alias Forge.Project
 
   require Logger
 
@@ -14,6 +15,26 @@ defmodule Engine.Search.Store.StateTest do
     def delete_by_path(_path) do
       exit({:timeout, {GenServer, :call, [:some_ref]}})
     end
+
+    def new(_project), do: {:ok, :new}
+    def prepare(_), do: {:ok, :empty}
+    def insert(_entries), do: :ok
+    def replace_all(_entries), do: :ok
+    def find_by_subject(_subject, _type, _subtype), do: []
+    def find_by_prefix(_prefix, _type, _subtype), do: []
+    def find_by_ids(_ids, _type, _subtype), do: []
+    def reduce(acc, _fun), do: acc
+    def siblings(_entry), do: []
+    def parent(_entry), do: nil
+    def structure_for_path(_path), do: {:ok, %{}}
+    def drop, do: :ok
+    def destroy(_state), do: :ok
+  end
+
+  defmodule DeleteErrorBackend do
+    @behaviour Engine.Search.Store.Backend
+
+    def delete_by_path(_path), do: {:error, :delete_failed}
 
     def new(_project), do: {:ok, :new}
     def prepare(_), do: {:ok, :empty}
@@ -40,8 +61,8 @@ defmodule Engine.Search.Store.StateTest do
       state =
         State.new(
           project,
-          fn _project -> {:ok, []} end,
-          fn _project, _backend -> {:ok, [], []} end,
+          fn _project, _backend -> :ok end,
+          fn _project, _backend -> :ok end,
           TimeoutBackend
         )
 
@@ -50,8 +71,25 @@ defmodule Engine.Search.Store.StateTest do
           State.update_nosync(state, "/some/path.ex", [])
         end)
 
-      assert assert {:ok, returned_state} = result
+      assert {:ok, %State{}} = result
       assert log =~ "Timeout updating index for path: /some/path.ex"
+    end
+  end
+
+  describe "refresh_index/1" do
+    @tag :tmp_dir
+    test "returns index update errors instead of crashing", %{tmp_dir: tmp_dir} do
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.bare()
+
+      state =
+        State.new(
+          project,
+          fn _project, _backend -> :ok end,
+          fn _project, _backend -> {:error, :update_failed} end,
+          DeleteErrorBackend
+        )
+
+      assert {:error, :update_failed} = State.refresh_index(state)
     end
   end
 end

--- a/apps/engine/test/engine/search/store_test.exs
+++ b/apps/engine/test/engine/search/store_test.exs
@@ -360,12 +360,12 @@ defmodule Engine.Search.StoreTest do
     :ok
   end
 
-  defp default_create(_project) do
-    {:ok, []}
+  defp default_create(_project, _backend) do
+    :ok
   end
 
-  defp default_update(_project, _entities) do
-    {:ok, [], []}
+  defp default_update(_project, _backend) do
+    :ok
   end
 
   defp with_a_started_store(project, backend) do
@@ -373,7 +373,7 @@ defmodule Engine.Search.StoreTest do
 
     start_supervised!(Dispatch)
     start_supervised!(backend)
-    start_supervised!({Store, [project, &default_create/1, &default_update/2, backend]})
+    start_supervised!({Store, [project, &default_create/2, &default_update/2, backend]})
 
     assert_eventually alive?()
 
@@ -406,7 +406,7 @@ defmodule Engine.Search.StoreTest do
       start_supervised!(Dispatch)
       start_supervised!(Ets)
 
-      blocking_create = fn _project ->
+      blocking_create = fn _project, _backend ->
         Process.sleep(:infinity)
       end
 
@@ -447,6 +447,14 @@ defmodule Engine.Search.StoreTest do
       assert {:error, :loading} = Store.all([])
       assert_receive search_store_loading(project: received_project)
       assert received_project == project
+    end
+
+    test "refresh_index/1 returns loading while startup indexing is running", %{project: project} do
+      assert {:error, :loading} = Store.refresh_index(project)
+    end
+
+    test "rebuild_index/1 returns loading while startup indexing is running", %{project: project} do
+      assert {:error, :loading} = Store.rebuild_index(project)
     end
 
     test "parent/1 broadcasts search_store_loading when loading", %{project: project} do


### PR DESCRIPTION
BEAM metadata provide all the information we need to index definitions, but not references. We only index deps definitions, so it makes sense to index from BEAM files for them.

This reduces a lot of work by skipping most of the work Extractors do for source files, only requiring to scan a few lines of code from the source file to refine the definition range(this is a bit hacky, but it seems to work well for most code, metaprogramming would be where we need to be more careful).

It also adds a new `Manifest` for incremental indexing. We were previously relying on the `Entry.path` to get the file path to compare mtime against, but `.beam` file paths are not stored in the Entry structs(nor should they be) which required me to rethink how we do incremental indexing. I added a Manifest(and a ManifestStore module to handle its lifecycle) which holds a mapping of file -> source files + file stats and all the metadata needed to determine if a file should be reindexed, and which entries are stale and need to be removed.

Expert indexes in ~1.8 seconds for me without this change, and goes down to ~800ms with this change.

Another reason this change is interesting is that if we decide to use compiler tracers we will need a beam extractor(since compiler tracers provide us with the compile code's debug_info), and this sets the foundation for that.

This does not replace indexing of source files for the user project though, for two reasons:
- I didn't see a significant boost in performance, mostly because we still need to properly parse the original files to index references, that is where the bulk of the work in the index seems to be spent. I think using this for the project beams would be better implemented in a PR that actually makes use of compiler tracers, or that attempts to improve the indexer accuracy on generated code
- We still require parsing source files for `.exs` files like configuration and test, those don't produce .beam artifacts and therefore can't be indexed with this approach