### PR TITLE
fix(expert): use document from request as fallback when document is not in the store

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -104,7 +104,7 @@ defmodule Expert do
   def handle_request(request, lsp) do
     with {:ok, handler} <- fetch_handler(request),
          {:ok, context} <- check_engine_initialized(request),
-         {:ok, request} <- Convert.to_native(request),
+         {:ok, request} <- Convert.to_native(request, context_document(context)),
          {:ok, response} <- handler.handle(request, context),
          {:ok, response} <- Expert.Protocol.Convert.to_lsp(response) do
       {:reply, response, lsp}
@@ -145,6 +145,9 @@ defmodule Expert do
          }, lsp}
     end
   end
+
+  defp context_document(%{document: %Forge.Document{} = document}), do: document
+  defp context_document(_), do: nil
 
   defp check_engine_initialized(request) do
     if document_request?(request) do

--- a/apps/expert/lib/expert/protocol/convert.ex
+++ b/apps/expert/lib/expert/protocol/convert.ex
@@ -16,12 +16,15 @@ defmodule Expert.Protocol.Convert do
     Convertible.to_lsp(other)
   end
 
-  def to_native(%GenLSP.Notifications.Exit{params: nil} = exit_notification) do
+  def to_native(message, context_document \\ nil)
+
+  def to_native(%GenLSP.Notifications.Exit{params: nil} = exit_notification, _context_document) do
     {:ok, exit_notification}
   end
 
-  def to_native(%{params: request_or_notification} = original_request) do
-    context_document = Document.Container.context_document(request_or_notification, nil)
+  def to_native(%{params: request_or_notification} = original_request, context_document) do
+    context_document =
+      Document.Container.context_document(request_or_notification, context_document)
 
     with {:ok, native_request} <- Convertible.to_native(request_or_notification, context_document) do
       updated_request =
@@ -34,7 +37,7 @@ defmodule Expert.Protocol.Convert do
     end
   end
 
-  def to_native(%GenLSP.Requests.Shutdown{} = request) do
+  def to_native(%GenLSP.Requests.Shutdown{} = request, _context_document) do
     # Special case for shutdown requests, which don't have a params field
     {:ok, request}
   end

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -5,7 +5,10 @@ defmodule Expert.ExpertTest do
   import Expert.Test.Protocol.TransportSupport
   import ExUnit.CaptureLog
 
+  alias Expert.Document.Context
   alias Expert.State
+  alias Forge.CodeAction
+  alias Forge.Document
   alias Forge.Project
   alias Forge.Test.Fixtures
   alias GenLSP.Notifications.WorkspaceDidChangeConfiguration
@@ -289,6 +292,76 @@ defmodule Expert.ExpertTest do
            } = Expert.handle_request(request, lsp)
 
     assert code == GenLSP.Enumerations.ErrorCodes.invalid_request()
+  end
+
+  test "document request conversion uses the resolved context document as fallback" do
+    project = Fixtures.project()
+    lsp = initialize_lsp(project)
+    test_pid = self()
+
+    Expert.Project.Store.add_projects([project])
+    Expert.Project.Store.transition(project, :ready)
+
+    uri = Document.Path.to_uri(Path.join(Forge.Project.root_path(project), "lib/context.ex"))
+
+    document =
+      Document.new(
+        uri,
+        """
+        defmodule Context do
+          alias Foo.Bar
+        end
+        """,
+        1,
+        "elixir"
+      )
+
+    range = %GenLSP.Structures.Range{
+      start: %GenLSP.Structures.Position{line: 1, character: 2},
+      end: %GenLSP.Structures.Position{line: 1, character: 15}
+    }
+
+    request = %GenLSP.Requests.TextDocumentCodeAction{
+      id: 1,
+      jsonrpc: "2.0",
+      method: "textDocument/codeAction",
+      params: %GenLSP.Structures.CodeActionParams{
+        text_document: %GenLSP.Structures.TextDocumentIdentifier{uri: uri},
+        range: range,
+        context: %GenLSP.Structures.CodeActionContext{
+          diagnostics: [
+            %GenLSP.Structures.Diagnostic{
+              range: range,
+              message: "Test diagnostic",
+              source: "TestSource"
+            }
+          ],
+          only: nil,
+          trigger_kind: 1
+        }
+      }
+    }
+
+    refute Document.Store.open?(uri)
+
+    patch(Expert.Document.Lookup, :resolve_from_request, fn _request, _projects ->
+      {:ok, Context.new(uri, document, project)}
+    end)
+
+    patch(Expert.EngineApi, :code_actions, fn
+      ^project,
+      ^document,
+      %Document.Range{} = native_range,
+      [%CodeAction.Diagnostic{range: %Document.Range{}}] = diagnostics,
+      :all,
+      1 ->
+        send(test_pid, {:code_actions, native_range, diagnostics})
+        []
+    end)
+
+    assert {:reply, [], ^lsp} = Expert.handle_request(request, lsp)
+
+    assert_receive {:code_actions, %Document.Range{}, [%CodeAction.Diagnostic{}]}
   end
 
   defp initialize_lsp(project, opts \\ []) do


### PR DESCRIPTION
Looking at #535 the reason is that a file on which a codeAction request is performed is not (yet?) in the `Document.Store` (or maybe was there, but is gone because of `didClose`). This smells like a misbehaving client, but I cannot rule out some kind of race condition too.

Anyway, even if we cannot fetch from `Document.Store` for some reason, we should already have a document resolved from the request (by temporary reading from disk). We can use this document as a fallback in such case. Not sure if it fixes #535, because I don't have a repro case, but it's the best shot I have.