### PR TITLE
fix(engine): set target when evaluating config diagnostics

### DIFF
--- a/apps/engine/lib/engine/build/document/compilers/config.ex
+++ b/apps/engine/lib/engine/build/document/compilers/config.ex
@@ -50,7 +50,7 @@ defmodule Engine.Build.Document.Compilers.Config do
     contents = Document.to_string(document)
 
     try do
-      Config.Reader.eval!(document.path, contents, env: :test)
+      Config.Reader.eval!(document.path, contents, env: :test, target: Mix.target())
       {:ok, []}
     rescue
       e ->

--- a/apps/engine/test/engine/build/document/compilers/config_test.exs
+++ b/apps/engine/test/engine/build/document/compilers/config_test.exs
@@ -156,5 +156,15 @@ defmodule Engine.Build.Document.Compilers.ConfigTest do
                |> document()
                |> compile()
     end
+
+    test "it produces no diagnostics when using config_target/0" do
+      assert {:ok, []} =
+               ~q[
+                 import Config
+                 config :my_app, target: config_target()
+               ]
+               |> document()
+               |> compile()
+    end
   end
 end


### PR DESCRIPTION
Diagnostics for config files are evaluated with `Config.Reader.eval!/3` but only `:env` is passed, so any config that calls `config_target/0` raises "no :target key was given to this configuration file" even though `mix compile` reports `:host` and compiles fine (#727).

Passing `target: Mix.target()` mirrors how mix resolves the target (defaulting to `:host`) and matches the existing `Mix.target()` usage in the indexer. Added a regression test covering a config file that uses `config_target/0`.