### PR TITLE
feat: configure toolchain paths

### DIFF
--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -13,6 +13,53 @@ defmodule Expert.Configuration do
   @default_lsp_log_level :info
   @default_file_log_level :debug
 
+  @lsp_log_levels %{
+    "error" => :error,
+    "warning" => :warning,
+    "info" => :info,
+    "log" => :log
+  }
+
+  @file_log_levels %{
+    "debug" => :debug,
+    "info" => :info,
+    "warning" => :warning,
+    "error" => :error
+  }
+
+  @settings %{
+    log_level: %{
+      key: "logLevel",
+      parser: {:enum, @lsp_log_levels, @default_lsp_log_level},
+      missing: :default
+    },
+    file_log_level: %{
+      key: "fileLogLevel",
+      parser: {:enum, @file_log_levels, @default_file_log_level},
+      missing: :preserve
+    },
+    elixir_source_path: %{
+      key: "elixirSourcePath",
+      parser: {:string, nil},
+      missing: :preserve
+    },
+    elixir_executable_path: %{
+      key: "elixirExecutablePath",
+      parser: {:string, nil},
+      missing: :preserve
+    },
+    erlang_executable_path: %{
+      key: "erlangExecutablePath",
+      parser: {:string, nil},
+      missing: :preserve
+    },
+    workspace_symbols: %{
+      key: "workspaceSymbols",
+      parser: :workspace_symbols,
+      missing: :preserve
+    }
+  }
+
   @type lsp_level :: :error | :warning | :info | :log
   @type file_level :: :debug | :info | :warning | :error
 
@@ -120,12 +167,7 @@ defmodule Expert.Configuration do
   defp apply_config_change(%__MODULE__{} = old_config, %{} = settings) do
     new_config =
       old_config
-      |> set_lsp_log_level(settings)
-      |> set_file_log_level(settings)
-      |> set_workspace_symbols(settings)
-      |> set_elixir_source_path(settings)
-      |> set_elixir_executable_path(settings)
-      |> set_erlang_executable_path(settings)
+      |> apply_settings(settings)
       |> set()
 
     apply_file_log_level(new_config)
@@ -136,30 +178,6 @@ defmodule Expert.Configuration do
     {:ok, old_config}
   end
 
-  defp set_lsp_log_level(%__MODULE__{} = config, settings) do
-    %__MODULE__{config | log_level: parse_lsp_log_level(settings)}
-  end
-
-  defp parse_lsp_log_level(%{"logLevel" => "error"}), do: :error
-  defp parse_lsp_log_level(%{"logLevel" => "warning"}), do: :warning
-  defp parse_lsp_log_level(%{"logLevel" => "info"}), do: :info
-  defp parse_lsp_log_level(%{"logLevel" => "log"}), do: :log
-  defp parse_lsp_log_level(_), do: @default_lsp_log_level
-
-  defp set_file_log_level(%__MODULE__{} = config, %{"fileLogLevel" => value}) do
-    %__MODULE__{config | file_log_level: parse_file_log_level(value)}
-  end
-
-  defp set_file_log_level(%__MODULE__{} = config, _settings) do
-    config
-  end
-
-  defp parse_file_log_level("debug"), do: :debug
-  defp parse_file_log_level("info"), do: :info
-  defp parse_file_log_level("warning"), do: :warning
-  defp parse_file_log_level("error"), do: :error
-  defp parse_file_log_level(_), do: @default_file_log_level
-
   defp apply_file_log_level(%__MODULE__{file_log_level: level}) do
     handler_name = Expert.Logging.ProjectLogFile.handler_name()
 
@@ -169,47 +187,52 @@ defmodule Expert.Configuration do
     end
   end
 
-  defp set_elixir_source_path(%__MODULE__{} = config, %{"elixirSourcePath" => value})
-       when is_binary(value) do
-    %__MODULE__{config | elixir_source_path: value}
+  defp apply_settings(%__MODULE__{} = config, settings) do
+    Enum.reduce(@settings, config, fn {field, setting}, config ->
+      apply_setting(config, settings, field, setting)
+    end)
   end
 
-  defp set_elixir_source_path(%__MODULE__{} = config, %{"elixirSourcePath" => _}) do
-    %__MODULE__{config | elixir_source_path: nil}
+  defp apply_setting(%__MODULE__{} = config, settings, field, %{
+         key: key,
+         parser: parser,
+         missing: on_missing
+       }) do
+    case Map.fetch(settings, key) do
+      {:ok, value} -> put_setting(config, field, parse_setting(value, parser))
+      :error -> apply_missing_setting(config, field, parser, on_missing)
+    end
   end
 
-  defp set_elixir_source_path(%__MODULE__{} = config, _settings) do
+  defp apply_missing_setting(%__MODULE__{} = config, field, parser, :default) do
+    put_setting(config, field, default_setting(parser))
+  end
+
+  defp apply_missing_setting(%__MODULE__{} = config, _field, _parser, :preserve) do
     config
   end
 
-  defp set_elixir_executable_path(%__MODULE__{} = config, %{"elixirExecutablePath" => value})
-       when is_binary(value) do
-    %__MODULE__{config | elixir_executable_path: value}
+  defp parse_setting(value, {:enum, values, default}) do
+    Map.get(values, value, default)
   end
 
-  defp set_elixir_executable_path(%__MODULE__{} = config, %{"elixirExecutablePath" => _}) do
-    %__MODULE__{config | elixir_executable_path: nil}
+  defp parse_setting(value, {:string, _default}) when is_binary(value) do
+    value
   end
 
-  defp set_elixir_executable_path(%__MODULE__{} = config, _settings) do
-    config
+  defp parse_setting(_value, {:string, default}) do
+    default
   end
 
-  defp set_erlang_executable_path(%__MODULE__{} = config, %{"erlangExecutablePath" => value})
-       when is_binary(value) do
-    %__MODULE__{config | erlang_executable_path: value}
+  defp parse_setting(settings, :workspace_symbols) do
+    WorkspaceSymbols.new(%{"workspaceSymbols" => settings})
   end
 
-  defp set_erlang_executable_path(%__MODULE__{} = config, %{"erlangExecutablePath" => _}) do
-    %__MODULE__{config | erlang_executable_path: nil}
-  end
+  defp default_setting({:enum, _values, default}), do: default
+  defp default_setting({:string, default}), do: default
 
-  defp set_erlang_executable_path(%__MODULE__{} = config, _settings) do
-    config
-  end
-
-  defp set_workspace_symbols(%__MODULE__{} = config, settings) do
-    %__MODULE__{config | workspace_symbols: WorkspaceSymbols.new(settings)}
+  defp put_setting(%__MODULE__{} = config, field, value) do
+    struct!(config, [{field, value}])
   end
 
   defp maybe_watched_extensions_request(

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -22,7 +22,9 @@ defmodule Expert.Configuration do
             workspace_symbols: %WorkspaceSymbols{},
             log_level: @default_lsp_log_level,
             file_log_level: @default_file_log_level,
-            elixir_source_path: nil
+            elixir_source_path: nil,
+            elixir_executable_path: nil,
+            erlang_executable_path: nil
 
   @type t :: %__MODULE__{
           support: support | nil,
@@ -31,7 +33,9 @@ defmodule Expert.Configuration do
           workspace_symbols: WorkspaceSymbols.t(),
           log_level: lsp_level(),
           file_log_level: file_level(),
-          elixir_source_path: String.t() | nil
+          elixir_source_path: String.t() | nil,
+          elixir_executable_path: String.t() | nil,
+          erlang_executable_path: String.t() | nil
         }
 
   @opaque support :: Support.t()
@@ -120,6 +124,8 @@ defmodule Expert.Configuration do
       |> set_file_log_level(settings)
       |> set_workspace_symbols(settings)
       |> set_elixir_source_path(settings)
+      |> set_elixir_executable_path(settings)
+      |> set_erlang_executable_path(settings)
       |> set()
 
     apply_file_log_level(new_config)
@@ -173,6 +179,32 @@ defmodule Expert.Configuration do
   end
 
   defp set_elixir_source_path(%__MODULE__{} = config, _settings) do
+    config
+  end
+
+  defp set_elixir_executable_path(%__MODULE__{} = config, %{"elixirExecutablePath" => value})
+       when is_binary(value) do
+    %__MODULE__{config | elixir_executable_path: value}
+  end
+
+  defp set_elixir_executable_path(%__MODULE__{} = config, %{"elixirExecutablePath" => _}) do
+    %__MODULE__{config | elixir_executable_path: nil}
+  end
+
+  defp set_elixir_executable_path(%__MODULE__{} = config, _settings) do
+    config
+  end
+
+  defp set_erlang_executable_path(%__MODULE__{} = config, %{"erlangExecutablePath" => value})
+       when is_binary(value) do
+    %__MODULE__{config | erlang_executable_path: value}
+  end
+
+  defp set_erlang_executable_path(%__MODULE__{} = config, %{"erlangExecutablePath" => _}) do
+    %__MODULE__{config | erlang_executable_path: nil}
+  end
+
+  defp set_erlang_executable_path(%__MODULE__{} = config, _settings) do
     config
   end
 

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -35,6 +35,7 @@ defmodule Expert.EngineNode do
     end
 
     @dialyzer {:nowarn_function, start: 3}
+    @dialyzer {:nowarn_function, start: 4}
 
     def start(%__MODULE__{} = state, paths, from, opts \\ []) do
       this_node = to_string(Node.self())

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -3,6 +3,7 @@ defmodule Expert.Port do
   Utilities for launching ports in the context of a project.
   """
 
+  alias Expert.Configuration
   alias Forge.Project
 
   require Logger
@@ -61,21 +62,33 @@ defmodule Expert.Port do
     # OTP version. Spawning a login shell to detect the project-local executable
     # can return a different OTP version (e.g. via mise), causing the child to
     # fail to load the test BEAM files.
-    def project_executable(_project, name) do
-      fallback_executable(name)
+    def project_executable(project, name) do
+      case configured_executable_path(name) do
+        nil ->
+          fallback_executable(name)
+
+        path ->
+          {:ok, to_charlist(path), project_environment(project)}
+      end
     end
   else
     def project_executable(%Project{} = project, name) do
-      case find_project_executable(project, name) do
-        {:ok, _, _} = success ->
-          success
+      case configured_executable_path(name) do
+        nil ->
+          case find_project_executable(project, name) do
+            {:ok, _, _} = success ->
+              success
 
-        {:error, name, reason} ->
-          Logger.warning(
-            "Failed to find #{name} for project, falling back to packaged elixir: #{reason}"
-          )
+            {:error, name, reason} ->
+              Logger.warning(
+                "Failed to find #{name} for project, falling back to packaged elixir: #{reason}"
+              )
 
-          fallback_executable(name)
+              fallback_executable(name)
+          end
+
+        path ->
+          {:ok, to_charlist(path), project_environment(project)}
       end
     end
   end
@@ -110,7 +123,80 @@ defmodule Expert.Port do
     end
   end
 
+  defp configured_executable_path("elixir") do
+    Configuration.get().elixir_executable_path
+  end
+
+  defp configured_executable_path("erl") do
+    Configuration.get().erlang_executable_path
+  end
+
+  defp configured_executable_path(_name) do
+    nil
+  end
+
+  defp project_environment(%Project{} = project) do
+    project
+    |> project_path()
+    |> sanitized_system_env()
+  end
+
+  # These variables are interpreted by release, Elixir, or Erlang launchers and
+  # must not leak from Expert's own runtime into project runtime detection.
+  @scrubbed_env_vars [
+    "ELIXIR_ERL_OPTIONS",
+    "ERL_AFLAGS",
+    "ERL_FLAGS",
+    "ERL_LIBS",
+    "ERL_ZFLAGS",
+    "ERLEXEC_DIR",
+    "RELEASE_ROOT",
+    "ROOTDIR",
+    "BINDIR",
+    "RELEASE_SYS_CONFIG",
+    "MIX_HOME",
+    "MIX_ARCHIVES",
+    "MIX_ENV"
+  ]
+
+  defp sanitized_system_env(path) do
+    path = prepend_configured_erlang_path(path)
+
+    System.get_env()
+    |> Enum.map(fn
+      {key, _path} when key in ["PATH", "Path"] -> {key, path}
+      {key, _value} when key in @scrubbed_env_vars -> {key, ""}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp prepend_configured_erlang_path(path) do
+    case configured_executable_path("erl") do
+      erl_path when is_binary(erl_path) ->
+        Enum.join([Path.dirname(erl_path), path], path_env_separator())
+
+      _ ->
+        path
+    end
+  end
+
+  defp path_env_separator do
+    if Forge.OS.windows?(), do: ";", else: ":"
+  end
+
   defp find_project_executable_windows(name) do
+    path = windows_project_path()
+
+    case find_windows_executable(name, path) do
+      false ->
+        {:error, name, "Couldn't find an #{name} executable"}
+
+      elixir ->
+        {:ok, elixir, sanitized_system_env(path)}
+    end
+  end
+
+  defp windows_project_path do
     release_root =
       "RELEASE_ROOT"
       |> System.get_env()
@@ -124,54 +210,21 @@ defmodule Expert.Port do
           |> String.replace("/", "\\")
       end
 
-    path =
-      "PATH"
-      |> System.get_env("")
-      |> then(fn current_path ->
-        if release_root do
-          current_path
-          |> String.split(";")
-          |> Enum.reject(fn entry ->
-            normalized = entry |> String.downcase() |> String.replace("/", "\\")
-            String.contains?(normalized, release_root)
-          end)
-          |> Enum.join(";")
-        else
-          current_path
-        end
-      end)
-
-    case find_windows_executable(name, path) do
-      false ->
-        {:error, name, "Couldn't find an #{name} executable"}
-
-      elixir ->
-        release_vars = [
-          "RELEASE_ROOT",
-          "ROOTDIR",
-          "BINDIR",
-          "RELEASE_SYS_CONFIG",
-          "ERLEXEC_DIR",
-          "MIX_HOME",
-          "MIX_ARCHIVES"
-        ]
-
-        env =
-          System.get_env()
-          |> Enum.map(fn
-            {key, _path} when key in ["PATH", "Path"] ->
-              {key, path}
-
-            {key, _value} ->
-              if key in release_vars do
-                {key, ""}
-              else
-                {key, System.get_env(key)}
-              end
-          end)
-
-        {:ok, elixir, env}
-    end
+    "PATH"
+    |> System.get_env("")
+    |> then(fn current_path ->
+      if release_root do
+        current_path
+        |> String.split(";")
+        |> Enum.reject(fn entry ->
+          normalized = entry |> String.downcase() |> String.replace("/", "\\")
+          String.contains?(normalized, release_root)
+        end)
+        |> Enum.join(";")
+      else
+        current_path
+      end
+    end)
   end
 
   defp find_windows_executable(name, path) do
@@ -184,29 +237,10 @@ defmodule Expert.Port do
     end
   end
 
-  @release_vars [
-    "RELEASE_ROOT",
-    "ROOTDIR",
-    "BINDIR",
-    "RELEASE_SYS_CONFIG",
-    "MIX_HOME",
-    "MIX_ARCHIVES",
-    "MIX_ENV"
-  ]
-
   defp find_project_executable_unix(%Project{} = project, name) do
     root_path = Project.root_path(project)
     shell_env = System.get_env("SHELL")
-
-    path =
-      if shell_available?(shell_env) do
-        case path_env_at_directory(root_path, shell_env) do
-          {:ok, path} -> path
-          {:error, :timeout} -> filter_release_root_from_path()
-        end
-      else
-        filter_release_root_from_path()
-      end
+    path = project_path(project)
 
     case :os.find_executable(to_charlist(name), to_charlist(path)) do
       false ->
@@ -219,13 +253,7 @@ defmodule Expert.Port do
         end
 
       elixir ->
-        env =
-          System.get_env()
-          |> Enum.map(fn
-            {"PATH", _path} -> {"PATH", path}
-            {key, _value} when key in @release_vars -> {key, ""}
-            {key, value} -> {key, value}
-          end)
+        env = sanitized_system_env(path)
 
         {:ok, elixir, env}
     end
@@ -233,6 +261,28 @@ defmodule Expert.Port do
 
   defp shell_available?(shell) do
     shell != nil and File.exists?(shell)
+  end
+
+  defp project_path(%Project{} = project) do
+    if Forge.OS.windows?() do
+      windows_project_path()
+    else
+      unix_project_path(project)
+    end
+  end
+
+  defp unix_project_path(%Project{} = project) do
+    root_path = Project.root_path(project)
+    shell_env = System.get_env("SHELL")
+
+    if shell_available?(shell_env) do
+      case path_env_at_directory(root_path, shell_env) do
+        {:ok, path} -> path
+        {:error, :timeout} -> filter_release_root_from_path()
+      end
+    else
+      filter_release_root_from_path()
+    end
   end
 
   defp filter_release_root_from_path do

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -9,137 +9,15 @@ defmodule Expert.Port do
   require Logger
 
   @type open_opt ::
-          {:env, list()}
+          {:args, [String.t() | charlist()]}
           | {:cd, String.t() | charlist()}
           | {:env, [{:os.env_var_name(), :os.env_var_value()}]}
-          | {:args, list()}
           | {:line, non_neg_integer()}
 
-  @type open_opts :: [open_opt]
+  @type open_opts :: [open_opt()]
 
-  @path_marker "__EXPERT_PATH__"
   @default_unix_path "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-
-  @doc """
-  Launches elixir in a port.
-
-  This function takes the project's context into account and looks for the executable via calling
-  `elixir_executable(project)`. Environment variables are also retrieved with that call.
-  """
-  @spec open_elixir(Project.t(), open_opts()) :: port() | {:error, :no_elixir, String.t()}
-  def open_elixir(%Project{} = project, opts) do
-    case project_executable(project, "elixir") do
-      {:ok, elixir_executable, environment_variables} ->
-        opts =
-          opts
-          |> Keyword.put_new_lazy(:cd, fn -> Project.root_path(project) end)
-          |> Keyword.update(:env, environment_variables, fn env ->
-            environment_variables ++ env
-          end)
-
-        open_executable(elixir_executable, opts)
-
-      {:error, _, reason} ->
-        Logger.error("Failed to find elixir executable for project: #{reason}")
-        {:error, :no_elixir, reason}
-    end
-  end
-
-  @doc """
-  Returns the specified executable path and environment for a project.
-
-  Returns `{:ok, executable_path, env}` where:
-  - `executable_path` is a charlist path to the specified executable
-  - `env` is a list of `{key, value}` tuples for the environment
-
-  Returns `{:error, name, reason}` if no executable can be found.
-  """
-  @spec project_executable(Project.t(), String.t()) ::
-          {:ok, charlist(), list()} | {:error, String.t(), String.t()}
-  if Mix.env() == :test do
-    # In test mode, the child engine node must use the same Elixir/OTP as the
-    # test runner, because the test build produces BEAM files for that specific
-    # OTP version. Spawning a login shell to detect the project-local executable
-    # can return a different OTP version (e.g. via mise), causing the child to
-    # fail to load the test BEAM files.
-    def project_executable(project, name) do
-      case configured_executable_path(name) do
-        nil ->
-          fallback_executable(name)
-
-        path ->
-          {:ok, to_charlist(path), project_environment(project)}
-      end
-    end
-  else
-    def project_executable(%Project{} = project, name) do
-      case configured_executable_path(name) do
-        nil ->
-          case find_project_executable(project, name) do
-            {:ok, _, _} = success ->
-              success
-
-            {:error, name, reason} ->
-              Logger.warning(
-                "Failed to find #{name} for project, falling back to packaged elixir: #{reason}"
-              )
-
-              fallback_executable(name)
-          end
-
-        path ->
-          {:ok, to_charlist(path), project_environment(project)}
-      end
-    end
-  end
-
-  @doc """
-  Opens a port for elixir with the given executable and environment.
-
-  Use this when you already have the elixir path and env from `elixir_executable/1`
-  and need to customize the port options.
-
-  ## Options
-
-    * `:args` - List of arguments to pass to the elixir executable
-    * `:cd` - Working directory for the port
-    * `:env` - Additional environment variables (merged with the provided env)
-
-  """
-  @spec open_elixir_with_env(charlist(), list(), open_opts()) :: port()
-  def open_elixir_with_env(elixir_executable, env, opts) do
-    opts =
-      opts
-      |> Keyword.update(:env, env, fn additional_env -> env ++ additional_env end)
-
-    open_executable(elixir_executable, opts)
-  end
-
-  def find_project_executable(%Project{} = project, name) do
-    if Forge.OS.windows?() do
-      find_project_executable_windows(name)
-    else
-      find_project_executable_unix(project, name)
-    end
-  end
-
-  defp configured_executable_path("elixir") do
-    Configuration.get().elixir_executable_path
-  end
-
-  defp configured_executable_path("erl") do
-    Configuration.get().erlang_executable_path
-  end
-
-  defp configured_executable_path(_name) do
-    nil
-  end
-
-  defp project_environment(%Project{} = project) do
-    project
-    |> project_path()
-    |> sanitized_system_env()
-  end
+  @path_marker "__EXPERT_PATH__"
 
   # These variables are interpreted by release, Elixir, or Erlang launchers and
   # must not leak from Expert's own runtime into project runtime detection.
@@ -159,233 +37,352 @@ defmodule Expert.Port do
     "MIX_ENV"
   ]
 
-  defp sanitized_system_env(path) do
-    path = prepend_configured_erlang_path(path)
+  @doc """
+  Launches Elixir in a port.
 
-    System.get_env()
-    |> Enum.map(fn
-      {key, _path} when key in ["PATH", "Path"] -> {key, path}
-      {key, _value} when key in @scrubbed_env_vars -> {key, ""}
-      {key, value} -> {key, value}
-    end)
-  end
+  The executable and environment are resolved from the project context by
+  `project_executable/2`.
+  """
+  @spec open_elixir(Project.t(), open_opts()) :: port() | {:error, :no_elixir, String.t()}
+  def open_elixir(%Project{} = project, opts) do
+    case project_executable(project, "elixir") do
+      {:ok, elixir, env} ->
+        opts =
+          opts
+          |> Keyword.put_new_lazy(:cd, fn -> Project.root_path(project) end)
+          |> put_env(env)
 
-  defp prepend_configured_erlang_path(path) do
-    case configured_executable_path("erl") do
-      erl_path when is_binary(erl_path) ->
-        Enum.join([Path.dirname(erl_path), path], path_env_separator())
+        open_executable(elixir, opts)
 
-      _ ->
-        path
+      {:error, _name, reason} ->
+        Logger.error("Failed to find elixir executable for project: #{reason}")
+        {:error, :no_elixir, reason}
     end
   end
 
-  defp path_env_separator do
-    if Forge.OS.windows?(), do: ";", else: ":"
+  @doc """
+  Opens a port for Elixir with a previously resolved executable and environment.
+  """
+  @spec open_elixir_with_env(charlist(), list(), open_opts()) :: port()
+  def open_elixir_with_env(elixir, env, opts) do
+    elixir
+    |> open_executable(put_env(opts, env))
   end
 
-  defp find_project_executable_windows(name) do
+  @doc """
+  Returns the specified executable path and environment for a project.
+
+  Returns `{:ok, executable_path, env}` where:
+
+    * `executable_path` is a charlist path to the specified executable
+    * `env` is a list of `{key, value}` tuples for the environment
+
+  Returns `{:error, name, reason}` if no executable can be found.
+  """
+  @spec project_executable(Project.t(), String.t()) ::
+          {:ok, charlist(), list()} | {:error, String.t(), String.t()}
+  if Mix.env() == :test do
+    # In test mode, the child engine node must use the same Elixir/OTP as the
+    # test runner, because the test build produces BEAM files for that specific
+    # OTP version. Spawning a login shell to detect the project-local executable
+    # can return a different OTP version (e.g. via mise), causing the child to
+    # fail to load the test BEAM files.
+    def project_executable(%Project{} = project, name) do
+      case configured_executable(project, name) do
+        {:ok, _executable, _env} = ok -> ok
+        :error -> fallback_executable(name)
+      end
+    end
+  else
+    def project_executable(%Project{} = project, name) do
+      case configured_executable(project, name) do
+        {:ok, _executable, _env} = ok ->
+          ok
+
+        :error ->
+          project_executable_or_fallback(project, name)
+      end
+    end
+
+    defp project_executable_or_fallback(%Project{} = project, name) do
+      case find_project_executable(project, name) do
+        {:ok, _executable, _env} = ok ->
+          ok
+
+        {:error, ^name, reason} ->
+          Logger.warning(
+            "Failed to find #{name} for project, falling back to packaged elixir: #{reason}"
+          )
+
+          fallback_executable(name)
+      end
+    end
+  end
+
+  @spec find_project_executable(Project.t(), String.t()) ::
+          {:ok, charlist(), list()} | {:error, String.t(), String.t()}
+  def find_project_executable(%Project{} = project, name) do
+    find_project_executable(Forge.OS.os_family(), project, name)
+  end
+
+  defp configured_executable(%Project{} = project, name) do
+    case configured_executable_path(name) do
+      path when is_binary(path) -> {:ok, to_charlist(path), project_environment(project)}
+      nil -> :error
+    end
+  end
+
+  defp configured_executable_path("elixir") do
+    Configuration.get().elixir_executable_path
+  end
+
+  defp configured_executable_path("erl") do
+    Configuration.get().erlang_executable_path
+  end
+
+  defp configured_executable_path(_name) do
+    nil
+  end
+
+  defp fallback_executable(name) do
+    case System.find_executable(name) do
+      nil -> {:error, name, "Couldn't find any #{name} executable"}
+      executable -> {:ok, to_charlist(executable), []}
+    end
+  end
+
+  defp find_project_executable(:windows, %Project{}, name) do
     path = windows_project_path()
 
     case find_windows_executable(name, path) do
-      false ->
-        {:error, name, "Couldn't find an #{name} executable"}
-
-      elixir ->
-        {:ok, elixir, sanitized_system_env(path)}
+      false -> {:error, name, "Couldn't find an #{name} executable"}
+      executable -> {:ok, executable, sanitized_system_env(path)}
     end
   end
 
-  defp windows_project_path do
-    release_root =
-      "RELEASE_ROOT"
-      |> System.get_env()
-      |> case do
-        nil ->
-          nil
+  defp find_project_executable(:unix, %Project{} = project, name) do
+    path = unix_project_path(project)
 
-        release_root ->
-          release_root
-          |> String.downcase()
-          |> String.replace("/", "\\")
-      end
-
-    "PATH"
-    |> System.get_env("")
-    |> then(fn current_path ->
-      if release_root do
-        current_path
-        |> String.split(";")
-        |> Enum.reject(fn entry ->
-          normalized = entry |> String.downcase() |> String.replace("/", "\\")
-          String.contains?(normalized, release_root)
-        end)
-        |> Enum.join(";")
-      else
-        current_path
-      end
-    end)
+    case :os.find_executable(to_charlist(name), to_charlist(path)) do
+      false -> {:error, name, executable_not_found_message(project, name, path)}
+      executable -> {:ok, executable, sanitized_system_env(path)}
+    end
   end
 
   defp find_windows_executable(name, path) do
-    cmd = "#{name}.cmd"
-    bat = "#{name}.bat"
+    path = to_charlist(path)
 
-    with false <- :os.find_executable(to_charlist(cmd), to_charlist(path)),
-         false <- :os.find_executable(to_charlist(name), to_charlist(path)) do
-      :os.find_executable(to_charlist(bat), to_charlist(path))
+    with false <- :os.find_executable(to_charlist("#{name}.cmd"), path),
+         false <- :os.find_executable(to_charlist(name), path) do
+      :os.find_executable(to_charlist("#{name}.bat"), path)
     end
   end
 
-  defp find_project_executable_unix(%Project{} = project, name) do
+  defp executable_not_found_message(%Project{} = project, name, path) do
     root_path = Project.root_path(project)
-    shell_env = System.get_env("SHELL")
-    path = project_path(project)
 
-    case :os.find_executable(to_charlist(name), to_charlist(path)) do
-      false ->
-        if shell_env do
-          {:error, name,
-           "Couldn't find an #{name} executable for project at #{root_path}. Using shell at #{shell_env} with PATH=#{path}"}
-        else
-          {:error, name,
-           "Couldn't find an #{name} executable for project at #{root_path}. Using PATH=#{path}"}
-        end
+    case System.get_env("SHELL") do
+      nil ->
+        "Couldn't find an #{name} executable for project at #{root_path}. Using PATH=#{path}"
 
-      elixir ->
-        env = sanitized_system_env(path)
+      shell ->
+        "Couldn't find an #{name} executable for project at #{root_path}. Using shell at #{shell} with PATH=#{path}"
+    end
+  end
 
-        {:ok, elixir, env}
+  defp project_environment(%Project{} = project) do
+    project
+    |> project_path()
+    |> sanitized_system_env()
+  end
+
+  defp project_path(%Project{} = project) do
+    project_path(Forge.OS.os_family(), project)
+  end
+
+  defp project_path(:windows, %Project{}) do
+    windows_project_path()
+  end
+
+  defp project_path(:unix, %Project{} = project) do
+    unix_project_path(project)
+  end
+
+  defp windows_project_path do
+    "PATH"
+    |> System.get_env("")
+    |> remove_windows_release_root(System.get_env("RELEASE_ROOT"))
+  end
+
+  defp remove_windows_release_root(path, nil) do
+    path
+  end
+
+  defp remove_windows_release_root(path, release_root) do
+    release_root = normalize_windows_path(release_root)
+
+    path
+    |> String.split(";")
+    |> Enum.reject(fn entry ->
+      entry
+      |> normalize_windows_path()
+      |> String.contains?(release_root)
+    end)
+    |> Enum.join(";")
+  end
+
+  defp normalize_windows_path(path) do
+    path
+    |> String.downcase()
+    |> String.replace("/", "\\")
+  end
+
+  defp unix_project_path(%Project{} = project) do
+    shell = System.get_env("SHELL")
+
+    if shell_available?(shell) do
+      shell_project_path(project, shell)
+    else
+      system_path_without_release_root()
     end
   end
 
   defp shell_available?(shell) do
-    shell != nil and File.exists?(shell)
+    is_binary(shell) and File.exists?(shell)
   end
 
-  defp project_path(%Project{} = project) do
-    if Forge.OS.windows?() do
-      windows_project_path()
-    else
-      unix_project_path(project)
+  defp shell_project_path(%Project{} = project, shell) do
+    case path_env_at_directory(Project.root_path(project), shell) do
+      {:ok, path} -> path
+      {:error, :timeout} -> system_path_without_release_root()
     end
   end
 
-  defp unix_project_path(%Project{} = project) do
-    root_path = Project.root_path(project)
-    shell_env = System.get_env("SHELL")
-
-    if shell_available?(shell_env) do
-      case path_env_at_directory(root_path, shell_env) do
-        {:ok, path} -> path
-        {:error, :timeout} -> filter_release_root_from_path()
-      end
-    else
-      filter_release_root_from_path()
-    end
+  defp system_path_without_release_root do
+    "PATH"
+    |> System.get_env(@default_unix_path)
+    |> remove_unix_release_root(System.get_env("RELEASE_ROOT"))
   end
 
-  defp filter_release_root_from_path do
-    current_path = System.get_env("PATH", @default_unix_path)
-    release_root = System.get_env("RELEASE_ROOT")
+  defp remove_unix_release_root(path, nil) do
+    path
+  end
 
-    if release_root do
-      current_path
-      |> String.split(":")
-      |> Enum.reject(fn entry ->
-        String.starts_with?(entry, release_root)
-      end)
-      |> Enum.join(":")
-    else
-      current_path
-    end
+  defp remove_unix_release_root(path, release_root) do
+    path
+    |> String.split(":")
+    |> Enum.reject(&String.starts_with?(&1, release_root))
+    |> Enum.join(":")
   end
 
   defp path_env_at_directory(directory, shell) do
     env = [
+      {"EXPERT_PROJECT_ROOT", directory},
       {"SHELL_SESSIONS_DISABLE", "1"},
       {"PATH", System.get_env("PATH", @default_unix_path)}
     ]
 
-    args = path_fetch_cmd_args(shell, directory)
-
-    maybe_cmd_output =
-      case cmd_with_timeout(shell, args, env, 1_000) do
-        {:ok, result} ->
-          {:ok, result}
-
-        {:error, :timeout} ->
-          if Enum.member?(args, "-i") do
-            # If the command contained the -i flag, try again without it.
-            # Some users have exec calls or blocking prompts in their .bashrc,
-            # so we would hang here without the timeout
-            args = Enum.reject(args, &(&1 == "-i"))
-            cmd_with_timeout(shell, args, env, 1_000)
-          else
-            {:error, :timeout}
-          end
-      end
-
-    case maybe_cmd_output do
-      {:ok, {output, exit_code}} ->
-        case Regex.run(~r/#{@path_marker}:(.*?):#{@path_marker}/s, output) do
-          [_, clean_path] when exit_code == 0 ->
-            {:ok, clean_path}
-
-          _ ->
-            {:ok, output |> String.trim() |> String.split("\n") |> List.last()}
-        end
-
-      {:error, :timeout} ->
-        {:error, :timeout}
-    end
+    shell
+    |> path_fetch_cmd_args()
+    |> run_path_fetch_command(shell, env)
   end
 
-  defp path_fetch_cmd_args(shell, directory) do
+  defp path_fetch_cmd_args(shell) do
     case Path.basename(shell) do
       "fish" ->
         cmd =
-          "cd #{directory}; printf \"#{@path_marker}:%s:#{@path_marker}\" (string join ':' $PATH)"
+          "cd \"$EXPERT_PROJECT_ROOT\"; printf \"#{@path_marker}:%s:#{@path_marker}\" (string join ':' $PATH)"
 
         ["-l", "-c", cmd]
 
       "nu" ->
         cmd =
-          "cd #{directory}; print $\"#{@path_marker}:($env.PATH | str join \":\"):#{@path_marker}\""
+          "cd $env.EXPERT_PROJECT_ROOT; print $\"#{@path_marker}:($env.PATH | str join \":\"):#{@path_marker}\""
 
         ["-l", "-c", cmd]
 
       _ ->
-        cmd = "cd #{directory} && printf \"#{@path_marker}:%s:#{@path_marker}\" \"$PATH\""
+        cmd =
+          "cd \"$EXPERT_PROJECT_ROOT\" && printf \"#{@path_marker}:%s:#{@path_marker}\" \"$PATH\""
+
         ["-i", "-l", "-c", cmd]
     end
+  end
+
+  defp run_path_fetch_command(args, shell, env) do
+    case cmd_with_timeout(shell, args, env, 1_000) do
+      {:ok, {output, exit_code}} ->
+        {:ok, path_from_output(output, exit_code)}
+
+      {:error, :timeout} ->
+        if "-i" in args do
+          args
+          |> List.delete("-i")
+          |> run_path_fetch_command(shell, env)
+        else
+          {:error, :timeout}
+        end
+    end
+  end
+
+  defp path_from_output(output, 0) do
+    case Regex.run(~r/#{@path_marker}:(.*?):#{@path_marker}/s, output) do
+      [_, path] -> path
+      nil -> last_output_line(output)
+    end
+  end
+
+  defp path_from_output(output, _exit_code) do
+    last_output_line(output)
+  end
+
+  defp last_output_line(output) do
+    output
+    |> String.trim()
+    |> String.split("\n")
+    |> List.last()
   end
 
   defp cmd_with_timeout(shell, args, env, timeout) do
     task = Task.async(fn -> System.cmd(shell, args, env: env) end)
 
     case Task.yield(task, timeout) || Task.shutdown(task) do
-      {:ok, result} ->
-        {:ok, result}
-
-      _ ->
-        {:error, :timeout}
+      {:ok, result} -> {:ok, result}
+      _ -> {:error, :timeout}
     end
   end
 
-  defp fallback_executable(name) do
-    case System.find_executable(name) do
-      nil ->
-        {:error, name, "Couldn't find any #{name} executable"}
+  defp sanitized_system_env(path) do
+    path = prepend_configured_erlang_path(path)
 
-      elixir ->
-        {:ok, to_charlist(elixir), []}
+    System.get_env()
+    |> Enum.map(&sanitize_system_env_var(&1, path))
+  end
+
+  defp sanitize_system_env_var({key, _value}, path) when key in ["PATH", "Path"] do
+    {key, path}
+  end
+
+  defp sanitize_system_env_var({key, _value}, _path) when key in @scrubbed_env_vars do
+    {key, ""}
+  end
+
+  defp sanitize_system_env_var({key, value}, _path) do
+    {key, value}
+  end
+
+  defp prepend_configured_erlang_path(path) do
+    case configured_executable_path("erl") do
+      erl_path when is_binary(erl_path) -> Path.dirname(erl_path) <> path_env_separator() <> path
+      nil -> path
     end
+  end
+
+  defp put_env(opts, env) do
+    Keyword.update(opts, :env, env, fn old_env -> env ++ old_env end)
   end
 
   defp open_executable(executable, opts) do
-    {os_type, _} = Forge.OS.type()
-
     opts =
       if Keyword.has_key?(opts, :env) do
         Keyword.update!(opts, :env, &ensure_charlists/1)
@@ -393,38 +390,48 @@ defmodule Expert.Port do
         opts
       end
 
-    open_port(os_type, executable, opts)
+    open_port(Forge.OS.os_type(), executable, opts)
   end
 
   defp open_port(:win32, executable, opts) do
-    executable_str = to_string(executable)
-
-    {launcher, opts} =
-      if String.ends_with?(executable_str, ".cmd") or String.ends_with?(executable_str, ".bat") do
-        cmd_exe = "cmd" |> System.find_executable() |> to_charlist()
-
-        opts =
-          Keyword.update(opts, :args, ["/c", "call", executable_str], fn args ->
-            ["/c", "call", executable_str | args]
-          end)
-
-        {cmd_exe, [:hide | opts]}
-      else
-        {executable, opts}
-      end
-
-    Port.open({:spawn_executable, launcher}, [:binary, :stderr_to_stdout, :exit_status | opts])
+    if windows_batch_file?(executable) do
+      open_windows_batch_file(executable, opts)
+    else
+      do_open_port(executable, opts)
+    end
   end
 
   defp open_port(:unix, executable, opts) do
-    launcher = port_wrapper_path()
-
     opts =
-      Keyword.update(opts, :args, [executable], fn old_args ->
-        [executable | Enum.map(old_args, &to_string/1)]
+      Keyword.update(opts, :args, [executable], fn args ->
+        [executable | Enum.map(args, &to_string/1)]
       end)
 
-    Port.open({:spawn_executable, launcher}, [:binary, :stderr_to_stdout, :exit_status | opts])
+    port_wrapper_path()
+    |> do_open_port(opts)
+  end
+
+  defp windows_batch_file?(executable) do
+    executable
+    |> to_string()
+    |> String.ends_with?([".cmd", ".bat"])
+  end
+
+  defp open_windows_batch_file(executable, opts) do
+    executable = to_string(executable)
+    launcher = "cmd" |> System.find_executable() |> to_charlist()
+
+    opts =
+      opts
+      |> Keyword.update(:args, ["/c", "call", executable], fn args ->
+        ["/c", "call", executable | args]
+      end)
+
+    do_open_port(launcher, [:hide | opts])
+  end
+
+  defp do_open_port(executable, opts) do
+    Port.open({:spawn_executable, executable}, [:binary, :stderr_to_stdout, :exit_status | opts])
   end
 
   defp port_wrapper_path do
@@ -437,12 +444,13 @@ defmodule Expert.Port do
     |> to_string()
   end
 
-  defp ensure_charlists(environment_variables) do
-    Enum.map(environment_variables, fn {key, value} ->
-      # using to_string ensures nil values won't blow things up
-      erl_key = key |> to_string() |> String.to_charlist()
-      erl_value = value |> to_string() |> String.to_charlist()
-      {erl_key, erl_value}
+  defp ensure_charlists(env) do
+    Enum.map(env, fn {key, value} ->
+      {key |> to_string() |> String.to_charlist(), value |> to_string() |> String.to_charlist()}
     end)
+  end
+
+  defp path_env_separator do
+    if Forge.OS.os_family() == :windows, do: ";", else: ":"
   end
 end

--- a/apps/expert/lib/expert/project/supervisor.ex
+++ b/apps/expert/lib/expert/project/supervisor.ex
@@ -81,4 +81,12 @@ defmodule Expert.Project.Supervisor do
 
     Logger.info("Stopping project node for #{Project.name(project)}")
   end
+
+  def restart_node(%Project{} = project, opts \\ []) when is_list(opts) do
+    if Process.whereis(name(project)) do
+      stop_node(project)
+    end
+
+    ensure_node_started(project, opts)
+  end
 end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -93,18 +93,16 @@ defmodule Expert.State do
   end
 
   def apply(%__MODULE__{} = state, %Notifications.WorkspaceDidChangeConfiguration{} = event) do
-    old_elixir_source_path = Configuration.get().elixir_source_path
+    old_config = Configuration.get()
 
     case Configuration.on_change(event) do
       {:ok, config} ->
-        if config.elixir_source_path != old_elixir_source_path,
-          do: propagate_elixir_source_path(config)
+        apply_configuration_side_effects(old_config, config)
 
         {:ok, state}
 
       {:ok, config, request} ->
-        if config.elixir_source_path != old_elixir_source_path,
-          do: propagate_elixir_source_path(config)
+        apply_configuration_side_effects(old_config, config)
 
         GenLSP.request(Expert.get_lsp(), request)
         {:ok, state}
@@ -314,6 +312,43 @@ defmodule Expert.State do
     end
   rescue
     _ -> :ok
+  end
+
+  defp apply_configuration_side_effects(%Configuration{} = old_config, %Configuration{} = config) do
+    if config.elixir_source_path != old_config.elixir_source_path do
+      propagate_elixir_source_path(config)
+    end
+
+    if runtime_executable_paths_changed?(old_config, config) do
+      restart_runtime_projects()
+    end
+  end
+
+  defp runtime_executable_paths_changed?(%Configuration{} = old_config, %Configuration{} = config) do
+    config.elixir_executable_path != old_config.elixir_executable_path or
+      config.erlang_executable_path != old_config.erlang_executable_path
+  end
+
+  defp restart_runtime_projects do
+    for project <- Store.projects(), not Store.blocked?(project) do
+      restart_runtime_project(project)
+    end
+
+    :ok
+  end
+
+  defp restart_runtime_project(%Project{} = project) do
+    case Task.Supervisor.start_child(:expert_task_queue, fn ->
+           Expert.Project.Supervisor.restart_node(project, blocked?: false)
+         end) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to schedule project restart for #{Project.name(project)}: #{inspect(reason)}"
+        )
+    end
   end
 
   def initialize_result do

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -295,6 +295,16 @@ defmodule Expert.ConfigurationTest do
 
       assert updated.workspace_symbols.min_query_length == 3
     end
+
+    test "preserves previous value when workspaceSymbols is missing" do
+      change = build_change(%{"workspaceSymbols" => %{"minQueryLength" => 0}})
+      {:ok, _updated} = Configuration.on_change(change)
+
+      change = build_change(%{"fileLogLevel" => "error"})
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.workspace_symbols.min_query_length == 0
+    end
   end
 
   describe "on_change/1 with elixirSourcePath" do

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -12,6 +12,10 @@ defmodule Expert.ConfigurationTest do
     Configuration.new()
     |> Configuration.set()
 
+    on_exit(fn ->
+      :persistent_term.erase(Expert.Configuration)
+    end)
+
     :ok
   end
 
@@ -333,6 +337,56 @@ defmodule Expert.ConfigurationTest do
       {:ok, updated} = Configuration.on_change(change)
 
       assert updated.elixir_source_path == nil
+    end
+  end
+
+  describe "on_change/1 with runtime executable paths" do
+    test "stores configured executable paths" do
+      change =
+        build_change(%{
+          "elixirExecutablePath" => "/opt/elixir/bin/elixir",
+          "erlangExecutablePath" => "/opt/erlang/bin/erl"
+        })
+
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_executable_path == "/opt/elixir/bin/elixir"
+      assert updated.erlang_executable_path == "/opt/erlang/bin/erl"
+    end
+
+    test "preserves configured executable paths when settings are missing" do
+      change =
+        build_change(%{
+          "elixirExecutablePath" => "/opt/elixir/bin/elixir",
+          "erlangExecutablePath" => "/opt/erlang/bin/erl"
+        })
+
+      {:ok, _updated} = Configuration.on_change(change)
+      {:ok, updated} = Configuration.on_change(build_change(%{}))
+
+      assert updated.elixir_executable_path == "/opt/elixir/bin/elixir"
+      assert updated.erlang_executable_path == "/opt/erlang/bin/erl"
+    end
+
+    test "clears configured executable paths when explicit null is sent" do
+      change =
+        build_change(%{
+          "elixirExecutablePath" => "/opt/elixir/bin/elixir",
+          "erlangExecutablePath" => "/opt/erlang/bin/erl"
+        })
+
+      {:ok, _updated} = Configuration.on_change(change)
+
+      change =
+        build_change(%{
+          "elixirExecutablePath" => nil,
+          "erlangExecutablePath" => nil
+        })
+
+      {:ok, updated} = Configuration.on_change(change)
+
+      assert updated.elixir_executable_path == nil
+      assert updated.erlang_executable_path == nil
     end
   end
 

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -19,6 +19,7 @@ defmodule Expert.ExpertTest do
     # These tests call `Expert.handle_info/2` directly (bypassing `Expert.Application`),
     # so we must start the stores that runtime boot normally provides.
     start_supervised!({Forge.Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
+    start_supervised!({Task.Supervisor, name: :expert_task_queue})
     start_supervised!({Expert.Project.Store, []})
 
     # window/logMessage comes from Logger via WindowLogHandler,
@@ -29,6 +30,7 @@ defmodule Expert.ExpertTest do
     :logger.update_handler_config(:default, :level, :none)
 
     on_exit(fn ->
+      :persistent_term.erase(Expert.Configuration)
       Forge.Workspace.set_workspace(nil)
       Logger.configure(level: :none)
       :logger.update_handler_config(:default, :level, :all)
@@ -181,6 +183,56 @@ defmodule Expert.ExpertTest do
     config = Expert.Configuration.get()
     assert config.log_level == :info
     assert config.workspace_symbols.min_query_length == 2
+  end
+
+  test "restarts pending projects when runtime executable configuration changes" do
+    project = Fixtures.project()
+    test_pid = self()
+
+    {:ok, _response, state} = State.initialize(State.new(), initialize_request(project, []))
+
+    Expert.Project.Store.add_projects([project])
+
+    patch(Expert.Project.Supervisor, :restart_node, fn restarted_project, opts ->
+      send(test_pid, {:project_restarted, restarted_project.root_uri, opts})
+      {:ok, self()}
+    end)
+
+    notification = %WorkspaceDidChangeConfiguration{
+      params: %DidChangeConfigurationParams{
+        settings: %{"elixirExecutablePath" => "/opt/elixir/bin/elixir"}
+      }
+    }
+
+    assert {:ok, ^state} = State.apply(state, notification)
+
+    assert_receive {:project_restarted, root_uri, [blocked?: false]}
+    assert root_uri == project.root_uri
+  end
+
+  test "does not restart blocked projects when runtime executable configuration changes" do
+    project = Fixtures.project()
+    test_pid = self()
+
+    {:ok, _response, state} = State.initialize(State.new(), initialize_request(project, []))
+
+    Expert.Project.Store.add_projects([project])
+    Expert.Project.Store.transition(project, :blocked)
+
+    patch(Expert.Project.Supervisor, :restart_node, fn restarted_project, opts ->
+      send(test_pid, {:project_restarted, restarted_project.root_uri, opts})
+      {:ok, self()}
+    end)
+
+    notification = %WorkspaceDidChangeConfiguration{
+      params: %DidChangeConfigurationParams{
+        settings: %{"elixirExecutablePath" => "/opt/elixir/bin/elixir"}
+      }
+    }
+
+    assert {:ok, ^state} = State.apply(state, notification)
+
+    refute_receive {:project_restarted, _root_uri, _opts}
   end
 
   test "initialization stores an empty workspace when root_uri and workspace_folders are nil" do

--- a/apps/forge/lib/forge/os.ex
+++ b/apps/forge/lib/forge/os.ex
@@ -3,6 +3,15 @@ defmodule Forge.OS do
     match?({:win32, _}, type())
   end
 
+  def os_family do
+    if windows?(), do: :windows, else: :unix
+  end
+
+  def os_type do
+    {os_type, _os_name} = type()
+    os_type
+  end
+
   # this is here to be mocked in tests
   def type do
     :os.type()

--- a/apps/forge/test/forge/os_test.exs
+++ b/apps/forge/test/forge/os_test.exs
@@ -1,0 +1,26 @@
+defmodule Forge.OSTest do
+  use ExUnit.Case
+  use Patch
+
+  describe "os_family/0" do
+    test "returns :windows for win32" do
+      patch(Forge.OS, :type, {:win32, :nt})
+
+      assert Forge.OS.os_family() == :windows
+    end
+
+    test "returns :unix for non-win32 systems" do
+      patch(Forge.OS, :type, {:unix, :darwin})
+
+      assert Forge.OS.os_family() == :unix
+    end
+  end
+
+  describe "os_type/0" do
+    test "eturns the first element of :os.type/0" do
+      patch(Forge.OS, :type, {:unix, :linux})
+
+      assert Forge.OS.os_type() == :unix
+    end
+  end
+end

--- a/apps/forge/test/forge/os_test.exs
+++ b/apps/forge/test/forge/os_test.exs
@@ -17,7 +17,7 @@ defmodule Forge.OSTest do
   end
 
   describe "os_type/0" do
-    test "eturns the first element of :os.type/0" do
+    test "returns the first element of :os.type/0" do
       patch(Forge.OS, :type, {:unix, :linux})
 
       assert Forge.OS.os_type() == :unix

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -11,7 +11,9 @@ Expert supports the following configuration options.
   },
   "logLevel": "info",
   "fileLogLevel": "info",
-  "elixirSourcePath": "/path/to/elixir/source"
+  "elixirSourcePath": "/path/to/elixir/source",
+  "elixirExecutablePath": "/absolute/path/to/elixir",
+  "erlangExecutablePath": "/absolute/path/to/erl"
 }
 ```
 
@@ -23,3 +25,5 @@ Expert supports the following configuration options.
 | `logLevel` | string | `"info"` | Minimum severity of log messages forwarded to the editor. Valid values: `"error"`, `"warning"`, `"info"`, `"log"`. |
 | `fileLogLevel` | string | `"debug"` | Minimum severity of log messages written to the log file (`.expert/expert.log`). Valid values: `"debug"`, `"info"`, `"warning"`, `"error"`, `null`. Sending `null` resets log level to default. |
 | `elixirSourcePath` | string | `null` | Path to a local Elixir source directory. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result. Should be an absolute path. |
+| `elixirExecutablePath` | string | `null` | Path to the Elixir executable Expert should use for building and running project engines. Sending `null` clears the override. Expert uses the path as provided and does not validate it. |
+| `erlangExecutablePath` | string | `null` | Path to the Erlang `erl` executable Expert should use when resolving the project Erlang runtime. Sending `null` clears the override. Expert uses the path as provided and does not validate it. |


### PR DESCRIPTION
Close #389 

Adds two new configuration options to allow users to specify their paths to the elixir and erlang executables, as an escape hatch if our discovery logic doesn't work for their setup: `elixirExecutablePath` and `erlangExecutablePath`

There are 3 commits in this PR, I recommend reviewing them one at a time. The first commit is the main one that implements the feature. The other two are refactors I thought necessary now that we have several config options, and to cleanup the rot that was building up in `Expert.Port`

There's also a few changes to the env vars we scrub, I was getting crashes when pointing to a different toolchain and scrubbing those extra vars solved the issue.

NOTE: This does not support configuring the toolchain per-project, I'm not yet sure of a clean way to implement that because projects are dynamically discovered, and requiring a file that needs to be added to `.gitignore` does not strike me as the right solution at this moment.