### PR TITLE
fix: compile the engine with MIX_ENV=dev

### DIFF
--- a/apps/engine/deps.nix
+++ b/apps/engine/deps.nix
@@ -206,7 +206,7 @@ let
 
       jason =
         let
-          version = "1.4.4";
+          version = "1.4.5";
           drv = buildMix {
             inherit version;
             name = "jason";
@@ -215,7 +215,24 @@ let
             src = fetchHex {
               inherit version;
               pkg = "jason";
-              sha256 = "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b";
+              sha256 = "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684";
+            };
+          };
+        in
+        drv;
+
+      logger_backends =
+        let
+          version = "1.0.0";
+          drv = buildMix {
+            inherit version;
+            name = "logger_backends";
+            appConfigPath = ./config;
+
+            src = fetchHex {
+              inherit version;
+              pkg = "logger_backends";
+              sha256 = "1faceb3e7ec3ef66a8f5746c5afd020e63996df6fd4eb8cdb789e5665ae6c9ce";
             };
           };
         in
@@ -320,7 +337,7 @@ let
 
       sourceror =
         let
-          version = "1.10.1";
+          version = "1.12.2";
           drv = buildMix {
             inherit version;
             name = "sourceror";
@@ -329,7 +346,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "sourceror";
-              sha256 = "288f3079d93865cd1e3e20df5b884ef2cb440e0e03e8ae393624ee8a770ba588";
+              sha256 = "da37d3da09c5b890528802c7056a8f585a061973820d7656b6e3649c14f0e9cb";
             };
           };
         in

--- a/apps/expert/lib/expert/engine_node/builder.ex
+++ b/apps/expert/lib/expert/engine_node/builder.ex
@@ -210,7 +210,7 @@ defmodule Expert.EngineNode.Builder do
 
     Process.flag(:trap_exit, true)
 
-    env = [{"MIX_ENV", "dev"} | env]
+    env = [{"MIX_ENV", "prod"} | env]
 
     Expert.Port.open_elixir_with_env(elixir, env,
       args: args,

--- a/apps/expert_credo/deps.nix
+++ b/apps/expert_credo/deps.nix
@@ -188,7 +188,7 @@ let
 
       jason =
         let
-          version = "1.4.4";
+          version = "1.4.5";
           drv = buildMix {
             inherit version;
             name = "jason";
@@ -197,7 +197,24 @@ let
             src = fetchHex {
               inherit version;
               pkg = "jason";
-              sha256 = "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b";
+              sha256 = "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684";
+            };
+          };
+        in
+        drv;
+
+      logger_backends =
+        let
+          version = "1.0.0";
+          drv = buildMix {
+            inherit version;
+            name = "logger_backends";
+            appConfigPath = ./config;
+
+            src = fetchHex {
+              inherit version;
+              pkg = "logger_backends";
+              sha256 = "1faceb3e7ec3ef66a8f5746c5afd020e63996df6fd4eb8cdb789e5665ae6c9ce";
             };
           };
         in
@@ -243,7 +260,7 @@ let
 
       sourceror =
         let
-          version = "1.10.1";
+          version = "1.12.2";
           drv = buildMix {
             inherit version;
             name = "sourceror";
@@ -252,7 +269,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "sourceror";
-              sha256 = "288f3079d93865cd1e3e20df5b884ef2cb440e0e03e8ae393624ee8a770ba588";
+              sha256 = "da37d3da09c5b890528802c7056a8f585a061973820d7656b6e3649c14f0e9cb";
             };
           };
         in

--- a/apps/expert_credo/mix.lock
+++ b/apps/expert_credo/mix.lock
@@ -20,7 +20,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "quokka": {:hex, :quokka, "2.12.1", "9fcdd6dbe6b8e950237e9c3b53c1da6d07da10496a1d89d08dc317a3160f9912", [:mix], [{:credo, "~> 1.7", [hex: :credo, repo: "hexpm", optional: false]}], "hexpm", "f5b38b8689625e90e377d124d2f6bf9f6e145e4895c33357a3f5fd8be8166aae"},
   "schematic": {:hex, :schematic, "0.2.1", "0b091df94146fd15a0a343d1bd179a6c5a58562527746dadd09477311698dbb1", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "0b255d65921e38006138201cd4263fd8bb807d9dfc511074615cd264a571b3b1"},
-  "sourceror": {:hex, :sourceror, "1.10.1", "325753ed460fe9fa34ebb4deda76d57b2e1507dcd78a5eb9e1c41bfb78b7cdfe", [:mix], [], "hexpm", "288f3079d93865cd1e3e20df5b884ef2cb440e0e03e8ae393624ee8a770ba588"},
+  "sourceror": {:hex, :sourceror, "1.12.2", "85bfd48159f020c0cbfc72f289f11456fdc05dc43719b6f2589fb969faefa113", [:mix], [], "hexpm", "da37d3da09c5b890528802c7056a8f585a061973820d7656b6e3649c14f0e9cb"},
   "spitfire": {:hex, :spitfire, "0.3.13", "edd207b065eaec57acc5484097d0aa3e97fe4246168c54e67a9af040b8dee4c1", [:mix], [], "hexpm", "3601be88ceed4967b584e96444de3e1d12d6555ae0864a7390b9cd5332d134b4"},
   "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},

--- a/apps/forge/deps.nix
+++ b/apps/forge/deps.nix
@@ -188,7 +188,7 @@ let
 
       jason =
         let
-          version = "1.4.4";
+          version = "1.4.5";
           drv = buildMix {
             inherit version;
             name = "jason";
@@ -197,7 +197,24 @@ let
             src = fetchHex {
               inherit version;
               pkg = "jason";
-              sha256 = "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b";
+              sha256 = "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684";
+            };
+          };
+        in
+        drv;
+
+      logger_backends =
+        let
+          version = "1.0.0";
+          drv = buildMix {
+            inherit version;
+            name = "logger_backends";
+            appConfigPath = ./config;
+
+            src = fetchHex {
+              inherit version;
+              pkg = "logger_backends";
+              sha256 = "1faceb3e7ec3ef66a8f5746c5afd020e63996df6fd4eb8cdb789e5665ae6c9ce";
             };
           };
         in
@@ -243,7 +260,7 @@ let
 
       sourceror =
         let
-          version = "1.10.1";
+          version = "1.12.2";
           drv = buildMix {
             inherit version;
             name = "sourceror";
@@ -252,7 +269,7 @@ let
             src = fetchHex {
               inherit version;
               pkg = "sourceror";
-              sha256 = "288f3079d93865cd1e3e20df5b884ef2cb440e0e03e8ae393624ee8a770ba588";
+              sha256 = "da37d3da09c5b890528802c7056a8f585a061973820d7656b6e3649c14f0e9cb";
             };
           };
         in

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -6,7 +6,29 @@
 let
   version = builtins.readFile ../version.txt;
 
-  engineDeps = callPackages ../apps/engine/deps.nix { inherit lib beamPackages; };
+  engineDeps = callPackages ../apps/engine/deps.nix {
+    inherit lib beamPackages;
+    # elixir_sense ships a yecc grammar (src/elixir_sense_parser.yrl). Mix normally
+    # compiles it into src/elixir_sense_parser.erl, but at runtime the engine builds
+    # against these sources straight from the read-only Nix store, so that in-tree
+    # write fails. Pre-generate the parser so Mix finds it and skips regenerating
+    # (Nix zeroes mtimes, so the .erl is never considered stale relative to the .yrl).
+    #
+    # This lives here, in deps.nix's `overrides` hook, rather than in deps.nix itself
+    # so it survives `nix run .#update-deps` regenerating that file.
+    overrides = _final: prev: {
+      elixir_sense = prev.elixir_sense.overrideAttrs (old: {
+        postInstall = (old.postInstall or "") + ''
+          grammar="$out/src/src/elixir_sense_parser.yrl"
+          if [ -f "$grammar" ]; then
+            chmod -R u+w "$out/src/src"
+            ${beamPackages.erlang}/bin/erlc -o "$out/src/src" "$grammar"
+            test -f "$out/src/src/elixir_sense_parser.erl"
+          fi
+        '';
+      });
+    };
+  };
 in
 beamPackages.mixRelease rec {
   pname = "expert";


### PR DESCRIPTION
Fixes #748

The main issue was having dev dependencies in the build. The fix was to default `MIX_ENV` to `prod` in `builder.ex`. This mimicks what is done in the `justfile` so I hope it is OK.

While that fixed the main issue, it also surfaced a couple of other issues related to nix and dependencies that also prevented the LSP from starting.

- `deps.nix` was out of sync with the `mix.lock` files. Fixed by running `nix run .#update-deps` manually.
- `elixir_sense` packaging. Because the nix store is read-only, I had to pregenerate the yecc grammar as part of the build.