### PR TITLE
fix: engine build crashes when changing tooling versions

### DIFF
--- a/apps/expert/lib/expert/engine_builds.ex
+++ b/apps/expert/lib/expert/engine_builds.ex
@@ -10,7 +10,7 @@ defmodule Expert.EngineBuilds do
     defstruct ready: %{}, pending: %{}
   end
 
-  @type build_result :: {[String.t()], String.t() | nil}
+  @type build_result :: {[String.t()], [{String.t(), String.t()}] | nil}
 
   def child_spec(_) do
     %{

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -54,9 +54,9 @@ defmodule Expert.EngineNode do
             project_node_eval_string(state.project)
           ]
 
-      mix_home_env =
-        case Keyword.fetch(opts, :mix_home) do
-          {:ok, mix_home} when is_binary(mix_home) -> [{"MIX_HOME", mix_home}]
+      tooling_env =
+        case Keyword.fetch(opts, :tooling_env) do
+          {:ok, env} when is_list(env) -> env
           _ -> []
         end
 
@@ -64,7 +64,7 @@ defmodule Expert.EngineNode do
         [
           {"EXPERT_PARENT_NODE", this_node},
           {"EXPERT_PARENT_PORT", to_string(dist_port)}
-        ] ++ mix_home_env
+        ] ++ tooling_env
 
       case Expert.Port.open_elixir(state.project, args: args, env: env) do
         {:error, _, message} ->
@@ -224,9 +224,9 @@ defmodule Expert.EngineNode do
     ]
 
     with {:ok, node_pid} <- EngineSupervisor.start_project_node(project),
-         {:ok, {glob_paths, mix_home}} <- prepare_engine(project),
+         {:ok, {glob_paths, tooling_env}} <- prepare_engine(project),
          :ok <- Progress.report(token, message: "Starting Erlang node..."),
-         :ok <- start_node(project, glob_paths, mix_home: mix_home),
+         :ok <- start_node(project, glob_paths, tooling_env: tooling_env),
          :ok <- Progress.report(token, message: "Bootstrapping engine..."),
          :ok <- bootstrap(node_name, bootstrap_args),
          :ok <- ensure_apps_started(node_name, token) do

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -78,14 +78,14 @@ defmodule Expert.EngineNode.Builder do
       end
 
     case parse_engine_meta(line) do
-      {:ok, mix_home, engine_path} ->
+      {:ok, tooling_env, engine_path} ->
         Logger.info("Engine available at: #{engine_path}", project: state.project)
 
         Logger.info("ebin paths:\n#{inspect(ebin_paths(engine_path), pretty: true)}",
           project: state.project
         )
 
-        notify(state, {:ok, {ebin_paths(engine_path), mix_home}})
+        notify(state, {:ok, {ebin_paths(engine_path), tooling_env}})
         {:stop, :normal, state}
 
       :error ->
@@ -257,14 +257,23 @@ defmodule Expert.EngineNode.Builder do
     meta = String.trim(meta)
 
     with {:ok, binary} <- Base.decode64(meta),
-         %{mix_home: mix_home, engine_path: engine_path} <- :erlang.binary_to_term(binary) do
-      {:ok, mix_home, engine_path}
+         %{tooling_env: tooling_env, engine_path: engine_path} <- :erlang.binary_to_term(binary),
+         true <- valid_tooling_env?(tooling_env) do
+      {:ok, tooling_env, engine_path}
     else
       _ -> :error
     end
   end
 
   defp parse_engine_meta(_), do: :error
+
+  defp valid_tooling_env?(tooling_env) do
+    is_list(tooling_env) and
+      Enum.all?(tooling_env, fn
+        {key, value} when is_binary(key) and is_binary(value) -> true
+        _ -> false
+      end)
+  end
 
   @deps_error_patterns [
     "Can't continue due to errors on dependencies",

--- a/apps/expert/lib/expert/port.ex
+++ b/apps/expert/lib/expert/port.ex
@@ -33,9 +33,12 @@ defmodule Expert.Port do
     "ROOTDIR",
     "BINDIR",
     "RELEASE_SYS_CONFIG",
-    "MIX_HOME",
     "MIX_ARCHIVES",
-    "MIX_ENV"
+    "MIX_INSTALL_DIR",
+    "MIX_HOME",
+    "MIX_ENV",
+    "MIX_REBAR3",
+    "REBAR_CACHE_DIR"
   ]
 
   @doc """
@@ -357,6 +360,7 @@ defmodule Expert.Port do
     path = prepend_configured_erlang_path(path)
 
     System.get_env()
+    |> Enum.reject(fn {key, _value} -> key in @scrubbed_env_vars end)
     |> Enum.map(&sanitize_system_env_var(&1, path))
   end
 
@@ -390,7 +394,7 @@ defmodule Expert.Port do
 
   @doc false
   def scrub_env(env) do
-    already_set = MapSet.new(env, &elem(&1, 0))
+    already_set = MapSet.new(env, fn {key, _value} -> to_string(key) end)
 
     scrub_entries =
       for var <- @scrubbed_env_vars, var not in already_set do

--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -18,11 +18,14 @@ expert_data_path = Path.join(cache_dir, expert_vsn)
 
 elixir_erts_vsn = "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
 tooling_path = Path.join([expert_data_path, "tooling", elixir_erts_vsn])
+mix_home = Path.join(tooling_path, "mix_home")
+mix_archives = Path.join(tooling_path, "mix_archives")
+rebar_cache = Path.join(tooling_path, "rebar_cache")
 
 System.put_env("MIX_INSTALL_DIR", expert_data_path)
-System.put_env("MIX_HOME", Path.join(tooling_path, "mix_home"))
-System.put_env("HEX_HOME", Path.join(tooling_path, "hex_home"))
-System.put_env("REBAR_CACHE_DIR", Path.join(tooling_path, "rebar_cache"))
+System.put_env("MIX_HOME", mix_home)
+System.put_env("MIX_ARCHIVES", mix_archives)
+System.put_env("REBAR_CACHE_DIR", rebar_cache)
 
 {:ok, _} = Application.ensure_all_started(:elixir)
 {:ok, _} = Application.ensure_all_started(:mix)
@@ -55,10 +58,15 @@ ns_build_path = Path.join([install_path, "_build", "dev_ns"])
 
 Mix.Task.run("namespace", [dev_build_path, ns_build_path, "--cwd", install_path, "--no-progress"])
 
-mix_home = Path.join(tooling_path, "mix_home")
+tooling_env = [
+  {"MIX_INSTALL_DIR", expert_data_path},
+  {"MIX_HOME", mix_home},
+  {"MIX_ARCHIVES", mix_archives},
+  {"REBAR_CACHE_DIR", rebar_cache}
+]
 
 engine_meta =
   "engine_meta:" <>
-    Base.encode64(:erlang.term_to_binary(%{mix_home: mix_home, engine_path: ns_build_path}))
+    Base.encode64(:erlang.term_to_binary(%{tooling_env: tooling_env, engine_path: ns_build_path}))
 
 IO.puts(engine_meta)

--- a/apps/expert/test/expert/engine_node/builder_test.exs
+++ b/apps/expert/test/expert/engine_node/builder_test.exs
@@ -135,10 +135,10 @@ defmodule Expert.EngineNode.BuilderTest do
     {:ok, builder_pid} = start_builder(project)
 
     engine_path = Path.join(System.tmp_dir!(), "dev_ns")
-    mix_home = Path.join(System.tmp_dir!(), "mix_home")
+    tooling_env = tooling_env()
 
     meta =
-      %{mix_home: mix_home, engine_path: engine_path}
+      %{tooling_env: tooling_env, engine_path: engine_path}
       |> :erlang.term_to_binary()
       |> Base.encode64()
 
@@ -146,7 +146,7 @@ defmodule Expert.EngineNode.BuilderTest do
     send(builder_pid, {nil, {:data, {:eol, "engine_meta:#{meta}"}}})
 
     assert_receive {:engine_build_complete, :builder_test, ^builder_pid,
-                    {:ok, {paths, ^mix_home}}},
+                    {:ok, {paths, ^tooling_env}}},
                    5_000
 
     assert paths == Forge.Path.glob([engine_path, "lib/**/ebin"])
@@ -258,10 +258,10 @@ defmodule Expert.EngineNode.BuilderTest do
     {:ok, builder_pid} = start_builder(project)
 
     engine_path = Path.join(System.tmp_dir!(), "dev_ns")
-    mix_home = Path.join(System.tmp_dir!(), "mix_home")
+    tooling_env = tooling_env()
 
     meta =
-      %{mix_home: mix_home, engine_path: engine_path}
+      %{tooling_env: tooling_env, engine_path: engine_path}
       |> :erlang.term_to_binary()
       |> Base.encode64()
 
@@ -271,7 +271,7 @@ defmodule Expert.EngineNode.BuilderTest do
     send(builder_pid, {nil, {:data, {:eol, second}}})
 
     assert_receive {:engine_build_complete, :builder_test, ^builder_pid,
-                    {:ok, {paths, ^mix_home}}},
+                    {:ok, {paths, ^tooling_env}}},
                    5_000
 
     assert paths == Forge.Path.glob([engine_path, "lib/**/ebin"])
@@ -286,5 +286,16 @@ defmodule Expert.EngineNode.BuilderTest do
     |> Enum.filter(fn entry ->
       Enum.any?(@allowed_apps, &String.contains?(entry, to_string(&1)))
     end)
+  end
+
+  defp tooling_env do
+    root = System.tmp_dir!()
+
+    [
+      {"MIX_INSTALL_DIR", Path.join(root, "mix_install")},
+      {"MIX_HOME", Path.join(root, "mix_home")},
+      {"MIX_ARCHIVES", Path.join(root, "mix_archives")},
+      {"REBAR_CACHE_DIR", Path.join(root, "rebar_cache")}
+    ]
   end
 end

--- a/apps/expert/test/expert/engine_node_test.exs
+++ b/apps/expert/test/expert/engine_node_test.exs
@@ -67,6 +67,38 @@ defmodule Expert.EngineNodeTest do
     assert {:error, :no_elixir} = EngineNode.start(project)
   end
 
+  test "passes isolated engine tooling env when starting project node", %{project: project} do
+    test_pid = self()
+
+    tooling_env = [
+      {"MIX_INSTALL_DIR", "/isolated/mix_install"},
+      {"MIX_HOME", "/isolated/mix_home"},
+      {"MIX_ARCHIVES", "/isolated/mix_archives"},
+      {"REBAR_CACHE_DIR", "/isolated/rebar_cache"}
+    ]
+
+    patch(Forge.EPMD, :dist_port, fn -> 13_737 end)
+
+    patch(Expert.Port, :open_elixir, fn _project, opts ->
+      send(test_pid, {:open_elixir_opts, opts})
+      make_ref()
+    end)
+
+    state = EngineNode.State.new(project)
+
+    assert {:ok, _state} =
+             EngineNode.State.start(state, [], {self(), make_ref()}, tooling_env: tooling_env)
+
+    assert_receive {:open_elixir_opts, opts}, 1_000
+
+    env = Keyword.fetch!(opts, :env)
+
+    assert {"MIX_INSTALL_DIR", "/isolated/mix_install"} in env
+    assert {"MIX_HOME", "/isolated/mix_home"} in env
+    assert {"MIX_ARCHIVES", "/isolated/mix_archives"} in env
+    assert {"REBAR_CACHE_DIR", "/isolated/rebar_cache"} in env
+  end
+
   test "shuts down with error message if exited with error code", %{project: project} do
     {:ok, _node_name, node_pid} = EngineNode.start(project)
 


### PR DESCRIPTION
Working on bumping elixir + erlang versions I kept hitting errors like this one:

```
LSP[expert] [engine] Engine build failed for engine::49905813.
Build script exited with status: 1

15:52:13.161 [error] beam/beam_load.c(604): Error loading function 'Elixir.Hex.State':print_invalid_config_error/2:
please re-compile this module with an Erlang/OTP 29 compiler or update your Erlang/OTP version
15:52:13.165 [error] beam/beam_load.c(604): Error loading function 'Elixir.Hex.State':print_invalid_config_error/2:
please re-compile this module with an Erlang/OTP 29 compiler or update your Erlang/OTP version
15:52:13.167 [notice] Application hex exited: exited in: Hex.Application.start(:normal, [])
** (EXIT) an exception was raised:
** (ArgumentError) The module Hex.State was given as a child to a supervisor but it does not exist
(elixir 1.20.0) lib/supervisor.ex:827: Supervisor.init_child/1
(elixir 1.20.0) lib/enum.ex:1725: Enum."-map/2-lists^map/1-1-"/2
(elixir 1.20.0) lib/enum.ex:1725: Enum."-map/2-lists^map/1-1-"/2
(elixir 1.20.0) lib/supervisor.ex:813: Supervisor.init/2
(elixir 1.20.0) lib/supervisor.ex:737: Supervisor.start_link/2
(kernel 11.0.1) application_master.erl:299: :application_master.start_it_old/4
15:52:13.168 [notice] Application inets exited: :stopped
15:52:13.169 [notice] Application ssl exited: :stopped
15:52:13.169 [notice] Application public_key exited: :stopped
15:52:13.169 [notice] Application asn1 exited: :stopped
15:52:13.169 [notice] Application crypto exited: :stopped
==> engine
Could not start Hex. Try fetching a new version with "mix local.hex" or uninstalling it with "mix archive.uninstall hex.ez"
** (MatchError) no match of right hand side value:
{:error,
{:hex,
{:bad_return,
{{Hex.Application, :start, [:normal, []]},
{:EXIT,
{%ArgumentError{
message: "The module Hex.State was given as a child to a supervisor but it does not exist"
},
[
{Supervisor, :init_child, 1, [file: ~c"lib/supervisor.ex", line: 827]},
{Enum, :"-map/2-lists^map/1-1-", 2, [file: ~c"lib/enum.ex", line: 1725]},
{Enum, :"-map/2-lists^map/1-1-", 2, [file: ~c"lib/enum.ex", line: 1725]},
{Supervisor, :init, 2, [file: ~c"lib/supervisor.ex", line: 813]},
{Supervisor, :start_link, 2, [file: ~c"lib/supervisor.ex", line: 737]},
{:application_master, :start_it_old, 4,
[file: ~c"application_master.erl", line: 299]}
]}}}}}}
(hex 2.3.1) lib/hex.ex:5: Hex.start/0
(mix 1.20.0) lib/mix/hex.ex:64: Mix.Hex.start/0
(mix 1.20.0) lib/mix/dep/loader.ex:196: Mix.Dep.Loader.with_scm_and_app/5
(mix 1.20.0) lib/mix/dep/loader.ex:147: Mix.Dep.Loader.to_dep/4
(elixir 1.20.0) lib/enum.ex:1725: Enum."-map/2-lists^map/1-1-"/2
(mix 1.20.0) lib/mix/dep/loader.ex:377: Mix.Dep.Loader.mix_children/3
(mix 1.20.0) lib/mix/dep/loader.ex:330: anonymous fn/5 in Mix.Dep.Loader.mix_dep/3
(mix 1.20.0) lib/mix/project.ex:557: Mix.Project.in_project/4 
```

I'm not entirely sure if this happened because we started setting some vars to empty strings instead of removing them, or if it was the missing env vars I added to the scrub list, but the changes here stopped the engine build errors for me when changing elixir/erlang versions on my projects