### PR TITLE
fix(forge): reset ASCII assumption on a new line

### DIFF
--- a/apps/forge/lib/forge/document/line_parser.ex
+++ b/apps/forge/lib/forge/document/line_parser.ex
@@ -68,7 +68,7 @@ defmodule Forge.Document.LineParser do
 
       acc = [{line_number, line_start_index, line_length, is_ascii?, unquote(ending)} | acc]
       next_index = current_index + unquote(ending_length)
-      traverse(rest, next_index, line_number + 1, next_index, is_ascii?, acc)
+      traverse(rest, next_index, line_number + 1, next_index, _is_ascii? = true, acc)
     end
   end
 

--- a/apps/forge/test/forge/line_parser_test.exs
+++ b/apps/forge/test/forge/line_parser_test.exs
@@ -52,6 +52,14 @@ defmodule Forge.Document.LineParserTest do
              ] = parse("line1\nline2\nline3")
     end
 
+    test "resets ascii detection after each line ending" do
+      assert [
+               line(text: "👨‍👩‍👦 test", ending: "\n", ascii?: false),
+               line(text: "basic", ending: "\n", ascii?: true),
+               line(text: "more text", ending: "", ascii?: true)
+             ] = parse("👨‍👩‍👦 test\nbasic\nmore text")
+    end
+
     test "with multiple CR LF line endings" do
       text = "A\r\nB\r\n\r\nC"
 


### PR DESCRIPTION
Every time we start parsing a new line in a line parser, we need to assume it's ASCII first, until proven otherwise. Not doing that leads to negative indices on following ASCII-only lines which are treated as non-ASCII.

Fixes #623 

