### PR TITLE
chore(expert): use colon in filter text for Hex completion

### DIFF
--- a/apps/expert/lib/expert/code_intelligence/completion/translations/hex_package.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion/translations/hex_package.ex
@@ -15,17 +15,20 @@ defmodule Expert.CodeIntelligence.Completion.Translations.HexPackage do
         description: repo_label(package.repo)
       }
 
-      # Insert with the leading `:` so `{:phoe` → `{:phoenix` regardless of
-      # whether the builder's prefix range covers the `:` (unquoted atom
-      # cursor_context) or only the bare word (local_or_var context). Either
-      # way the result is a well-formed atom literal. The `filter_text`
-      # keeps matching against the bare name so fuzzy matching on "phoe"
-      # still works.
+      # Insert with the leading `:` so `{:phoe` → `{:phoenix`. The cursor sits
+      # on an unquoted atom (a colon is always present when we reach this
+      # slot), so the builder's replacement range covers the `:` too.
+      #
+      # `filter_text` must span that same range, otherwise a client that
+      # filters the typed word against `filter_text` (e.g. VS Code) matches
+      # `:phoe` against `phoenix`, fails, and drops the item.
+      name_with_colon = ":" <> package.name
+
       env
-      |> builder.plain_text(":" <> package.name,
+      |> builder.plain_text(name_with_colon,
         label: package.name,
         label_details: label_details,
-        filter_text: package.name,
+        filter_text: name_with_colon,
         kind: CompletionItemKind.module(),
         detail: "hex",
         documentation: package.description


### PR DESCRIPTION
VSCode filters out the results returned by completion according to filter text. If it does not contain the colon in the beginning, all results get filtered out and instead of Hex packages, VSCode presents fuzzy-matched irrelevant atoms from the project.

This works differently in Emacs (and I assume in Vim, which was the primary target for the author of Hex intelligence feature), so it was missed during the review phase.

## Before
<img width="629" height="265" alt="Screenshot 2026-06-23 at 10 57 39" src="https://github.com/user-attachments/assets/669d9791-f4ff-4da6-913d-f8c6d83eb430" />

## After
<img width="627" height="283" alt="Screenshot 2026-06-23 at 11 27 59" src="https://github.com/user-attachments/assets/9d667ee5-a926-47f8-b9de-d14ead506cd1" />

Not sure if this should be a "fix" PR. It is a fix, but of an unreleased feature, so maybe it could be "chore" to have only one entry in the changelog? Anyway, this is why I'm not exactly a fan of autogenerated changelogs ;)