### PR TITLE
feat: make on-the-fly engine builds work offline

### DIFF
--- a/apps/engine/mix.exs
+++ b/apps/engine/mix.exs
@@ -59,6 +59,9 @@ defmodule Engine.MixProject do
       {:phoenix_live_view, "~> 1.0", only: [:test], runtime: false},
       {:sourceror, "~> 1.12.2"},
       {:stream_data, "~> 1.1", only: [:test], runtime: false},
+      # Offline engine builds cannot depend on a local Rebar archive, so we
+      # force it to Mix
+      {:telemetry, "~> 1.3", manager: :mix, optional: false, override: true},
       {:refactorex, "~> 0.1.52"}
     ]
   end

--- a/apps/expert/lib/expert/engine.ex
+++ b/apps/expert/lib/expert/engine.ex
@@ -2,9 +2,9 @@ defmodule Expert.Engine do
   @moduledoc """
   Utilities for managing Expert engine builds.
 
-  When Expert builds the engine for a project using Mix.install, it caches
-  the build in the user data directory. If engine dependencies change (e.g.,
-  in nightly builds), Mix.install may not know to rebuild, causing errors.
+  When Expert builds the engine for a project, it caches the build in the user
+  data directory. If engine dependencies change (e.g., in nightly builds), a
+  cached build may become stale and cause errors.
 
   This module provides functions to inspect and clean these cached builds.
   """
@@ -204,8 +204,8 @@ defmodule Expert.Engine do
     IO.puts("""
     Expert Engine Management
 
-    Manage cached engine builds created by Mix.install. Use these commands
-    to resolve dependency errors or free up disk space.
+    Manage cached engine builds. Use these commands to resolve dependency
+    errors or free up disk space.
 
     USAGE:
         expert engine <subcommand>

--- a/apps/expert/mix.exs
+++ b/apps/expert/mix.exs
@@ -117,7 +117,8 @@ defmodule Expert.MixProject do
       {:path_glob, "~> 0.2"},
       {:phoenix_live_view, "~> 1.0", only: [:test], runtime: false},
       {:schematic, "~> 0.2"},
-      {:sourceror, "~> 1.12.2"}
+      {:sourceror, "~> 1.12.2"},
+      {:telemetry, "~> 1.3", manager: :mix, optional: false, override: true}
     ]
   end
 end

--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -10,7 +10,7 @@
   )
 
 expert_vsn = Keyword.fetch!(args, :vsn)
-engine_source_path = Keyword.fetch!(args, :source_path)
+engine_source_path = args |> Keyword.fetch!(:source_path) |> Path.expand()
 force? = Keyword.get(args, :force, false)
 cache_dir = Keyword.fetch!(args, :cache_dir)
 
@@ -22,41 +22,110 @@ mix_home = Path.join(tooling_path, "mix_home")
 mix_archives = Path.join(tooling_path, "mix_archives")
 rebar_cache = Path.join(tooling_path, "rebar_cache")
 
-System.put_env("MIX_INSTALL_DIR", expert_data_path)
-System.put_env("MIX_HOME", mix_home)
-System.put_env("MIX_ARCHIVES", mix_archives)
+for var <- ["MIX_ARCHIVES", "MIX_HOME", "MIX_REBAR3"] do
+  if System.get_env(var) == "" do
+    System.delete_env(var)
+  end
+end
+
+# Mix's partitioned deps.compile starts fresh OS processes that do not inherit
+# the in_project build/deps/lockfile paths used by this script.
+System.put_env("MIX_OS_DEPS_COMPILE_PARTITION_COUNT", "1")
+
 System.put_env("REBAR_CACHE_DIR", rebar_cache)
 
 {:ok, _} = Application.ensure_all_started(:elixir)
 {:ok, _} = Application.ensure_all_started(:mix)
 
-Mix.Task.run("local.hex", ["--if-missing", "--force"])
-Mix.Task.run("local.rebar", ["--if-missing", "--force"])
+packaged_deps_path = Path.join(engine_source_path, "deps")
+lockfile_path = Path.join(engine_source_path, "mix.lock")
 
-Mix.install([{:engine, path: engine_source_path, env: :dev}],
-  start_applications: false,
-  config_path: Path.join(engine_source_path, "config/config.exs"),
-  lockfile: Path.join(engine_source_path, "mix.lock"),
-  force: force?
-)
+# We use a custom Mix.SCM module to bypass the Hex SCM and allow this script to
+# work fully offline. Otherwise Mix will try to use the Hex.SCM which may not be
+# available(due to the hex archive not being available) or it may try to connect
+# to the internet.
+defmodule Expert.BuildEngine.SCM do
+  @behaviour Mix.SCM
 
-install_path =
-  with false <- Version.match?(System.version(), ">= 1.16.2"),
-       false <- is_nil(Process.whereis(Mix.State)),
-       cache_id <- Mix.State.get(:installed) do
-    install_root =
-      System.get_env("MIX_INSTALL_DIR") || Path.join(Mix.Utils.mix_cache(), "installs")
+  @path_scm_opts [:path, :in_umbrella]
 
-    version = "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
-    Path.join([install_root, version, cache_id])
-  else
-    _ -> Mix.install_project_dir()
+  @impl Mix.SCM
+  def fetchable?, do: false
+
+  @impl Mix.SCM
+  def format(opts), do: opts[:dest]
+
+  @impl Mix.SCM
+  def format_lock(_opts), do: nil
+
+  @impl Mix.SCM
+  def accepts_options(_app, opts) do
+    if !Enum.any?(@path_scm_opts, &Keyword.has_key?(opts, &1)) do
+      opts
+    end
   end
 
-dev_build_path = Path.join([install_path, "_build", "dev"])
-ns_build_path = Path.join([install_path, "_build", "dev_ns"])
+  @impl Mix.SCM
+  def checked_out?(opts), do: File.dir?(opts[:dest])
 
-Mix.Task.run("namespace", [dev_build_path, ns_build_path, "--cwd", install_path, "--no-progress"])
+  @impl Mix.SCM
+  def checkout(opts), do: Mix.raise("Missing packaged dependency at #{opts[:dest]}")
+
+  @impl Mix.SCM
+  def update(opts), do: opts[:lock]
+
+  @impl Mix.SCM
+  def lock_status(_opts), do: :ok
+
+  @impl Mix.SCM
+  def equal?(opts1, opts2), do: opts1[:dest] == opts2[:dest]
+
+  @impl Mix.SCM
+  def managers(_opts), do: []
+end
+
+Mix.SCM.prepend(Expert.BuildEngine.SCM)
+
+workspace_path = Path.join([expert_data_path, "engine_builds", elixir_erts_vsn])
+build_root_path = Path.join(workspace_path, "_build")
+
+if force? do
+  File.rm_rf!(build_root_path)
+end
+
+Mix.Project.in_project(
+  :engine,
+  engine_source_path,
+  [
+    build_path: build_root_path,
+    deps_path: packaged_deps_path,
+    lockfile: lockfile_path,
+    prune_code_paths: false
+  ],
+  fn _project_module ->
+    Mix.Task.clear()
+    Mix.Project.clear_deps_cache()
+
+    Mix.Task.run("deps.compile", ["--no-archives-check"])
+    Mix.Task.run("compile", ["--no-archives-check"])
+  end
+)
+
+mix_env = Mix.env()
+dev_build_path = Path.join(build_root_path, to_string(mix_env))
+ns_build_path = Path.join([workspace_path, "_build", "#{mix_env}_ns"])
+
+if force? do
+  File.rm_rf!(ns_build_path)
+end
+
+Mix.Task.run("namespace", [
+  dev_build_path,
+  ns_build_path,
+  "--cwd",
+  workspace_path,
+  "--no-progress"
+])
 
 tooling_env = [
   {"MIX_INSTALL_DIR", expert_data_path},

--- a/apps/expert/priv/build_engine.exs
+++ b/apps/expert/priv/build_engine.exs
@@ -17,7 +17,7 @@ cache_dir = Keyword.fetch!(args, :cache_dir)
 expert_data_path = Path.join(cache_dir, expert_vsn)
 
 elixir_erts_vsn = "elixir-#{System.version()}-erts-#{:erlang.system_info(:version)}"
-tooling_path = Path.join([expert_data_path, "tooling", elixir_erts_vsn])
+tooling_path = Path.join([expert_data_path, elixir_erts_vsn, "tooling"])
 mix_home = Path.join(tooling_path, "mix_home")
 mix_archives = Path.join(tooling_path, "mix_archives")
 rebar_cache = Path.join(tooling_path, "rebar_cache")
@@ -86,7 +86,7 @@ end
 
 Mix.SCM.prepend(Expert.BuildEngine.SCM)
 
-workspace_path = Path.join([expert_data_path, "engine_builds", elixir_erts_vsn])
+workspace_path = Path.join([expert_data_path, elixir_erts_vsn])
 build_root_path = Path.join(workspace_path, "_build")
 
 if force? do

--- a/apps/expert/test/expert/engine_test.exs
+++ b/apps/expert/test/expert/engine_test.exs
@@ -78,6 +78,26 @@ defmodule Expert.EngineTest do
       end
     end
 
+    test "deletes engine builds using the current cache layout", %{tmp_dir: tmp_dir} do
+      build_dir = Path.join(tmp_dir, "0.1.0/elixir-1.20.0-erts-16.0/_build/dev_ns")
+      tooling_dir = Path.join(tmp_dir, "0.1.0/elixir-1.20.0-erts-16.0/tooling")
+      File.mkdir_p!(Path.join([build_dir, "lib", "engine", "ebin"]))
+      File.mkdir_p!(tooling_dir)
+
+      output =
+        capture_io(fn ->
+          exit_code = Engine.run(["clean", "--force"])
+          assert exit_code == 0
+        end)
+
+      assert output =~ "Deleted"
+      assert output =~ "elixir-1.20.0-erts-16.0"
+      refute output =~ "engine_builds"
+      refute output =~ "tooling"
+      refute File.exists?(build_dir)
+      refute File.exists?(tooling_dir)
+    end
+
     test "stops deleting after first error and returns error code 1", %{tmp_dir: tmp_dir} do
       dir1 = Path.join(tmp_dir, "0.1.0/foobar")
       dir2 = Path.join(tmp_dir, "0.2.0/foobar")


### PR DESCRIPTION
Closes #713 

The first time I implemented on-the-fly engine builds I had assumed it worked offline but didn't extensively test it. Turns out we never had proper support for offline engine builds, this PR adds that.

The main change is a custom `Mix.SCM` module that prevents Mix from trying to use the local hex archives, which may be unavailable, or it may try and fail to reach the internet if the user is offline.
The custom SCM module was the cleanest solution I could come up with, other things I tried involved rewriting the lock file and all the mix.exs files to use path dependencies instead of hex/git dependencies(too convoluted), or doing various tricks with what gets copied into the packaged release, but it was all too unreliable and complicated.

The second main change is moving away from `Mix.install` to a regular mix compile task, which allows us to pass additional required context to it via `Mix.Project.in_project`.

There is also a change to force `manager: :mix` for the `:telemetry` dependency, which is a transitive dependency for us. Without doing that I was experiencing Mix trying to use `rebar` to compile it instead, which required the rebar archive to be present, which may not be the case and would require you to be connected to internet to install it. Forcing it to `:mix` workarounds this issue.

To test this I disconnected my laptop from the internet and tried to use expert on a project, see it works, then using mise to switch the elixir/erlang versions and restarting expert.