### PR TITLE
chore(expert): fold sigils

### DIFF
--- a/apps/expert/lib/expert/provider/handlers/code_folding.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_folding.ex
@@ -82,6 +82,14 @@ defmodule Expert.Provider.Handlers.CodeFolding do
         {:__block__, meta, [str]} = node, acc when is_binary(str) and is_list(meta) ->
           {node, collect_string(meta, str, acc)}
 
+        {sigil, meta, [{:<<>>, _, [str]}, _mods]} = node, acc
+        when is_atom(sigil) and is_binary(str) and is_list(meta) ->
+          if match?("sigil_" <> _, Atom.to_string(sigil)) do
+            {node, collect_string(meta, str, acc)}
+          else
+            {node, acc}
+          end
+
         node, acc ->
           {node, acc}
       end)

--- a/apps/expert/test/expert/provider/handlers/code_folding_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_folding_test.exs
@@ -148,6 +148,21 @@ defmodule Expert.Provider.Handlers.CodeFoldingTest do
       assert range(2, 4) in fold(source)
     end
 
+    test "folds a function with inline heredoc string" do
+      source = """
+      defmodule Foo do
+        def bar do
+          \"\"\"
+          a
+          b
+          \"\"\"
+        end
+      end
+      """
+
+      assert range(1, 5) in fold(source)
+    end
+
     test "does not fold a 2-line heredoc with empty content" do
       source = """
       defmodule Foo do
@@ -175,6 +190,38 @@ defmodule Expert.Provider.Handlers.CodeFoldingTest do
       """
 
       assert range(2, 3) in fold(source)
+    end
+  end
+
+  describe "sigils" do
+    test "folds a multiline sigil" do
+      source = """
+      defmodule Foo do
+        def bar do
+          ~H\"\"\"
+          a
+          b
+          \"\"\"
+        end
+      end
+      """
+
+      assert range(2, 4) in fold(source)
+    end
+
+    test "folds a function with a multiline sigil" do
+      source = """
+      defmodule Foo do
+        def bar do
+          ~H\"\"\"
+          a
+          b
+          \"\"\"
+        end
+      end
+      """
+
+      assert range(1, 5) in fold(source)
     end
   end
 


### PR DESCRIPTION
While investigating #744 I noticed that sigils such as `~H"""\n\n"""` are not marked as foldable regions. This fixes it. Also added some more tests for correctness.

Chore, because folding ranges are not released yet.