### PR TITLE
chore(expert): serve foldingRange request even if the engine is initializing

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -5,6 +5,7 @@ defmodule Expert do
   alias Expert.Project.Store
   alias Expert.Protocol.Convert
   alias Expert.Protocol.Id
+  alias Expert.Provider.Handler
   alias Expert.Provider.Handlers
   alias Expert.State
   alias Forge.Project
@@ -103,7 +104,7 @@ defmodule Expert do
 
   def handle_request(request, lsp) do
     with {:ok, handler} <- fetch_handler(request),
-         {:ok, context} <- check_engine_initialized(request),
+         {:ok, context} <- check_engine_initialized(request, handler),
          {:ok, request} <- Convert.to_native(request, context_document(context)),
          {:ok, response} <- handler.handle(request, context),
          {:ok, response} <- Expert.Protocol.Convert.to_lsp(response) do
@@ -149,12 +150,12 @@ defmodule Expert do
   defp context_document(%{document: %Forge.Document{} = document}), do: document
   defp context_document(_), do: nil
 
-  defp check_engine_initialized(request) do
+  defp check_engine_initialized(request, handler) do
     if document_request?(request) do
       projects = Store.projects()
 
       with {:ok, context} <- Lookup.resolve_from_request(request, projects) do
-        if Store.ready?(context.project) do
+        if !Handler.requires_engine?(handler) or Store.ready?(context.project) do
           {:ok, context}
         else
           {:error, :engine_not_initialized, context.project}

--- a/apps/expert/lib/expert/provider/handler.ex
+++ b/apps/expert/lib/expert/provider/handler.ex
@@ -13,4 +13,23 @@ defmodule Expert.Provider.Handler do
   """
   @callback handle(request :: struct(), context :: Context.t() | nil) ::
               {:ok, term()} | {:error, term()}
+
+  @doc """
+  Returns whether the handler requires the engine to be initialized before
+  it can handle a request. Defaults to `true`.
+
+  Handlers that operate purely on the document text (e.g. folding range) can
+  override this to `false` so they are not blocked during engine startup.
+  """
+  @callback requires_engine?() :: boolean()
+
+  @optional_callbacks requires_engine?: 0
+
+  @doc "Returns the value of `requires_engine?/0`, defaulting to `true`."
+  @spec requires_engine?(module()) :: boolean()
+  def requires_engine?(handler) do
+    handler.requires_engine?()
+  rescue
+    UndefinedFunctionError -> true
+  end
 end

--- a/apps/expert/lib/expert/provider/handlers/code_folding.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_folding.ex
@@ -9,6 +9,9 @@ defmodule Expert.Provider.Handlers.CodeFolding do
   alias GenLSP.Structures
 
   @impl Expert.Provider.Handler
+  def requires_engine?, do: false
+
+  @impl Expert.Provider.Handler
   def handle(
         %Requests.TextDocumentFoldingRange{params: %Structures.FoldingRangeParams{}},
         %Context{} = context

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -259,6 +259,32 @@ defmodule Expert.ExpertTest do
              Forge.Workspace.get_workspace()
   end
 
+  test "foldingRange request is served before the engine is initialized" do
+    project = Fixtures.project()
+    lsp = initialize_lsp(project)
+
+    # Project is known but not yet ready
+    Expert.Project.Store.add_projects([project])
+
+    uri = Fixtures.file_uri(project, "lib/foo.ex")
+    document = Document.new(uri, "defmodule Foo do\n  :ok\nend\n", 1)
+
+    patch(Expert.Document.Lookup, :resolve_from_request, fn _request, _projects ->
+      {:ok, Context.new(uri, document, project)}
+    end)
+
+    request = %GenLSP.Requests.TextDocumentFoldingRange{
+      id: 1,
+      jsonrpc: "2.0",
+      method: "textDocument/foldingRange",
+      params: %GenLSP.Structures.FoldingRangeParams{
+        text_document: %GenLSP.Structures.TextDocumentIdentifier{uri: uri}
+      }
+    }
+
+    assert {:reply, [_ | _], ^lsp} = Expert.handle_request(request, lsp)
+  end
+
   test "document requests return an error when the document cannot be loaded" do
     project = Fixtures.project()
     lsp = initialize_lsp(project)


### PR DESCRIPTION
The reason for bad folding in #744 is that Expert does not serve `foldingRanges` requests until the engine is ready. This causes VSCode to fall back into the extensions regex-based folding, which is buggy (and likely non-fixable). However, `foldingRanges` request only needs an AST analysis, not the whole engine, so we can server it, even if the server is still starting.

There is still very brief moment when VSCode uses extension folding, then sends request and waits for response - during which the folding is wrong - but it gets fixed in under a second usually. Not sure if anything can be done about it. Perhaps we could disable extension-side folding completely.