### PR TITLE
fix(expert): log correct path when looking up executables

### DIFF
--- a/apps/expert/lib/expert/engine_builds.ex
+++ b/apps/expert/lib/expert/engine_builds.ex
@@ -98,7 +98,21 @@ defmodule Expert.EngineBuilds do
   defp resolve_build(%Project{} = project) do
     with {:ok, elixir, env} <- Expert.Port.project_executable(project, "elixir"),
          {:ok, erl, _env} <- Expert.Port.project_executable(project, "erl") do
-      Logger.info("Using path: #{System.get_env("PATH")}", project: project)
+      # PATH used for resolving Elixir and Erlang is taken by spawning a child shell and it might
+      # be different from the PATH from ENV in which Expert is run. We want to log this child-shell
+      # PATH here.
+      case List.keyfind(env, "PATH", 0) do
+        {"PATH", value} ->
+          Logger.info("Using path: #{value}", project: project)
+
+        _ ->
+          path = System.get_env("PATH")
+
+          Logger.warning("No path from child shell. Path in which Expert is run: #{path}",
+            project: project
+          )
+      end
+
       Logger.info("Found elixir executable at #{elixir}", project: project)
       Logger.info("Found erl executable at #{erl}", project: project)
 

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -184,6 +184,16 @@ defmodule Expert.Port do
     end
   end
 
+  @release_vars [
+    "RELEASE_ROOT",
+    "ROOTDIR",
+    "BINDIR",
+    "RELEASE_SYS_CONFIG",
+    "MIX_HOME",
+    "MIX_ARCHIVES",
+    "MIX_ENV"
+  ]
+
   defp find_project_executable_unix(%Project{} = project, name) do
     root_path = Project.root_path(project)
     shell_env = System.get_env("SHELL")
@@ -209,28 +219,12 @@ defmodule Expert.Port do
         end
 
       elixir ->
-        release_vars = [
-          "RELEASE_ROOT",
-          "ROOTDIR",
-          "BINDIR",
-          "RELEASE_SYS_CONFIG",
-          "MIX_HOME",
-          "MIX_ARCHIVES",
-          "MIX_ENV"
-        ]
-
         env =
           System.get_env()
           |> Enum.map(fn
-            {"PATH", _path} ->
-              {"PATH", path}
-
-            {key, _value} ->
-              if key in release_vars do
-                {key, ""}
-              else
-                {key, System.get_env(key)}
-              end
+            {"PATH", _path} -> {"PATH", path}
+            {key, _value} when key in @release_vars -> {key, ""}
+            {key, value} -> {key, value}
           end)
 
         {:ok, elixir, env}


### PR DESCRIPTION
I was debugging an issue few days ago where the PATH logged by Expert logs looks fine, with asdf correctly set up, but a system version of Elixir and Erlang were still picked up. I don't know the reason, but I noticed we are logging a "wrong" path on startup - not the one used to look up the executables, but the one from env in which Expert is started. They theoretically could be different, which would explain the weird observed behaviour.

This fixes the logging, to list the very PATH that was used to find executables + additional code cleanup (01d07a0e83e3eedc962b21b28097a24aa82820e0)