### PR TITLE
fix(engine): increase build timeout duration, add batch uri reindex with debounce

### DIFF
--- a/apps/engine/lib/engine/build.ex
+++ b/apps/engine/lib/engine/build.ex
@@ -8,8 +8,6 @@ defmodule Engine.Build do
 
   require Logger
 
-  @timeout_interval_millis 1000
-
   # Public interface
 
   def schedule_compile(%Project{} = _project, force? \\ false) do
@@ -73,7 +71,7 @@ defmodule Engine.Build do
   @impl GenServer
   def handle_call({:force_compile_file, %Document{} = document}, _from, %State{} = state) do
     State.compile_file(state, document)
-    {:reply, :ok, state, @timeout_interval_millis}
+    {:reply, :ok, state, State.edit_window_millis()}
   end
 
   @impl GenServer
@@ -86,13 +84,13 @@ defmodule Engine.Build do
   @impl GenServer
   def handle_cast({:compile, force?}, %State{} = state) do
     new_state = State.on_project_compile(state, force?)
-    {:noreply, new_state, @timeout_interval_millis}
+    {:noreply, new_state, State.edit_window_millis()}
   end
 
   @impl GenServer
   def handle_cast({:compile_file, %Document{} = document}, %State{} = state) do
     new_state = State.on_file_compile(state, document)
-    {:noreply, new_state, @timeout_interval_millis}
+    {:noreply, new_state, State.edit_window_millis()}
   end
 
   @impl GenServer

--- a/apps/engine/lib/engine/build.ex
+++ b/apps/engine/lib/engine/build.ex
@@ -8,7 +8,7 @@ defmodule Engine.Build do
 
   require Logger
 
-  @timeout_interval_millis 50
+  @timeout_interval_millis 1000
 
   # Public interface
 

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -111,6 +111,10 @@ defmodule Engine.Build.State do
 
   def last_deps_fetch_result(%__MODULE__{last_deps_fetch_result: result}), do: result
 
+  def edit_window_millis do
+    Application.get_env(:engine, :edit_window_millis, 1000)
+  end
+
   defp normalize_fetch_deps_result({:ok, :ok}), do: :ok
   defp normalize_fetch_deps_result(result), do: result
 

--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -19,16 +19,20 @@ defmodule Engine.Commands.Reindex do
 
     require Logger
 
-    @debounce_interval_millis 1000
+    @default_debounce_interval_millis 1000
 
     defstruct reindex_fun: nil,
               index_task: nil,
               pending_updates: %{},
               pending_uris: MapSet.new(),
-              debounce_timer: nil
+              debounce_timer: nil,
+              debounce_interval_millis: @default_debounce_interval_millis
 
-    def new(reindex_fun) do
-      %__MODULE__{reindex_fun: reindex_fun}
+    def new(reindex_fun, debounce_interval_millis \\ @default_debounce_interval_millis) do
+      %__MODULE__{
+        reindex_fun: reindex_fun,
+        debounce_interval_millis: debounce_interval_millis
+      }
     end
 
     def set_task(%__MODULE__{} = state, {_, _} = task) do
@@ -46,11 +50,13 @@ defmodule Engine.Commands.Reindex do
         Process.cancel_timer(state.debounce_timer)
       end
 
-      timer = Process.send_after(self(), :flush_pending, @debounce_interval_millis)
+      timer =
+        Process.send_after(self(), :flush_pending, state.debounce_interval_millis)
+
       %{new_state | debounce_timer: timer}
     end
 
-    def flush_pending_uris(%__MODULE__{} = state) do
+    def flush_pending_uris(%__MODULE__{index_task: nil} = state) do
       Enum.each(state.pending_uris, fn uri ->
         case entries_for_uri(uri) do
           {:ok, path, entries} ->
@@ -62,6 +68,23 @@ defmodule Engine.Commands.Reindex do
       end)
 
       %{state | pending_uris: MapSet.new(), debounce_timer: nil}
+    end
+
+    def flush_pending_uris(%__MODULE__{} = state) do
+      new_pending_updates =
+        Enum.reduce(state.pending_uris, state.pending_updates, fn uri, acc ->
+          case entries_for_uri(uri) do
+            {:ok, path, entries} -> Map.put(acc, path, entries)
+            _ -> acc
+          end
+        end)
+
+      %{
+        state
+        | pending_uris: MapSet.new(),
+          debounce_timer: nil,
+          pending_updates: new_pending_updates
+      }
     end
 
     def flush_pending_updates(%__MODULE__{} = state) do
@@ -86,8 +109,13 @@ defmodule Engine.Commands.Reindex do
   end
 
   def start_link(opts) do
-    [reindex_fun: fun] = Keyword.validate!(opts, reindex_fun: &do_reindex/1)
-    GenServer.start_link(__MODULE__, fun, name: __MODULE__)
+    opts =
+      Keyword.validate!(opts,
+        reindex_fun: &do_reindex/1,
+        debounce_interval_millis: 1000
+      )
+
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   def uri(uri) do
@@ -107,10 +135,17 @@ defmodule Engine.Commands.Reindex do
   end
 
   @impl GenServer
-  def init(reindex_fun) do
+  def init(opts) do
     Process.flag(:fullsweep_after, 5)
     schedule_gc()
-    {:ok, State.new(reindex_fun)}
+
+    state =
+      State.new(
+        Keyword.fetch!(opts, :reindex_fun),
+        Keyword.fetch!(opts, :debounce_interval_millis)
+      )
+
+    {:ok, state}
   end
 
   @impl GenServer

--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -47,25 +47,23 @@ defmodule Engine.Commands.Reindex do
       new_state = %{state | pending_uris: MapSet.put(state.pending_uris, uri)}
 
       if state.debounce_timer do
-        Process.cancel_timer(state.debounce_timer)
+        {timer, _timer_ref} = state.debounce_timer
+        Process.cancel_timer(timer)
       end
 
-      timer =
-        Process.send_after(self(), :flush_pending, state.debounce_interval_millis)
+      timer_ref = make_ref()
 
-      %{new_state | debounce_timer: timer}
+      timer =
+        Process.send_after(self(), {:flush_pending, timer_ref}, state.debounce_interval_millis)
+
+      %{new_state | debounce_timer: {timer, timer_ref}}
     end
 
     def flush_pending_uris(%__MODULE__{index_task: nil} = state) do
-      Enum.each(state.pending_uris, fn uri ->
-        case entries_for_uri(uri) do
-          {:ok, path, entries} ->
-            Search.Store.update(path, entries)
-
-          _ ->
-            :ok
-        end
-      end)
+      for uri <- state.pending_uris,
+          {:ok, path, entries} <- [entries_for_uri(uri)] do
+        Search.Store.update(path, entries)
+      end
 
       %{state | pending_uris: MapSet.new(), debounce_timer: nil}
     end
@@ -185,9 +183,13 @@ defmodule Engine.Commands.Reindex do
   end
 
   @impl GenServer
-  def handle_info(:flush_pending, %State{} = state) do
+  def handle_info({:flush_pending, timer_ref}, %State{debounce_timer: {_, timer_ref}} = state) do
     new_state = State.flush_pending_uris(state)
     {:noreply, new_state}
+  end
+
+  def handle_info({:flush_pending, _timer_ref}, %State{} = state) do
+    {:noreply, state}
   end
 
   defp do_reindex(%Project{} = project) do

--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -19,7 +19,13 @@ defmodule Engine.Commands.Reindex do
 
     require Logger
 
-    defstruct reindex_fun: nil, index_task: nil, pending_updates: %{}
+    @debounce_interval_millis 1000
+
+    defstruct reindex_fun: nil,
+              index_task: nil,
+              pending_updates: %{},
+              pending_uris: MapSet.new(),
+              debounce_timer: nil
 
     def new(reindex_fun) do
       %__MODULE__{reindex_fun: reindex_fun}
@@ -33,26 +39,29 @@ defmodule Engine.Commands.Reindex do
       %__MODULE__{state | index_task: nil}
     end
 
-    def reindex_uri(%__MODULE__{index_task: nil} = state, uri) do
-      case entries_for_uri(uri) do
-        {:ok, path, entries} ->
-          Search.Store.update(path, entries)
+    def reindex_uri(%__MODULE__{} = state, uri) do
+      new_state = %{state | pending_uris: MapSet.put(state.pending_uris, uri)}
 
-        _ ->
-          :ok
+      if state.debounce_timer do
+        Process.cancel_timer(state.debounce_timer)
       end
 
-      state
+      timer = Process.send_after(self(), :flush_pending, @debounce_interval_millis)
+      %{new_state | debounce_timer: timer}
     end
 
-    def reindex_uri(%__MODULE__{} = state, uri) do
-      case entries_for_uri(uri) do
-        {:ok, path, entries} ->
-          put_in(state.pending_updates[path], entries)
+    def flush_pending_uris(%__MODULE__{} = state) do
+      Enum.each(state.pending_uris, fn uri ->
+        case entries_for_uri(uri) do
+          {:ok, path, entries} ->
+            Search.Store.update(path, entries)
 
-        _ ->
-          state
-      end
+          _ ->
+            :ok
+        end
+      end)
+
+      %{state | pending_uris: MapSet.new(), debounce_timer: nil}
     end
 
     def flush_pending_updates(%__MODULE__{} = state) do
@@ -138,6 +147,12 @@ defmodule Engine.Commands.Reindex do
     :erlang.garbage_collect()
     schedule_gc()
     {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info(:flush_pending, %State{} = state) do
+    new_state = State.flush_pending_uris(state)
+    {:noreply, new_state}
   end
 
   defp do_reindex(%Project{} = project) do

--- a/apps/engine/test/engine/commands/reindex_test.exs
+++ b/apps/engine/test/engine/commands/reindex_test.exs
@@ -12,15 +12,21 @@ defmodule Engine.Commands.ReindexTest do
   alias Forge.Document
 
   setup context do
+    debounce_interval_millis = Map.get(context, :debounce_interval_millis, 0)
+
     case Map.get(context, :reindex_fun, :sleep) do
       :default ->
-        start_supervised!(Reindex)
-
-      :sleep ->
-        start_supervised!({Reindex, reindex_fun: fn _ -> Process.sleep(20) end})
+        start_supervised!({Reindex, debounce_interval_millis: debounce_interval_millis})
 
       :none ->
         :ok
+
+      :sleep ->
+        start_supervised!(
+          {Reindex,
+           reindex_fun: fn _ -> Process.sleep(20) end,
+           debounce_interval_millis: debounce_interval_millis}
+        )
     end
 
     {:ok, project: project()}
@@ -86,6 +92,27 @@ defmodule Engine.Commands.ReindexTest do
       Reindex.uri(uri)
 
       assert_receive {:entries, "/file.ex", ^new_entries}
+    end
+
+    @tag debounce_interval_millis: 100
+    test "debounces uri reindex requests until the quiet period elapses" do
+      first_uri = "file:///first.ex"
+      second_uri = "file:///second.ex"
+      first_entries = [reference()]
+      second_entries = [definition()]
+
+      Process.put(first_uri, first_entries)
+      Process.put(second_uri, second_entries)
+
+      Reindex.uri(first_uri)
+      refute_receive {:entries, _, _}, 50
+
+      Reindex.uri(second_uri)
+      refute_receive {:entries, _, _}, 75
+
+      assert_receive {:entries, "/first.ex", ^first_entries}, 100
+      assert_receive {:entries, "/second.ex", ^second_entries}, 100
+      refute_receive {:entries, _, _}, 50
     end
   end
 

--- a/apps/engine/test/engine/commands/reindex_test.exs
+++ b/apps/engine/test/engine/commands/reindex_test.exs
@@ -93,27 +93,6 @@ defmodule Engine.Commands.ReindexTest do
 
       assert_receive {:entries, "/file.ex", ^new_entries}
     end
-
-    @tag debounce_interval_millis: 100
-    test "debounces uri reindex requests until the quiet period elapses" do
-      first_uri = "file:///first.ex"
-      second_uri = "file:///second.ex"
-      first_entries = [reference()]
-      second_entries = [definition()]
-
-      Process.put(first_uri, first_entries)
-      Process.put(second_uri, second_entries)
-
-      Reindex.uri(first_uri)
-      refute_receive {:entries, _, _}, 50
-
-      Reindex.uri(second_uri)
-      refute_receive {:entries, _, _}, 75
-
-      assert_receive {:entries, "/first.ex", ^first_entries}, 100
-      assert_receive {:entries, "/second.ex", ^second_entries}, 100
-      refute_receive {:entries, _, _}, 50
-    end
   end
 
   describe "perform/1 with the default reindexer" do

--- a/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
+++ b/apps/engine/test/engine/dispatch/handlers/indexer_test.exs
@@ -33,7 +33,7 @@ defmodule Engine.Dispatch.Handlers.IndexingTest do
 
     start_supervised!(Engine.ApplicationCache)
     start_supervised!(Engine.Dispatch)
-    start_supervised!(Commands.Reindex)
+    start_supervised!({Commands.Reindex, debounce_interval_millis: 0})
     start_supervised!(Search.Store.Backends.Ets)
     start_supervised!({Search.Store, [project, create_index, update_index]})
     start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})

--- a/apps/expert/config/test.exs
+++ b/apps/expert/config/test.exs
@@ -3,3 +3,5 @@ import Config
 # Without this option, ExUnit would randomly not terminate or tests would behave
 # erratically.
 config :gen_lsp, :exit_on_end, false
+
+config :engine, edit_window_millis: 10


### PR DESCRIPTION
- Increased `Engine.Build` compilation timeout from 50ms to 1000ms (do not know which value will fit)

- Slightly reworked `Engine.Commands.Reindex`: now reindex adds URIs into `pending_uris` MapSet and process them after 1000ms debounce 

Closes #672 