### PR TITLE
chore: move `ensure_hex_and_rebar` to engine

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -95,7 +95,7 @@ defmodule Engine do
       :error ->
         {:ok, deps_paths} =
           Engine.Mix.in_project(fn _ ->
-            Project.ensure_hex_and_rebar()
+            Engine.Mix.ensure_hex_and_rebar()
             Mix.Task.run("loadpaths")
             Mix.Project.deps_paths()
           end)

--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -64,7 +64,7 @@ defmodule Engine.Build.Project do
       Progress.report(token, message: "Compiling #{Project.display_name(project)}")
       result = compile_in_isolation()
       maybe_load_modules()
-      Project.ensure_hex_and_rebar()
+      Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:loadpaths)
       result
     end
@@ -103,7 +103,7 @@ defmodule Engine.Build.Project do
 
   defp compile_in_isolation do
     compile_fun = fn ->
-      Project.ensure_hex_and_rebar()
+      Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:compile, mix_compile_opts())
     end
 

--- a/apps/engine/lib/engine/mix.ex
+++ b/apps/engine/lib/engine/mix.ex
@@ -1,8 +1,22 @@
 defmodule Engine.Mix do
+  alias Forge.Internet
   alias Forge.Project
+
+  require Logger
 
   def loaded? do
     not is_nil(Mix.Project.get())
+  end
+
+  def ensure_hex_and_rebar do
+    if Internet.connected_to_internet?() do
+      Mix.Task.run("local.hex", ~w(--force --if-missing))
+      Mix.Task.run("local.rebar", ~w(--force --if-missing))
+      :ok
+    else
+      Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
+      :ok
+    end
   end
 
   def in_project(fun) do

--- a/apps/engine/lib/engine/mix.tasks.deps.safe_compile.ex
+++ b/apps/engine/lib/engine/mix.tasks.deps.safe_compile.ex
@@ -40,8 +40,6 @@ if !Elixir.Features.compile_keeps_current_directory?() do
 
     use Mix.Task
 
-    alias Forge.Project
-
     @switches [
       include_children: :boolean,
       force: :boolean,
@@ -55,7 +53,7 @@ if !Elixir.Features.compile_keeps_current_directory?() do
         Mix.Tasks.Deps.Compile.run(args)
       else
         if "--no-archives-check" not in args do
-          Project.ensure_hex_and_rebar()
+          Engine.Mix.ensure_hex_and_rebar()
           Mix.Task.run("archive.check", args)
         end
 
@@ -179,7 +177,7 @@ if !Elixir.Features.compile_keeps_current_directory?() do
             "--no-warnings-as-errors"
           ]
 
-          Project.ensure_hex_and_rebar()
+          Engine.Mix.ensure_hex_and_rebar()
           res = Mix.Task.run("compile", options)
           match?({:ok, _}, res)
         catch

--- a/apps/forge/lib/forge/project.ex
+++ b/apps/forge/lib/forge/project.ex
@@ -6,9 +6,6 @@ defmodule Forge.Project do
   as well as business logic for how to change its attributes.
   """
   alias Forge.Document
-  alias Forge.Internet
-
-  require Logger
 
   defstruct root_uri: nil,
             mix_exs_uri: nil,
@@ -391,16 +388,5 @@ defmodule Forge.Project do
 
   def kind(%__MODULE__{} = project) do
     project.kind
-  end
-
-  def ensure_hex_and_rebar do
-    if Internet.connected_to_internet?() do
-      Mix.Task.run("local.hex", ~w(--force --if-missing))
-      Mix.Task.run("local.rebar", ~w(--force --if-missing))
-      :ok
-    else
-      Logger.warning("Could not connect to hex.pm, dependencies will not be fetched")
-      :ok
-    end
   end
 end


### PR DESCRIPTION
While the scope of Forge seems a bit under-defined, I don't think it a good place for a function that only performs side-effects and is only used by Engine. Thereforce I think Engine.Mix is a better place for it.

Not sure about Forge.Internet, maybe it should be moved as well.