### PR TITLE
fix: prevent ProjectStack from becoming `nil`

### DIFF
--- a/apps/engine/lib/engine/build.ex
+++ b/apps/engine/lib/engine/build.ex
@@ -17,7 +17,7 @@ defmodule Engine.Build do
   end
 
   def compile_document(%Project{} = _project, %Document{} = document) do
-    with false <- Path.absname(document.path) == "mix.exs",
+    with false <- mix_project_file?(document),
          false <- HEEx.recognizes?(document) do
       GenServer.cast(__MODULE__, {:compile_file, document})
     end
@@ -27,12 +27,16 @@ defmodule Engine.Build do
 
   # this is for testing
   def force_compile_document(%Document{} = document) do
-    with false <- Path.absname(document.path) == "mix.exs",
+    with false <- mix_project_file?(document),
          false <- HEEx.recognizes?(document) do
       GenServer.call(__MODULE__, {:force_compile_file, document})
     end
 
     :ok
+  end
+
+  defp mix_project_file?(%Document{path: path}) when is_binary(path) do
+    Path.basename(path) == "mix.exs"
   end
 
   def clean_and_fetch_deps(%Project{} = project) do

--- a/apps/engine/lib/engine/build/document/compilers/quoted.ex
+++ b/apps/engine/lib/engine/build/document/compilers/quoted.ex
@@ -8,6 +8,14 @@ defmodule Engine.Build.Document.Compilers.Quoted do
   alias Forge.Document
 
   def compile(%Document{} = document, quoted_ast, compiler_name) do
+    if mix_project_file?(document.path) do
+      {:ok, []}
+    else
+      compile_quoted_document(document, quoted_ast, compiler_name)
+    end
+  end
+
+  defp compile_quoted_document(%Document{} = document, quoted_ast, compiler_name) do
     prepare_compile(document.path)
 
     quoted_ast =
@@ -25,6 +33,10 @@ defmodule Engine.Build.Document.Compilers.Quoted do
       end
 
     {status, Enum.map(diagnostics, &replace_source(&1, compiler_name))}
+  end
+
+  defp mix_project_file?(path) when is_binary(path) do
+    Path.basename(path) == "mix.exs"
   end
 
   defp do_compile(quoted_ast, document) do
@@ -94,17 +106,8 @@ defmodule Engine.Build.Document.Compilers.Quoted do
     end
   end
 
-  defp prepare_compile(path) do
+  defp prepare_compile(_path) do
     if Engine.Mix.loaded?() do
-      # If we're compiling a mix.exs file, the after compile callback from
-      # `use Mix.Project` will blow up if we add the same project to the project stack
-      # twice. Preemptively popping it prevents that error from occurring.
-      if Path.basename(path) == "mix.exs" do
-        Engine.with_lock(Engine.Mix.StackMutation, fn ->
-          Mix.ProjectStack.pop()
-        end)
-      end
-
       Mix.Task.run(:loadconfig)
     else
       :ok

--- a/apps/engine/lib/engine/code_mod/format.ex
+++ b/apps/engine/lib/engine/code_mod/format.ex
@@ -245,16 +245,16 @@ defmodule Engine.CodeMod.Format do
     root_path = Project.root_path(project)
     deps_paths = Engine.deps_paths()
 
-    formatter_and_opts =
-      Engine.with_lock(Engine.Mix.StackMutation, fn ->
-        Mix.Tasks.Future.Format.formatter_for_file(file_path,
-          root: root_path,
-          deps_paths: deps_paths,
-          plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
-        )
-      end)
-
-    {:ok, formatter_and_opts}
+    case Engine.Mix.in_project(project, fn _ ->
+           Mix.Tasks.Future.Format.formatter_for_file(file_path,
+             root: root_path,
+             deps_paths: deps_paths,
+             plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
+           )
+         end) do
+      {:ok, formatter_and_opts} -> {:ok, formatter_and_opts}
+      {:error, _reason} -> :error
+    end
   rescue
     _ ->
       :error

--- a/apps/engine/test/engine/build/document/compilers/quoted_test.exs
+++ b/apps/engine/test/engine/build/document/compilers/quoted_test.exs
@@ -4,6 +4,13 @@ defmodule Engine.Build.Document.Compilers.QuotedTest do
   import Forge.Test.CodeSigil
 
   alias Engine.Build.Document.Compilers.Quoted
+  alias Forge.Document
+
+  defmodule ProjectStackSentinel do
+    def project do
+      [app: :project_stack_sentinel, version: "0.1.0"]
+    end
+  end
 
   defp parse!(code) do
     Code.string_to_quoted!(code, columns: true, token_metadata: true)
@@ -46,6 +53,31 @@ defmodule Engine.Build.Document.Compilers.QuotedTest do
                end
              end\
              """
+    end
+  end
+
+  describe "compile/3" do
+    test "skips mix.exs without popping the current Mix project" do
+      Mix.ProjectStack.on_clean_slate(fn ->
+        Mix.Project.push(ProjectStackSentinel, "/tmp/project/mix.exs", :project_stack_sentinel)
+
+        quoted =
+          """
+          defmodule Other.MixProject do
+            use Mix.Project
+
+            def project do
+              [app: :other, version: "0.1.0"]
+            end
+          end
+          """
+          |> parse!()
+
+        document = Document.new("file:///tmp/project/mix.exs", Macro.to_string(quoted), 0)
+
+        assert {:ok, []} = Quoted.compile(document, quoted, "Elixir")
+        assert Mix.Project.get() == ProjectStackSentinel
+      end)
     end
   end
 

--- a/apps/engine/test/engine/build_test.exs
+++ b/apps/engine/test/engine/build_test.exs
@@ -1,0 +1,19 @@
+defmodule Engine.BuildTest do
+  use ExUnit.Case
+
+  alias Engine.Build
+  alias Forge.Document
+
+  describe "force_compile_document/1" do
+    test "skips mix.exs files" do
+      document =
+        Document.new(
+          "file:///workspace/project/mix.exs",
+          "defmodule Example.MixProject do\nend\n",
+          0
+        )
+
+      assert :ok = Build.force_compile_document(document)
+    end
+  end
+end

--- a/apps/engine/test/engine/code_mod/format_test.exs
+++ b/apps/engine/test/engine/code_mod/format_test.exs
@@ -133,4 +133,89 @@ defmodule Engine.CodeMod.FormatTest do
                |> String.trim()
     end
   end
+
+  describe "formatter_for_file/2" do
+    @tag :tmp_dir
+    test "resolves imported dependency formatter options with an empty Mix project stack", %{
+      project: original_project,
+      tmp_dir: tmp_dir
+    } do
+      project = mix_project_with_imported_formatter_dep!(tmp_dir)
+      file_path = Path.join([tmp_dir, "lib", "format.ex"])
+
+      on_exit(fn ->
+        Engine.set_project(original_project)
+        :persistent_term.erase({Engine, :deps_paths})
+      end)
+
+      Engine.set_project(project)
+      :persistent_term.erase({Engine, :deps_paths})
+
+      Mix.ProjectStack.on_clean_slate(fn ->
+        {_formatter, opts} = Format.formatter_for_file(project, file_path)
+
+        assert {:dep_local, 1} in Keyword.fetch!(opts, :locals_without_parens)
+      end)
+    end
+  end
+
+  defp mix_project_with_imported_formatter_dep!(tmp_dir) do
+    File.mkdir_p!(Path.join([tmp_dir, "lib"]))
+    File.mkdir_p!(Path.join([tmp_dir, "deps", "formatter_dep", "lib"]))
+
+    File.write!(Path.join([tmp_dir, "lib", "format.ex"]), "dep_local :ok\n")
+
+    File.write!(
+      Path.join(tmp_dir, "mix.exs"),
+      """
+      defmodule FormatterHost.MixProject do
+        use Mix.Project
+
+        def project do
+          [
+            app: :formatter_host,
+            version: "0.1.0",
+            deps: [{:formatter_dep, path: "deps/formatter_dep"}]
+          ]
+        end
+      end
+      """
+    )
+
+    File.write!(
+      Path.join(tmp_dir, ".formatter.exs"),
+      """
+      [
+        import_deps: [:formatter_dep],
+        inputs: ["lib/**/*.{ex,exs}"]
+      ]
+      """
+    )
+
+    File.write!(
+      Path.join([tmp_dir, "deps", "formatter_dep", "mix.exs"]),
+      """
+      defmodule FormatterDep.MixProject do
+        use Mix.Project
+
+        def project do
+          [app: :formatter_dep, version: "0.1.0"]
+        end
+      end
+      """
+    )
+
+    File.write!(
+      Path.join([tmp_dir, "deps", "formatter_dep", ".formatter.exs"]),
+      """
+      [
+        export: [locals_without_parens: [dep_local: 1]]
+      ]
+      """
+    )
+
+    tmp_dir
+    |> Document.Path.to_uri()
+    |> Project.new()
+  end
 end


### PR DESCRIPTION
There's an issue some issues are facing since elixir 1.19 where there's lots of build errors and stale diagnostics.
It seems to have been caused by the `Mix.ProjectStack` becoming `nil`.
I think I might have found a potential culprit in the formatting code: `Mix.Tasks.Future.Format.formatter_for_file` is called outside the context of a mix project, thus the `Mix.ProjectStack` is empty and causes crashes and weird compiler behavior. This is triggered by code actions that produce formatted code, formatting requests and format-on-save.

Another place where we used to pop the project stack was in `Engine.Build.Document.Compilers.Quoted`, if I understand the build process correctly, a module that does `use Mix.Project` will register an `@after_compile Mix.Project` callback, which calls `Mix.Project.push`. If the same project is already in the stack, mix misbehaves so we try to compensate for that by preemptively popping the current project. I suspect there is an unexpected side effect to this, and skipping compilation for mix.exs files seems to work the same while avoiding this issue.

There is also a related issue where we would check the `Path.absname` instead of the `Path.basename` for `mix.exs` files which could lead to us popping the only project from the ProjectStack, but I'm not sure it's the real culprit given it requires changing and saving a mix.exs file.

I can not reproduce the reported issue so this is a shot in the dark really. I did verify that it's not breaking builds for me at least.