### PR TITLE
feat(expert): fold consecutive comment lines

### DIFF
--- a/apps/expert/lib/expert/provider/handlers/code_folding.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_folding.ex
@@ -4,6 +4,7 @@ defmodule Expert.Provider.Handlers.CodeFolding do
   alias Expert.Document.Context
   alias Forge.Ast
   alias Forge.Document
+  alias GenLSP.Enumerations.FoldingRangeKind
   alias GenLSP.Requests
   alias GenLSP.Structures
 
@@ -18,19 +19,19 @@ defmodule Expert.Provider.Handlers.CodeFolding do
 
   defp folding_ranges(%Document{} = document) do
     case Ast.from(document) do
-      {:ok, ast, _comments} ->
-        ranges_from(ast)
+      {:ok, ast, comments} ->
+        ranges_from(ast, comments)
 
-      {:error, ast, _parse_error, _comments} when is_tuple(ast) ->
-        ranges_from(ast)
+      {:error, ast, _parse_error, comments} when is_tuple(ast) ->
+        ranges_from(ast, comments)
 
       _ ->
         []
     end
   end
 
-  defp ranges_from(ast) do
-    block_ranges(ast) ++ string_ranges(ast)
+  defp ranges_from(ast, comments) do
+    block_ranges(ast) ++ string_ranges(ast) ++ comment_ranges(comments)
   end
 
   defp block_ranges(ast) do
@@ -121,5 +122,41 @@ defmodule Expert.Provider.Handlers.CodeFolding do
 
   defp count_newlines(str) do
     str |> :binary.matches("\n") |> length()
+  end
+
+  defp comment_ranges(comments) do
+    comments
+    |> Enum.filter(&standalone_comment?/1)
+    |> Enum.chunk_while(
+      [],
+      &chunk_consecutive/2,
+      fn acc -> {:cont, Enum.reverse(acc), []} end
+    )
+    |> Enum.filter(fn chunk -> match?([_, _ | _], chunk) end)
+    |> Enum.map(&to_comment_folding_range/1)
+  end
+
+  # A trailing comment (`code # comment`) has no end-of-line before it, so it
+  # is not the start of a foldable comment block.
+  defp standalone_comment?(%{previous_eol_count: count}), do: count > 0
+  defp standalone_comment?(_), do: false
+
+  defp chunk_consecutive(comment, [%{line: previous_line} | _] = acc)
+       when comment.line == previous_line + 1 do
+    {:cont, [comment | acc]}
+  end
+
+  defp chunk_consecutive(comment, acc) do
+    {:cont, Enum.reverse(acc), [comment]}
+  end
+
+  defp to_comment_folding_range([first | _] = comments) do
+    last = List.last(comments)
+
+    %Structures.FoldingRange{
+      start_line: first.line - 1,
+      end_line: last.line - 1,
+      kind: FoldingRangeKind.comment()
+    }
   end
 end

--- a/apps/expert/test/expert/provider/handlers/code_folding_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_folding_test.exs
@@ -30,6 +30,10 @@ defmodule Expert.Provider.Handlers.CodeFoldingTest do
     %FoldingRange{start_line: start_line, end_line: end_line}
   end
 
+  defp comment_range(start_line, end_line) do
+    %FoldingRange{start_line: start_line, end_line: end_line, kind: "comment"}
+  end
+
   describe "do/end blocks" do
     test "folds a multi-line module" do
       source = """
@@ -171,6 +175,93 @@ defmodule Expert.Provider.Handlers.CodeFoldingTest do
       """
 
       assert range(2, 3) in fold(source)
+    end
+  end
+
+  describe "comments" do
+    test "folds two or more consecutive comment lines" do
+      source = """
+      # one
+      # two
+      # three
+      :ok
+      """
+
+      assert comment_range(0, 2) in fold(source)
+    end
+
+    test "folds a pair of consecutive comment lines" do
+      source = """
+      # one
+      # two
+      :ok
+      """
+
+      assert comment_range(0, 1) in fold(source)
+    end
+
+    test "does not fold a single comment line" do
+      source = """
+      # lonely
+      :ok
+      """
+
+      refute Enum.any?(fold(source), fn r -> r.kind == "comment" end)
+    end
+
+    test "does not fold across a blank line between comments" do
+      source = """
+      # one
+      # two
+
+      # three
+      # four
+      :ok
+      """
+
+      ranges = fold(source)
+
+      assert comment_range(0, 1) in ranges
+      assert comment_range(3, 4) in ranges
+    end
+
+    test "does not group a comment broken by a line of code" do
+      source = """
+      # one
+      x = 1
+      # two
+      :ok
+      """
+
+      refute Enum.any?(fold(source), fn r -> r.kind == "comment" end)
+    end
+
+    test "does not start a comment fold from a trailing comment" do
+      source = """
+      x = 1 # trailing
+      # standalone one
+      # standalone two
+      :ok
+      """
+
+      ranges = fold(source)
+
+      assert comment_range(1, 2) in ranges
+      refute comment_range(0, 2) in ranges
+    end
+
+    test "folds comments indented inside a block" do
+      source = """
+      defmodule Foo do
+        def bar do
+          # step one
+          # step two
+          :ok
+        end
+      end
+      """
+
+      assert comment_range(2, 3) in fold(source)
     end
   end
 


### PR DESCRIPTION
part of #146 - this reports multiline comments (at least two consecutive lines) as a folding range, similar as ElixirLS does.