### PR TITLE
fix(engine): improve compatibility check messaging

### DIFF
--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -60,12 +60,24 @@ defmodule Engine.Build.State do
     project = state.project
     build_path = Project.versioned_build_path(project)
 
-    if !Versions.compatible?(build_path) do
-      Logger.info("Build path #{build_path} was compiled on a previous erlang version. Deleting")
+    case Versions.check_erlang_compatibility(build_path) do
+      :compatible ->
+        :ok
 
-      if File.exists?(build_path) do
+      {:incompatible, tagged, current} ->
+        Logger.info(
+          "Build path #{build_path} was compiled with Erlang #{tagged.erlang}, " <>
+            "but current Erlang is #{current.erlang}. Deleting"
+        )
+
         File.rm_rf(build_path)
-      end
+
+      :untagged ->
+        :ok
+
+      {:unreadable, _error} ->
+        Logger.info("Build path #{build_path} has unreadable version tags. Deleting")
+        File.rm_rf(build_path)
     end
 
     maybe_delete_old_builds(project)

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -66,8 +66,8 @@ defmodule Engine.Build.State do
 
       {:incompatible, tagged, current} ->
         Logger.info(
-          "Build path #{build_path} was compiled with Erlang #{tagged.erlang}, " <>
-            "but current Erlang is #{current.erlang}. Deleting"
+          "Build path #{build_path} was compiled with Erlang #{tagged}, " <>
+            "but current Erlang is #{current}. Deleting"
         )
 
         File.rm_rf(build_path)

--- a/apps/forge/lib/forge/vm/versions.ex
+++ b/apps/forge/lib/forge/vm/versions.ex
@@ -72,7 +72,7 @@ defmodule Forge.VM.Versions do
 
   @typep compatibility_result ::
            :compatible
-           | {:incompatible, tagged :: t(), current :: t()}
+           | {:incompatible, tagged :: version_string(), current :: version_string()}
            | :untagged
            | {:unreadable, {:error, term()}}
 
@@ -82,7 +82,7 @@ defmodule Forge.VM.Versions do
 
   Returns:
   - `:compatible` — versions match
-  - `{:incompatible, tagged, current}` — Erlang major versions don't match
+  - `{:incompatible, tagged_erlang, current_erlang}` — Erlang major versions don't match
   - `:untagged` — no version tags found (missing directory or fresh build path)
   - `{:unreadable, error}` — version tags exist but cannot be read
   """
@@ -98,7 +98,7 @@ defmodule Forge.VM.Versions do
         if tagged_erlang.major <= system_erlang.major do
           :compatible
         else
-          {:incompatible, tagged, system}
+          {:incompatible, tagged.erlang, system.erlang}
         end
 
       {:error, :enoent} ->

--- a/apps/forge/lib/forge/vm/versions.ex
+++ b/apps/forge/lib/forge/vm/versions.ex
@@ -70,25 +70,24 @@ defmodule Forge.VM.Versions do
     %{elixir: to_version(elixir), erlang: to_version(erlang)}
   end
 
+  @typep compatibility_result ::
+           :compatible
+           | {:incompatible, tagged :: t(), current :: t()}
+           | :untagged
+           | {:unreadable, {:error, term()}}
+
   @doc """
-  Tells whether or not the current version of VM is supported by
-  Expert's compiled artifacts.
+  Checks whether the build artifacts in `directory` are compatible with
+  the currently running VM.
+
+  Returns:
+  - `:compatible` — versions match
+  - `{:incompatible, tagged, current}` — Erlang major versions don't match
+  - `:untagged` — no version tags found (missing directory or fresh build path)
+  - `{:unreadable, error}` — version tags exist but cannot be read
   """
-  @spec compatible?() :: boolean
-  @spec compatible?(Path.t()) :: boolean
-  def compatible? do
-    case code_find_file(version_file(:erlang)) do
-      {:ok, path} ->
-        path
-        |> Path.dirname()
-        |> compatible?()
-
-      _ ->
-        false
-    end
-  end
-
-  def compatible?(directory) do
+  @spec check_erlang_compatibility(Path.t()) :: compatibility_result()
+  def check_erlang_compatibility(directory) do
     system = current()
 
     case read(directory) do
@@ -96,10 +95,17 @@ defmodule Forge.VM.Versions do
         system_erlang = to_version(system.erlang)
         tagged_erlang = to_version(tagged.erlang)
 
-        tagged_erlang.major <= system_erlang.major
+        if tagged_erlang.major <= system_erlang.major do
+          :compatible
+        else
+          {:incompatible, tagged, system}
+        end
 
-      _ ->
-        false
+      {:error, :enoent} ->
+        :untagged
+
+      {:error, _} = error ->
+        {:unreadable, error}
     end
   end
 

--- a/apps/forge/test/forge/vm/versions_test.exs
+++ b/apps/forge/test/forge/vm/versions_test.exs
@@ -110,9 +110,7 @@ defmodule Forge.VM.VersionTest do
       patch_system_versions("1.15.8", "25.0")
       patch_tagged_versions("1.15.8", "26.0")
 
-      assert {:incompatible, tagged, current} = check_erlang_compatibility("/foo/bar/baz")
-      assert tagged.erlang == "26.0"
-      assert current.erlang == "25.0"
+      assert {:incompatible, "26.0", "25.0"} = check_erlang_compatibility("/foo/bar/baz")
     end
 
     test "the same versions are compatible with each other" do

--- a/apps/forge/test/forge/vm/versions_test.exs
+++ b/apps/forge/test/forge/vm/versions_test.exs
@@ -94,37 +94,39 @@ defmodule Forge.VM.VersionTest do
     end
   end
 
-  test "an untagged directory is not compatible" do
-    refute compatible?(System.tmp_dir!())
+  test "an untagged directory returns :untagged" do
+    assert :untagged = check_erlang_compatibility(System.tmp_dir!())
   end
 
-  describe "compatible?/1" do
+  describe "check_erlang_compatibility/1" do
     test "lower major versions of erlang are compatible with later major versions" do
       patch_system_versions("1.15.8", "26.0")
       patch_tagged_versions("1.15.8", "25.0")
 
-      assert compatible?("/foo/bar/baz")
+      assert :compatible = check_erlang_compatibility("/foo/bar/baz")
     end
 
     test "higher major versions are not compatible with lower major versions" do
       patch_system_versions("1.15.8", "25.0")
       patch_tagged_versions("1.15.8", "26.0")
 
-      refute compatible?("/foo/bar/baz")
+      assert {:incompatible, tagged, current} = check_erlang_compatibility("/foo/bar/baz")
+      assert tagged.erlang == "26.0"
+      assert current.erlang == "25.0"
     end
 
     test "the same versions are compatible with each other" do
       patch_system_versions("1.15.8", "25.3.3")
       patch_tagged_versions("1.15.8", "25.0")
 
-      assert compatible?("/foo/bar/baz")
+      assert :compatible = check_erlang_compatibility("/foo/bar/baz")
     end
 
     test "higher minor versions are compatible" do
       patch_system_versions("1.15.8", "25.3.0")
       patch_tagged_versions("1.15.8", "25.0")
 
-      assert compatible?("/foo/bar/baz")
+      assert :compatible = check_erlang_compatibility("/foo/bar/baz")
     end
 
     test "release candidate erlang versions do not crash compatibility checks" do
@@ -134,14 +136,14 @@ defmodule Forge.VM.VersionTest do
       patch_system_versions("1.20.0-rc.4", "29.0-rc3.0")
       patch_tagged_versions("1.18.4", "28.0.2")
 
-      assert compatible?("/foo/bar/baz")
+      assert :compatible = check_erlang_compatibility("/foo/bar/baz")
     end
 
     test "release candidate erlang versions are compared by major version" do
       patch_system_versions("1.20.0-rc.4", "29.0-rc3.0")
       patch_tagged_versions("1.20.0-rc.4", "30.0.0")
 
-      refute compatible?("/foo/bar/baz")
+      assert {:incompatible, _, _} = check_erlang_compatibility("/foo/bar/baz")
     end
   end
 end


### PR DESCRIPTION
While investigating #701 I realized that the "Build path ... was compiled on a previous erlang version" is not precise for a few reasons:

* It's not always previous version
* this is logged when the build directory is absent

This PR improves a few things.

* rename `compatible?` to `check_erlang_compatibility` which returns `:ok | :untagged | {:incompatible, _, _}, {:unreadable, _}`
* Improve log messages
* don't log anything if the build dir is missing - nothing special about this case IMO