### PR TITLE
fix(expert): extend list of editors having VSCode completion bug

### DIFF
--- a/apps/expert/lib/expert/code_intelligence/completion.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion.ex
@@ -123,7 +123,7 @@ defmodule Expert.CodeIntelligence.Completion do
     # If VS Code receives an empty completion list, it will never issue
     # a new request, even if `is_incomplete: true` is specified.
     # https://github.com/lexical-lsp/lexical/issues/400
-    Configuration.get().client_name == "Visual Studio Code"
+    Configuration.vscode_family?()
   end
 
   defp has_meaningful_completions?(%Env{} = env) do

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -125,6 +125,27 @@ defmodule Expert.Configuration do
     get().file_log_level
   end
 
+  @vscode_family_patterns [
+    "visual studio code",
+    "cursor",
+    "windsurf",
+    "vscodium",
+    "positron",
+    "code-server"
+  ]
+
+  @spec vscode_family?() :: boolean()
+  def vscode_family? do
+    case get().client_name do
+      nil ->
+        false
+
+      client_name ->
+        downcased = client_name |> String.trim() |> String.downcase()
+        Enum.any?(@vscode_family_patterns, &String.contains?(downcased, &1))
+    end
+  end
+
   @spec window_log_message_enabled?() :: boolean()
   def window_log_message_enabled? do
     case get().client_name do


### PR DESCRIPTION
There is a bug in VSCode https://github.com/microsoft/vscode/issues/155738 that when an empty list is received by completion request, it never asks again for current word (they [claim](https://github.com/Microsoft/vscode/issues/13735) it's intentional). We had a workaround for that inherited from Lexical, but it only works for VSCode itself, not for any of its forks.

This is still a hack, just includes more editors. I believe the proper fix would be in our extension: either send in initialization options something like `"imBuggyVscode": true`, or even somehow intercept the empty completion responses and do something to trigger completion after next char (I haven't really explored the latter).