### PR TITLE
fix(expert): fix Node.start for Elixir pre-1.19

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -155,6 +155,48 @@
       "otp": "29.0.1",
       "elixir": "1.20.0",
       "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "28",
+      "elixir": "1.19",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "28",
+      "elixir": "1.18.4",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "27",
+      "elixir": "1.18",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "26",
+      "elixir": "1.18",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "27",
+      "elixir": "1.17",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "26",
+      "elixir": "1.17",
+      "project": "expert"
+    },
+    {
+      "os": "ubuntu-latest",
+      "otp": "26",
+      "elixir": "1.16",
+      "project": "expert"
     }
   ]
 }

--- a/apps/expert/lib/expert/clustering.ex
+++ b/apps/expert/lib/expert/clustering.ex
@@ -1,9 +1,10 @@
 defmodule Expert.Clustering do
   alias Forge.Workspace
 
+  @spec start_net_kernel() :: {:ok, pid()} | {:error, term()}
   def start_net_kernel do
     with {:ok, manager} <- manager_node_name() do
-      case Node.start(manager, name_domain: :longnames) do
+      case start_node(manager) do
         {:ok, pid} ->
           {:ok, pid}
 
@@ -13,6 +14,16 @@ defmodule Expert.Clustering do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  if Version.match?(System.version(), ">= 1.19.0") do
+    defp start_node(manager) do
+      Node.start(manager, name_domain: :longnames)
+    end
+  else
+    defp start_node(manager) do
+      Node.start(manager, :longnames)
     end
   end
 

--- a/apps/expert/test/expert/clustering_test.exs
+++ b/apps/expert/test/expert/clustering_test.exs
@@ -47,4 +47,25 @@ defmodule Expert.ClusteringTest do
       assert {:error, :not_initialized} = Clustering.manager_node_name()
     end
   end
+
+  describe "start_net_kernel/0" do
+    setup do
+      on_exit(fn ->
+        Workspace.set_workspace(nil)
+      end)
+
+      :ok
+    end
+
+    test "starts net kernel compatibly when distribution is already active" do
+      assert Node.alive?()
+      assert is_pid(Process.whereis(:net_kernel))
+
+      workspace = Workspace.new(["/path/to/expert-lsp.org"])
+      Workspace.set_workspace(workspace)
+
+      assert {:ok, pid} = Clustering.start_net_kernel()
+      assert is_pid(pid)
+    end
+  end
 end

--- a/apps/expert/test/expert/logging/window_log_handler_test.exs
+++ b/apps/expert/test/expert/logging/window_log_handler_test.exs
@@ -4,7 +4,7 @@ defmodule Expert.Logging.WindowLogHandlerTest do
   alias Expert.Logging.WindowLogHandler
 
   defmodule OtherHandler do
-    @behaviour :logger_handler
+    use Expert.Logging.LoggerHandler
 
     @impl true
     def log(_event, config), do: {:ok, config}

--- a/matrix.exs
+++ b/matrix.exs
@@ -8,13 +8,16 @@ versions = [
   %{elixir: "1.18", otp: "26", os: "ubuntu-latest"},
   %{elixir: "1.17", otp: "27", os: "ubuntu-latest"},
   %{elixir: "1.17", otp: "26", os: "ubuntu-latest"},
-  %{elixir: "1.16", otp: "26", os: "ubuntu-latest"},
+  %{elixir: "1.16", otp: "26", os: "ubuntu-latest"}
 ]
 
 expert_matrix =
   [
     %{elixir: "1.20.0", otp: "29.0.1", project: "expert", os: "ubuntu-latest"},
     %{elixir: "1.20.0", otp: "29.0.1", project: "expert", os: "windows-2022"}
+    | for version <- tl(versions) do
+        Map.put(version, :project, "expert")
+      end
   ]
 
 %{


### PR DESCRIPTION
Fixes #719 and adds missing coverage (not the greatest test, but reproduces on Elixir 1.18). Also realized we have missing test matrix entries for Expert.