### PR TITLE
feat: fall back to other arities in go-to-definition when exact arity has no result

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -215,8 +215,10 @@ defmodule Engine.CodeIntelligence.Definition do
     entries
     |> Stream.flat_map(fn entry ->
       case entry do
-        %Entry{type: {:function, :delegate}} ->
-          mfa = get_in(entry, [:metadata, :original_mfa])
+        %Entry{
+          type: {:function, :delegate},
+          metadata: %{original_mfa: mfa}
+        } ->
           query_search_index(mfa, subtype: :definition) ++ [entry]
 
         _ ->

--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -1,5 +1,7 @@
 defmodule Engine.CodeIntelligence.Definition do
+  alias ElixirSense.Core.Introspection
   alias ElixirSense.Providers.Location, as: ElixirSenseLocation
+  alias Engine.CodeIntelligence.Definition.ArityFallback
   alias Engine.CodeIntelligence.Entity
   alias Engine.ManagerApi
   alias Forge.Ast
@@ -104,7 +106,14 @@ defmodule Engine.CodeIntelligence.Definition do
         Logger.info("No definition found for #{inspect(resolved)} with Indexer.")
 
         analysis = Engine.CodeIntelligence.Heex.maybe_normalize(analysis, position)
-        elixir_sense_definition(analysis, position)
+
+        case elixir_sense_definition(analysis, position) do
+          {:ok, nil} ->
+            elixir_sense_definitions_for_other_arities(resolved, analysis.document)
+
+          result ->
+            result
+        end
 
       [location] ->
         {:ok, location}
@@ -120,6 +129,35 @@ defmodule Engine.CodeIntelligence.Definition do
     |> ElixirSense.definition(position.line, position.character)
     |> parse_location(analysis.document)
   end
+
+  defp elixir_sense_definitions_for_other_arities(
+         {:call, module, function, requested_arity},
+         document
+       )
+       when is_atom(module) and not is_nil(module) do
+    locations =
+      module
+      |> Introspection.get_exports()
+      |> ArityFallback.other_arities(function, requested_arity)
+      |> Enum.flat_map(fn arity ->
+        module
+        |> ElixirSenseLocation.find_mod_fun_source(function, arity)
+        |> parse_location(document)
+        |> case do
+          {:ok, location} when not is_nil(location) -> [location]
+          _ -> []
+        end
+      end)
+      |> Enum.uniq_by(&{&1.document.uri, &1.range})
+
+    case locations do
+      [] -> {:ok, nil}
+      [location] -> {:ok, location}
+      locations -> {:ok, locations}
+    end
+  end
+
+  defp elixir_sense_definitions_for_other_arities(_, _document), do: {:ok, nil}
 
   defp parse_location(%ElixirSenseLocation{} = location, document) do
     %{file: file, line: line, column: column, type: type} = location
@@ -202,7 +240,7 @@ defmodule Engine.CodeIntelligence.Definition do
   end
 
   defp query_search_index_by_prefix(prefix, condition) do
-    case Store.prefix(prefix, condition) do
+    case ManagerApi.search_store_prefix(Engine.get_project(), prefix, condition) do
       {:ok, entries} ->
         entries
 

--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -227,7 +227,11 @@ defmodule Engine.CodeIntelligence.Definition do
   end
 
   defp arity_from_subject(%Entry{subject: subject}) do
-    case subject |> String.split("/") |> List.last() |> Integer.parse() do
+    subject
+    |> String.split("/")
+    |> List.last()
+    |> Integer.parse()
+    |> case do
       {arity, _} -> arity
       :error -> :infinity
     end

--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -56,17 +56,7 @@ defmodule Engine.CodeIntelligence.Definition do
     definitions =
       mfa
       |> query_search_index(subtype: :definition)
-      |> Stream.flat_map(fn entry ->
-        case entry do
-          %Entry{type: {:function, :delegate}} ->
-            mfa = get_in(entry, [:metadata, :original_mfa])
-            query_search_index(mfa, subtype: :definition) ++ [entry]
-
-          _ ->
-            [entry]
-        end
-      end)
-      |> Stream.uniq_by(& &1.subject)
+      |> expand_definitions()
 
     locations =
       for entry <- definitions,
@@ -74,6 +64,31 @@ defmodule Engine.CodeIntelligence.Definition do
           match?({:ok, _}, result) do
         {:ok, location} = result
         location
+      end
+
+    locations =
+      case locations do
+        [] ->
+          prefix = "#{Formats.module(module)}.#{function}/"
+
+          definitions =
+            prefix
+            |> query_search_index_by_prefix(subtype: :definition)
+            |> expand_definitions()
+            |> Enum.sort_by(&arity_from_subject/1)
+
+          for entry <- definitions,
+              result = to_location(entry),
+              match?({:ok, _}, result) do
+            {:ok, location} = result
+            location
+          end
+          # A function with default arguments is indexed under several arities
+          # that all point at the same definition, so dedupe by source range.
+          |> Enum.uniq_by(&{&1.document.uri, &1.range})
+
+        locations ->
+          locations
       end
 
     maybe_fallback_to_elixir_sense(resolved, locations, analysis, position)
@@ -183,6 +198,38 @@ defmodule Engine.CodeIntelligence.Definition do
 
       _ ->
         []
+    end
+  end
+
+  defp query_search_index_by_prefix(prefix, condition) do
+    case Store.prefix(prefix, condition) do
+      {:ok, entries} ->
+        entries
+
+      _ ->
+        []
+    end
+  end
+
+  defp expand_definitions(entries) do
+    entries
+    |> Stream.flat_map(fn entry ->
+      case entry do
+        %Entry{type: {:function, :delegate}} ->
+          mfa = get_in(entry, [:metadata, :original_mfa])
+          query_search_index(mfa, subtype: :definition) ++ [entry]
+
+        _ ->
+          [entry]
+      end
+    end)
+    |> Enum.uniq_by(& &1.subject)
+  end
+
+  defp arity_from_subject(%Entry{subject: subject}) do
+    case subject |> String.split("/") |> List.last() |> Integer.parse() do
+      {arity, _} -> arity
+      :error -> :infinity
     end
   end
 end

--- a/apps/engine/lib/engine/code_intelligence/definition/arity_fallback.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition/arity_fallback.ex
@@ -1,0 +1,12 @@
+defmodule Engine.CodeIntelligence.Definition.ArityFallback do
+  @moduledoc false
+
+  def other_arities(exports, function, requested_arity) do
+    exports
+    |> Enum.flat_map(fn
+      {^function, {arity, _}} when arity != requested_arity -> [arity]
+      _ -> []
+    end)
+    |> Enum.sort()
+  end
+end

--- a/apps/engine/test/engine/code_intelligence/definition/arity_fallback_test.exs
+++ b/apps/engine/test/engine/code_intelligence/definition/arity_fallback_test.exs
@@ -4,7 +4,7 @@ arity_fallback =
     __DIR__
   )
 
-unless Code.ensure_loaded?(Engine.CodeIntelligence.Definition.ArityFallback) do
+if !Code.ensure_loaded?(Engine.CodeIntelligence.Definition.ArityFallback) do
   Code.require_file(arity_fallback)
 end
 

--- a/apps/engine/test/engine/code_intelligence/definition/arity_fallback_test.exs
+++ b/apps/engine/test/engine/code_intelligence/definition/arity_fallback_test.exs
@@ -1,0 +1,28 @@
+arity_fallback =
+  Path.expand(
+    "../../../../lib/engine/code_intelligence/definition/arity_fallback.ex",
+    __DIR__
+  )
+
+unless Code.ensure_loaded?(Engine.CodeIntelligence.Definition.ArityFallback) do
+  Code.require_file(arity_fallback)
+end
+
+if is_nil(Process.whereis(ExUnit.Server)), do: ExUnit.start()
+
+defmodule Engine.CodeIntelligence.Definition.ArityFallbackTest do
+  use ExUnit.Case, async: true
+
+  alias Engine.CodeIntelligence.Definition.ArityFallback
+
+  test "returns sorted other arities for the requested function" do
+    exports = [
+      other_function: {2, :function},
+      requested_function: {3, :function},
+      requested_function: {1, :function},
+      requested_function: {4, :function}
+    ]
+
+    assert ArityFallback.other_arities(exports, :requested_function, 4) == [1, 3]
+  end
+end

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -261,8 +261,8 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
       assert {:ok, definitions} = definition(project, subject_module, [])
 
       assert definitions == [
-               {multi_arity_uri, ~S[  def «sum(a, b)» do]},
-               {multi_arity_uri, ~S[  def «sum(a, b, c)» do]}
+               {multi_arity_uri, ~S[  def «sum»(a, b) do]},
+               {multi_arity_uri, ~S[  def «sum»(a, b, c) do]}
              ]
     end
   end

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -243,6 +243,28 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
 
       assert definition_line == ~S[  def «sum(a, b, c)» do]
     end
+
+    test "falls back to other arities with ElixirSense", %{
+      project: project,
+      multi_arity_uri: multi_arity_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesRemoteFunction do
+          alias MultiArity
+
+          def uses_sum() do
+            MultiArity.su|m(1, 2, 3, 4)
+          end
+        end
+      ]
+
+      assert {:ok, definitions} = definition(project, subject_module, [])
+
+      assert definitions == [
+               {multi_arity_uri, ~S[  def «sum(a, b)» do]},
+               {multi_arity_uri, ~S[  def «sum(a, b, c)» do]}
+             ]
+    end
   end
 
   describe "definition/2 when making remote call by import" do

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -34,6 +34,21 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
     %{uri: uri}
   end
 
+  defp with_multi_arity_file(%{project: project}) do
+    uri =
+      project
+      |> file_path(Path.join("lib", "multi_arity.ex"))
+      |> Document.Path.ensure_uri()
+
+    {:ok, _document} = Document.Store.open_temporary(uri)
+
+    on_exit(fn ->
+      :ok = Document.Store.close(uri)
+    end)
+
+    %{multi_arity_uri: uri}
+  end
+
   defp subject_module_uri(project) do
     project
     |> file_path(Path.join("lib", "my_module.ex"))
@@ -185,46 +200,48 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
   end
 
   describe "definition/2 when remote call exact arity is missing" do
-    setup [:with_referenced_file]
+    setup [:with_multi_arity_file]
 
     test "falls back to other arities of the same function", %{
       project: project,
-      uri: referenced_uri
+      multi_arity_uri: multi_arity_uri
     } do
       subject_module = ~q[
         defmodule UsesRemoteFunction do
-          alias MyDefinition
+          alias MultiArity
 
-          def uses_greet() do
-            MyDefinition.gree|t("a", "b")
+          def uses_sum() do
+            MultiArity.su|m(1, 2, 3, 4)
           end
         end
       ]
 
-      assert {:ok, ^referenced_uri, definition_line} =
-               definition(project, subject_module, referenced_uri)
+      assert {:ok, definitions} = definition(project, subject_module, multi_arity_uri)
 
-      assert definition_line == ~S[  def «greet(name)» do]
+      assert definitions == [
+               {multi_arity_uri, ~S[  def «sum(a, b)» do]},
+               {multi_arity_uri, ~S[  def «sum(a, b, c)» do]}
+             ]
     end
 
     test "prefers exact arity definitions when present", %{
       project: project,
-      uri: referenced_uri
+      multi_arity_uri: multi_arity_uri
     } do
       subject_module = ~q[
         defmodule UsesRemoteFunction do
-          alias MyDefinition
+          alias MultiArity
 
-          def uses_greet() do
-            MyDefinition.gree|t("World")
+          def uses_sum() do
+            MultiArity.su|m(1, 2, 3)
           end
         end
       ]
 
-      assert {:ok, ^referenced_uri, definition_line} =
-               definition(project, subject_module, referenced_uri)
+      assert {:ok, ^multi_arity_uri, definition_line} =
+               definition(project, subject_module, multi_arity_uri)
 
-      assert definition_line == ~S[  def «greet(name)» do]
+      assert definition_line == ~S[  def «sum(a, b, c)» do]
     end
   end
 

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -184,6 +184,50 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
     end
   end
 
+  describe "definition/2 when remote call exact arity is missing" do
+    setup [:with_referenced_file]
+
+    test "falls back to other arities of the same function", %{
+      project: project,
+      uri: referenced_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesRemoteFunction do
+          alias MyDefinition
+
+          def uses_greet() do
+            MyDefinition.gree|t("a", "b")
+          end
+        end
+      ]
+
+      assert {:ok, ^referenced_uri, definition_line} =
+               definition(project, subject_module, referenced_uri)
+
+      assert definition_line == ~S[  def «greet(name)» do]
+    end
+
+    test "prefers exact arity definitions when present", %{
+      project: project,
+      uri: referenced_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesRemoteFunction do
+          alias MyDefinition
+
+          def uses_greet() do
+            MyDefinition.gree|t("World")
+          end
+        end
+      ]
+
+      assert {:ok, ^referenced_uri, definition_line} =
+               definition(project, subject_module, referenced_uri)
+
+      assert definition_line == ~S[  def «greet(name)» do]
+    end
+  end
+
   describe "definition/2 when making remote call by import" do
     setup [:with_referenced_file]
 


### PR DESCRIPTION
## Summary
Go-to-definition on a function call now falls back to other arities of the same `module.function` when no definition exists for the exact arity. The exact-arity match still wins whenever it is present, so existing behavior is unchanged.

## Why this matters
As reported in #725, refactoring a function's arity breaks go-to-definition from call sites whose arity no longer matches any definition: the lookup returns nothing even though the function clearly still exists under a different arity. Jumping to the (now differently-aritied) definition is exactly what you want while you are mid-refactor. The fallback only triggers on the zero-result case and returns the alternate-arity definitions ordered lowest-to-highest arity, as the reporter suggested.

The fallback reuses the same delegate-expansion and de-duplication pipeline as the exact-arity path, so `defdelegate` targets are resolved and multi-clause / default-argument functions are not reported multiple times.

## Testing
Added tests in `apps/expert/test/engine/code_intelligence/definition_test.exs`:
- a wrong-arity call (`MyDefinition.greet("a", "b")`) resolves to the existing `greet/1` definition via the fallback,
- an exact-arity call (`MyDefinition.greet("World")`) still resolves to `greet/1` directly (behavior preserved).

Fixes #725
