### PR TITLE
fix(expert): remove release root entries from subprocess PATH

### DIFF
--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -277,7 +277,8 @@ defmodule Expert.Port do
 
   defp path_env_at_directory(directory, shell) do
     clean_path =
-      System.get_env("PATH", @default_unix_path)
+      "PATH"
+      |> System.get_env(@default_unix_path)
       |> remove_unix_release_root(System.get_env("RELEASE_ROOT"))
 
     env = [

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -276,10 +276,14 @@ defmodule Expert.Port do
   end
 
   defp path_env_at_directory(directory, shell) do
+    clean_path =
+      System.get_env("PATH", @default_unix_path)
+      |> remove_unix_release_root(System.get_env("RELEASE_ROOT"))
+
     env = [
       {"EXPERT_PROJECT_ROOT", directory},
       {"SHELL_SESSIONS_DISABLE", "1"},
-      {"PATH", System.get_env("PATH", @default_unix_path)}
+      {"PATH", clean_path}
     ]
 
     shell

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -360,12 +360,15 @@ defmodule Expert.Port do
     path = prepend_configured_erlang_path(path)
 
     System.get_env()
-    |> Enum.reject(fn {key, _value} -> key in @scrubbed_env_vars end)
     |> Enum.map(&sanitize_system_env_var(&1, path))
   end
 
   defp sanitize_system_env_var({key, _value}, path) when key in ["PATH", "Path"] do
     {key, path}
+  end
+
+  defp sanitize_system_env_var({key, _value}, _path) when key in @scrubbed_env_vars do
+    {key, ""}
   end
 
   defp sanitize_system_env_var({key, value}, _path) do

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -18,6 +18,7 @@ defmodule Expert.Port do
 
   @default_unix_path "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   @path_marker "__EXPERT_PATH__"
+  @path_fetch_cmd_timeout_ms 10_000
 
   # These variables are interpreted by release, Elixir, or Erlang launchers and
   # must not leak from Expert's own runtime into project runtime detection.
@@ -315,7 +316,7 @@ defmodule Expert.Port do
   end
 
   defp run_path_fetch_command(args, shell, env) do
-    case cmd_with_timeout(shell, args, env, 1_000) do
+    case cmd_with_timeout(shell, args, env, @path_fetch_cmd_timeout_ms) do
       {:ok, {output, exit_code}} ->
         {:ok, path_from_output(output, exit_code)}
 

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -18,7 +18,7 @@ defmodule Expert.Port do
 
   @default_unix_path "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   @path_marker "__EXPERT_PATH__"
-  @path_fetch_cmd_timeout_ms 10_000
+  @path_fetch_cmd_timeout_ms 5_000
 
   # These variables are interpreted by release, Elixir, or Erlang launchers and
   # must not leak from Expert's own runtime into project runtime detection.

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -356,15 +356,12 @@ defmodule Expert.Port do
     path = prepend_configured_erlang_path(path)
 
     System.get_env()
+    |> Enum.reject(fn {key, _value} -> key in @scrubbed_env_vars end)
     |> Enum.map(&sanitize_system_env_var(&1, path))
   end
 
   defp sanitize_system_env_var({key, _value}, path) when key in ["PATH", "Path"] do
     {key, path}
-  end
-
-  defp sanitize_system_env_var({key, _value}, _path) when key in @scrubbed_env_vars do
-    {key, ""}
   end
 
   defp sanitize_system_env_var({key, value}, _path) do

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -277,15 +277,10 @@ defmodule Expert.Port do
   end
 
   defp path_env_at_directory(directory, shell) do
-    clean_path =
-      "PATH"
-      |> System.get_env(@default_unix_path)
-      |> remove_unix_release_root(System.get_env("RELEASE_ROOT"))
-
     env = [
       {"EXPERT_PROJECT_ROOT", directory},
       {"SHELL_SESSIONS_DISABLE", "1"},
-      {"PATH", clean_path}
+      {"PATH", system_path_without_release_root()}
     ]
 
     shell


### PR DESCRIPTION
Hello expert team 👋🏼 this PR fixes an issue I have been encountering [after this pr](https://github.com/expert-lsp/expert/pull/682) using this setup:

```
ide: neovim v0.12.0
expert install method: build from source with `just release`
language version manager: mise
```

When launching neovim in a project directory, expert will crash with:

```
LSP[expert] [my-project] Failed to start engine my-project::24676988: {:error, "Failed to determine Elixir/OTP runtime for project: Runtime terminating during boot ({'cannot get bootfile','/Users/me/cod
e/opensource/expert/apps/expert/_build/prod/rel/plain/bin/start.boot'})\r\n\r\nCrash dump is being written to: erl_crash.dump...done (status 1)"}
```

I believe this is happening because we are passing `ROOTDIR=""` to `erlexec` [here](https://github.com/expert-lsp/expert/blob/fb358158ba7d2b2f33abbaf4f15a52cbca004f86/apps/expert/lib/expert/port.ex#L366) so we are skipping [this logic](https://github.com/erlang/otp/blame/a294e52685847f5108a07507152d6ff0c540dea6/erts/etc/common/erlexec.c#L1725)

<details>
  <summary>Example of bug</summary>

```sh
ERLEXEC=~/.local/share/mise/installs/erlang/26.2.5.15/erts-14.2.5.11/bin/erlexec
BINDIR=~/.local/share/mise/installs/erlang/26.2.5.15/erts-14.2.5.11/bin

env -i HOME="$HOME" PATH="$PATH" BINDIR="$BINDIR" "$ERLEXEC" -noshell -eval 'halt().' 2>&1; echo "exit: $?"

# prints exit: 0

env -i HOME="$HOME" PATH="$PATH" ROOTDIR="" BINDIR="$BINDIR" "$ERLEXEC" -noshell -eval 'halt().' 2>&1; echo "exit: $?"

# prints
# Runtime terminating during boot ({'cannot get bootfile','/bin/start.boot'})
# Crash dump is being written to: erl_crash.dump...done
# exit: 1
```

</details>

By omitting `@scrubbed_env_vars` entirely, I was able to get expert working again with my setup.

I believe this will also be the fix for https://github.com/expert-lsp/expert/issues/637