### PR TITLE
feat: add configuration to autofetch dependencies

### DIFF
--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -276,34 +276,41 @@ defmodule Expert do
   defp maybe_prompt_deps_fetch(lsp, project) do
     state = assigns(lsp).state
 
-    supports_show_message = Expert.Configuration.client_support(:show_message)
+    supports_show_message = show_message_supported?()
+    auto_fetch_dependencies? = Expert.Configuration.auto_fetch_dependencies?()
 
     # Avoids spamming the user with the same prompt if they already declined
     deps_declined = State.deps_declined?(state, project)
 
-    if supports_show_message && not deps_declined do
-      Store.transition(project, :blocked)
+    cond do
+      auto_fetch_dependencies? and not Store.blocked?(project) ->
+        Store.transition(project, :blocked)
+        start_deps_fetch_task(lsp, project)
 
-      response = prompt_deps_fetch(lsp, project)
+      supports_show_message and not deps_declined and not Store.blocked?(project) ->
+        Store.transition(project, :blocked)
 
-      handle_deps_fetch_result(response, lsp, project)
-    else
-      if deps_declined do
-        Logger.info(
-          "Engine failed due to dependency errors, but user declined to fetch dependencies.",
-          project: project
-        )
-      end
+        response = prompt_deps_fetch(lsp, project)
 
-      if !supports_show_message do
-        log_error(
-          lsp,
-          project,
-          "Engine failed due to dependency errors, but client does not support showing messages. Run 'mix deps.get' to fetch dependencies for #{Project.name(project)} and then restart Expert or your editor."
-        )
-      end
+        handle_deps_fetch_result(response, lsp, project)
 
-      lsp
+      true ->
+        if deps_declined do
+          Logger.info(
+            "Engine failed due to dependency errors, but user declined to fetch dependencies.",
+            project: project
+          )
+        end
+
+        if !supports_show_message do
+          log_error(
+            lsp,
+            project,
+            "Engine failed due to dependency errors, but client does not support showing messages. Run 'mix deps.get' to fetch dependencies for #{Project.name(project)} and then restart Expert or your editor."
+          )
+        end
+
+        lsp
     end
   end
 
@@ -415,6 +422,13 @@ defmodule Expert do
       )
 
     handle_deps_fetch_retry_result(response, lsp, project)
+  end
+
+  defp show_message_supported? do
+    case Expert.Configuration.client_support(:show_message) do
+      value when value in [false, nil] -> false
+      _ -> true
+    end
   end
 
   defp handle_deps_fetch_retry_result(

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -53,6 +53,11 @@ defmodule Expert.Configuration do
       parser: {:string, nil},
       missing: :preserve
     },
+    auto_fetch_dependencies: %{
+      key: "autoFetchDependencies",
+      parser: {:boolean, true},
+      missing: :preserve
+    },
     workspace_symbols: %{
       key: "workspaceSymbols",
       parser: :workspace_symbols,
@@ -71,7 +76,8 @@ defmodule Expert.Configuration do
             file_log_level: @default_file_log_level,
             elixir_source_path: nil,
             elixir_executable_path: nil,
-            erlang_executable_path: nil
+            erlang_executable_path: nil,
+            auto_fetch_dependencies: true
 
   @type t :: %__MODULE__{
           support: support | nil,
@@ -82,7 +88,8 @@ defmodule Expert.Configuration do
           file_log_level: file_level(),
           elixir_source_path: String.t() | nil,
           elixir_executable_path: String.t() | nil,
-          erlang_executable_path: String.t() | nil
+          erlang_executable_path: String.t() | nil,
+          auto_fetch_dependencies: boolean()
         }
 
   @opaque support :: Support.t()
@@ -123,6 +130,11 @@ defmodule Expert.Configuration do
   @spec file_log_level() :: file_level()
   def file_log_level do
     get().file_log_level
+  end
+
+  @spec auto_fetch_dependencies?() :: boolean()
+  def auto_fetch_dependencies? do
+    get().auto_fetch_dependencies
   end
 
   @vscode_family_patterns [
@@ -245,12 +257,21 @@ defmodule Expert.Configuration do
     default
   end
 
+  defp parse_setting(value, {:boolean, _default}) when is_boolean(value) do
+    value
+  end
+
+  defp parse_setting(_value, {:boolean, default}) do
+    default
+  end
+
   defp parse_setting(settings, :workspace_symbols) do
     WorkspaceSymbols.new(%{"workspaceSymbols" => settings})
   end
 
   defp default_setting({:enum, _values, default}), do: default
   defp default_setting({:string, default}), do: default
+  defp default_setting({:boolean, default}), do: default
 
   defp put_setting(%__MODULE__{} = config, field, value) do
     struct!(config, [{field, value}])

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -400,6 +400,35 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
+  describe "on_change/1 with autoFetchDependencies" do
+    test "parses boolean values" do
+      {:ok, updated} = Configuration.on_change(build_change(%{"autoFetchDependencies" => true}))
+
+      assert updated.auto_fetch_dependencies
+      assert Configuration.auto_fetch_dependencies?()
+
+      {:ok, updated} = Configuration.on_change(build_change(%{"autoFetchDependencies" => false}))
+
+      refute updated.auto_fetch_dependencies
+    end
+
+    test "preserves previous value when setting is missing" do
+      {:ok, _updated} = Configuration.on_change(build_change(%{"autoFetchDependencies" => true}))
+      {:ok, updated} = Configuration.on_change(build_change(%{}))
+
+      assert updated.auto_fetch_dependencies
+    end
+
+    test "defaults to true for invalid values and explicit null" do
+      for value <- [nil, "true", 1] do
+        {:ok, updated} =
+          Configuration.on_change(build_change(%{"autoFetchDependencies" => value}))
+
+        assert updated.auto_fetch_dependencies
+      end
+    end
+  end
+
   describe "race condition prevention" do
     defmodule DummyServer do
       use GenServer

--- a/apps/expert/test/expert/expert_test.exs
+++ b/apps/expert/test/expert/expert_test.exs
@@ -1221,6 +1221,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1267,6 +1268,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1316,6 +1318,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1357,6 +1360,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1389,6 +1393,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1439,6 +1444,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 
@@ -1504,6 +1510,7 @@ defmodule ExpertTest do
       assert :ok = notify(client, initialized_notification())
 
       assert_request(client, "client/registerCapability", fn _params -> nil end)
+      Expert.Configuration.set(%{Expert.Configuration.get() | auto_fetch_dependencies: false})
 
       send(server.lsp, {:deps_error, main_project, %{last_message: "deps failed"}})
 

--- a/pages/configuration.md
+++ b/pages/configuration.md
@@ -13,7 +13,8 @@ Expert supports the following configuration options.
   "fileLogLevel": "info",
   "elixirSourcePath": "/path/to/elixir/source",
   "elixirExecutablePath": "/absolute/path/to/elixir",
-  "erlangExecutablePath": "/absolute/path/to/erl"
+  "erlangExecutablePath": "/absolute/path/to/erl",
+  "autoFetchDependencies": true
 }
 ```
 
@@ -27,3 +28,4 @@ Expert supports the following configuration options.
 | `elixirSourcePath` | string | `null` | Path to a local Elixir source directory. When set, go-to-definition on Elixir standard library modules will navigate to source files in this directory instead of returning no result. Should be an absolute path. |
 | `elixirExecutablePath` | string | `null` | Path to the Elixir executable Expert should use for building and running project engines. Sending `null` clears the override. Expert uses the path as provided and does not validate it. |
 | `erlangExecutablePath` | string | `null` | Path to the Erlang `erl` executable Expert should use when resolving the project Erlang runtime. Sending `null` clears the override. Expert uses the path as provided and does not validate it. |
+| `autoFetchDependencies` | boolean | `true` | Automatically run `mix deps.get` when project engine startup fails because dependencies are missing or stale. |


### PR DESCRIPTION
Close #516 

Adds a new `autoFetchDependencies` configuration that skips the dependency fetching prompt and just runs `mix deps.get` for you.

If the autofetch fails, you get the retry prompt as usual.