### PR TITLE
fix: only index sibling beams when origin source file changes

### DIFF
--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -102,13 +102,101 @@ defmodule Engine.Search.Indexer do
       |> Manifest.plan(paths)
       |> include_missing_backend_outputs(manifest, paths, backend)
 
-    {entries, manifest_entries} =
-      index_paths(plan.source_paths_to_index, plan.beam_paths_to_index)
+    {entries, manifest_entries, plan} = index_plan(plan, manifest, paths)
 
     paths_to_clear = Manifest.output_paths_to_clear(manifest, plan, manifest_entries)
     manifest = Manifest.apply_update(manifest, plan, manifest_entries)
 
     {entries, paths_to_clear, manifest}
+  end
+
+  defp index_plan(%Manifest.Plan{} = plan, %Manifest{} = manifest, %Paths{} = paths) do
+    {source_entries, source_manifest_entries} = Sources.index(plan.source_paths_to_index)
+
+    {beam_entries, beam_manifest_entries, beam_paths_to_index} =
+      index_beam_plan(plan, manifest, paths)
+
+    plan = %Manifest.Plan{plan | beam_paths_to_index: beam_paths_to_index}
+
+    {source_entries ++ beam_entries, source_manifest_entries ++ beam_manifest_entries, plan}
+  end
+
+  # Search entries use the source file path as their `path`. They do not carry the
+  # BEAM file path because entries model searchable source symbols. The BEAM input
+  # path is incremental-indexing state, tracked by the manifest.
+  #
+  # A single source file can produce multiple BEAM files. For example:
+  #
+  #   defmodule Parent do
+  #     defmodule Child do
+  #     end
+  #   end
+  #
+  # produces both `Elixir.Parent.beam` and `Elixir.Parent.Child.beam`. Entries from
+  # both BEAM files are stored under the same source path.
+  #
+  # Updating the index for a source path is a full replacement: delete all existing
+  # entries for that source path, then insert the entries from this indexing pass.
+  # If we index only a newly discovered child BEAM, the replacement set contains
+  # only child entries, so existing parent entries for the same source path would be
+  # deleted.
+  #
+  # Supporting narrower replacement would require storing BEAM-origin paths in
+  # the search store which would potentially increase the index size by a lot
+  # in large codebases. As a compromise, this keeps the existing source-path
+  # replacement model and only reindexes known BEAMs that share a source path
+  # with the new BEAM.
+  defp index_beam_plan(%Manifest.Plan{beam_paths_to_index: []}, _manifest, _paths) do
+    {[], [], []}
+  end
+
+  defp index_beam_plan(%Manifest.Plan{} = plan, %Manifest{} = manifest, %Paths{} = paths) do
+    {entries, manifest_entries} = Beams.index(plan.beam_paths_to_index)
+    sibling_paths = beam_sibling_paths(plan, manifest, paths, manifest_entries)
+
+    case sibling_paths do
+      [] ->
+        {entries, manifest_entries, plan.beam_paths_to_index}
+
+      [_ | _] ->
+        {sibling_entries, sibling_manifest_entries} = Beams.index(sibling_paths)
+
+        {entries ++ sibling_entries, manifest_entries ++ sibling_manifest_entries,
+         Enum.uniq(plan.beam_paths_to_index ++ sibling_paths)}
+    end
+  end
+
+  defp beam_sibling_paths(
+         %Manifest.Plan{} = plan,
+         %Manifest{} = manifest,
+         %Paths{} = paths,
+         manifest_entries
+       ) do
+    new_beam_paths =
+      plan.beam_paths_to_index
+      |> Enum.filter(&(Manifest.fetch(manifest, &1) == :error))
+      |> MapSet.new()
+
+    output_paths =
+      for %Manifest.Entry{kind: :beam, input_path: input_path, output_path: output_path} <-
+            manifest_entries,
+          is_binary(output_path),
+          MapSet.member?(new_beam_paths, input_path),
+          into: MapSet.new() do
+        output_path
+      end
+
+    current_beam_paths = MapSet.new(paths.beam_paths)
+    planned_beam_paths = MapSet.new(plan.beam_paths_to_index)
+
+    for %Manifest.Entry{kind: :beam, input_path: input_path, output_path: output_path} <-
+          Manifest.entries(manifest),
+        is_binary(output_path),
+        MapSet.member?(output_paths, output_path),
+        MapSet.member?(current_beam_paths, input_path),
+        not MapSet.member?(planned_beam_paths, input_path) do
+      input_path
+    end
   end
 
   defp include_missing_backend_outputs(

--- a/apps/engine/lib/engine/search/indexer/manifest.ex
+++ b/apps/engine/lib/engine/search/indexer/manifest.ex
@@ -237,7 +237,8 @@ defmodule Engine.Search.Indexer.Manifest do
     beam_paths_to_index =
       beam_paths_to_index
       |> include_known_beams_for_dirty_outputs(manifest, beam_paths, dirty_outputs)
-      |> include_new_beams(new_beam_paths, beam_paths)
+      |> Enum.concat(new_beam_paths)
+      |> Enum.uniq()
 
     %Plan{
       source_paths_to_index: Enum.uniq(source_paths_to_index ++ new_source_paths),
@@ -350,12 +351,6 @@ defmodule Engine.Search.Indexer.Manifest do
       end)
 
     Enum.uniq(beam_paths_to_index ++ dirty_beam_paths)
-  end
-
-  defp include_new_beams(beam_paths_to_index, [], _beam_paths), do: Enum.uniq(beam_paths_to_index)
-
-  defp include_new_beams(_beam_paths_to_index, _new_beam_paths, beam_paths) do
-    MapSet.to_list(beam_paths)
   end
 
   defp output_paths_for_inputs(%__MODULE__{} = manifest, input_paths) do

--- a/apps/engine/test/engine/search/indexer/manifest_test.exs
+++ b/apps/engine/test/engine/search/indexer/manifest_test.exs
@@ -1,0 +1,40 @@
+defmodule Engine.Search.Indexer.ManifestTest do
+  use ExUnit.Case, async: true
+
+  alias Engine.Search.Indexer.Manifest
+  alias Engine.Search.Indexer.Manifest.Entry
+  alias Engine.Search.Indexer.Paths
+
+  @moduletag :tmp_dir
+
+  describe "plan/2" do
+    test "does not fan out from one new beam to all known beams", %{tmp_dir: tmp_dir} do
+      beam_paths =
+        [known_beam_1, known_beam_2, known_beam_3, new_beam_path] = beam_paths(tmp_dir, 4)
+
+      Enum.each(beam_paths, &File.write!(&1, "beam"))
+
+      manifest_entries =
+        [known_beam_1, known_beam_2, known_beam_3]
+        |> Enum.map(fn beam_path ->
+          assert {:ok, entry} = Entry.skipped_beam(beam_path, nil)
+          entry
+        end)
+
+      manifest = Manifest.new(manifest_entries)
+      paths = %Paths{source_paths: [], beam_paths: beam_paths}
+
+      assert %Manifest.Plan{beam_paths_to_index: [^new_beam_path]} =
+               Manifest.plan(manifest, paths)
+    end
+  end
+
+  defp beam_paths(tmp_dir, count) do
+    root = Path.join(tmp_dir, "ebin")
+    File.mkdir_p!(root)
+
+    for index <- 1..count do
+      Path.join(root, "dep#{index}.beam")
+    end
+  end
+end

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -6,6 +6,7 @@ defmodule Engine.Search.IndexerTest do
 
   alias Engine.Dispatch
   alias Engine.Search.Indexer
+  alias Engine.Search.Indexer.Beams
   alias Engine.Search.Indexer.Manifest
   alias Engine.Search.Indexer.Manifest.Entry, as: ManifestEntry
   alias Engine.Search.Indexer.ManifestStore
@@ -288,6 +289,51 @@ defmodule Engine.Search.IndexerTest do
       assert {entries, []} = update_index(project)
       assert [] = Enum.to_list(entries)
       refute_receive :dependency_progress_begin
+    end
+  end
+
+  describe "update_index/2 with dependency beams" do
+    @tag :tmp_dir
+    test "reindexes known beam siblings when a new beam shares their source", %{tmp_dir: tmp_dir} do
+      parent = Module.concat(BeamDependencyIndexerTest, :SiblingParent)
+      child = Module.concat(parent, :Child)
+
+      %{beam_paths: beam_paths, project: project} =
+        with_beam_dependency(tmp_dir,
+          module: parent,
+          expected_modules: [parent, child],
+          rewrite_source?: false,
+          dep_source: fn module ->
+            """
+            defmodule #{inspect(module)} do
+              def parent_fun, do: :ok
+
+              defmodule Child do
+                def child_fun, do: :ok
+              end
+            end
+            """
+          end
+        )
+
+      parent_beam_path =
+        Enum.find(beam_paths, &String.ends_with?(&1, Atom.to_string(parent) <> ".beam"))
+
+      child_beam_path =
+        Enum.find(beam_paths, &String.ends_with?(&1, Atom.to_string(child) <> ".beam"))
+
+      assert is_binary(parent_beam_path)
+      assert is_binary(child_beam_path)
+
+      {parent_entries, parent_manifest_entries} = Beams.index([parent_beam_path])
+      FakeBackend.set_entries(parent_entries)
+      assert :ok = ManifestStore.commit(project, Manifest.new(parent_manifest_entries))
+
+      assert {updated_entries, []} = update_index(project)
+      updated_entries = Enum.to_list(updated_entries)
+
+      assert Enum.any?(updated_entries, &(&1.subject == parent and &1.subtype == :definition))
+      assert Enum.any?(updated_entries, &(&1.subject == child and &1.subtype == :definition))
     end
   end
 


### PR DESCRIPTION
I found an issue where we would incorretly delete index entries created from .beam files, and also over-index files that did not change.

If you have a module like this:

```elixir
# parent.ex
defmodule Parent do
end
```

which produces `Elixir.Parent.beam` and update it like this:

```elixir
# parent.ex
defmodule Parent do
  defmodule Child do
  end
end
```

it would now also produce `Elixir.Parent.Child.beam`.

This should produce two entries, one for `Parent` definition and one for `Parent.Child` definition. When the indexer saw the latter, it would consider `parent.ex` to be stale, delete all entries for it in the index, and perform a full reindex of the .beam files, which is wasteful.

The fix in this PR is to check if entries from a .beam file shares source file with other .beam files, and only reindex those.