### PR TITLE
chore: improve performance of SQLite indexer

### DIFF
--- a/apps/expert/lib/expert/search/fuzzy.ex
+++ b/apps/expert/lib/expert/search/fuzzy.ex
@@ -50,11 +50,9 @@ defmodule Expert.Search.Fuzzy do
   def from_backend(%Project{} = project, backend) do
     mapper = default_mapper()
 
-    case backend.reduce(project, [], fn
-           %Entry{subtype: :definition} = entry, acc -> [mapper.(entry) | acc]
-           _, acc -> acc
-         end) do
-      mapped_items when is_list(mapped_items) ->
+    case backend.find_by_subject(project, :_, :_, :definition) do
+      entries when is_list(entries) ->
+        mapped_items = Enum.map(entries, mapper)
         {:ok, new(mapped_items, mapper, &stringify/1, build_filter_fn(project), false)}
 
       {:error, _} = error ->

--- a/apps/expert/lib/expert/search/fuzzy.ex
+++ b/apps/expert/lib/expert/search/fuzzy.ex
@@ -50,7 +50,7 @@ defmodule Expert.Search.Fuzzy do
   def from_backend(%Project{} = project, backend) do
     mapper = default_mapper()
 
-    case backend.find_by_subject(project, :_, :_, :definition) do
+    case backend.definitions_for_fuzzy(project) do
       entries when is_list(entries) ->
         mapped_items = Enum.map(entries, mapper)
         {:ok, new(mapped_items, mapper, &stringify/1, build_filter_fn(project), false)}

--- a/apps/expert/lib/expert/search/store.ex
+++ b/apps/expert/lib/expert/search/store.ex
@@ -78,10 +78,11 @@ defmodule Expert.Search.Store do
     )
   end
 
-  def clear(%Project{} = project, path), do: GenServer.call(name(project), {:update, path, []})
+  def clear(%Project{} = project, path),
+    do: GenServer.call(name(project), {:update, path, []}, :infinity)
 
   def update(%Project{} = project, path, entries),
-    do: GenServer.call(name(project), {:update, path, entries})
+    do: GenServer.call(name(project), {:update, path, entries}, :infinity)
 
   def destroy(%Project{} = project), do: GenServer.call(name(project), :destroy)
   def enable(%Project{} = project), do: GenServer.call(name(project), :enable)

--- a/apps/expert/lib/expert/search/store/backend.ex
+++ b/apps/expert/lib/expert/search/store/backend.ex
@@ -16,16 +16,13 @@ defmodule Expert.Search.Store.Backend do
   @type type_query :: Entry.entry_type() | wildcard()
   @type subtype_query :: Entry.entry_subtype() | wildcard()
   @type block_structure :: %{Entry.block_id() => block_structure()} | %{}
-  @type accumulator :: any()
-  @type reducer_fun :: (Entry.t(), accumulator() -> accumulator())
-
   @callback new(Project.t()) :: {:ok, priv_state()} | {:error, any()}
   @callback prepare(priv_state()) :: {:ok, load_state()} | {:error, any()}
   @callback sync(Project.t()) :: :ok | {:error, any()}
   @callback insert(Project.t(), [Entry.t()]) :: :ok | {:error, any()}
   @callback drop(Project.t()) :: boolean() | :ok | {:error, any()}
   @callback destroy(Project.t()) :: :ok | {:error, any()}
-  @callback reduce(Project.t(), accumulator(), reducer_fun()) :: accumulator() | {:error, any()}
+  @callback path_to_ids(Project.t()) :: %{Path.t() => Entry.entry_id()} | {:error, any()}
   @callback replace_all(Project.t(), [Entry.t()]) :: :ok | {:error, any()}
   @callback delete_by_path(Project.t(), Path.t()) :: {:ok, [Entry.entry_id()]} | {:error, any()}
   @callback apply_index_update(Project.t(), [Entry.t()], [Path.t()]) ::

--- a/apps/expert/lib/expert/search/store/backend.ex
+++ b/apps/expert/lib/expert/search/store/backend.ex
@@ -23,6 +23,7 @@ defmodule Expert.Search.Store.Backend do
   @callback drop(Project.t()) :: boolean() | :ok | {:error, any()}
   @callback destroy(Project.t()) :: :ok | {:error, any()}
   @callback path_to_ids(Project.t()) :: %{Path.t() => Entry.entry_id()} | {:error, any()}
+  @callback definitions_for_fuzzy(Project.t()) :: [Entry.t()] | {:error, any()}
   @callback replace_all(Project.t(), [Entry.t()]) :: :ok | {:error, any()}
   @callback delete_by_path(Project.t(), Path.t()) :: {:ok, [Entry.entry_id()]} | {:error, any()}
   @callback apply_index_update(Project.t(), [Entry.t()], [Path.t()]) ::

--- a/apps/expert/lib/expert/search/store/backends/ets.ex
+++ b/apps/expert/lib/expert/search/store/backends/ets.ex
@@ -37,8 +37,8 @@ defmodule Expert.Search.Store.Backends.Ets do
   def destroy_all(%Project{} = project), do: State.destroy_all(project)
 
   @impl Backend
-  def reduce(%Project{} = project, acc, reducer_fun) do
-    GenServer.call(name(project), {:reduce, [acc, reducer_fun]}, :infinity)
+  def path_to_ids(%Project{} = project) do
+    GenServer.call(name(project), {:path_to_ids, []})
   end
 
   @impl Backend

--- a/apps/expert/lib/expert/search/store/backends/ets.ex
+++ b/apps/expert/lib/expert/search/store/backends/ets.ex
@@ -42,6 +42,11 @@ defmodule Expert.Search.Store.Backends.Ets do
   end
 
   @impl Backend
+  def definitions_for_fuzzy(%Project{} = project) do
+    find_by_subject(project, :_, :_, :definition)
+  end
+
+  @impl Backend
   def replace_all(%Project{} = project, entries) do
     GenServer.call(name(project), {:replace_all, [entries]}, :infinity)
   end

--- a/apps/expert/lib/expert/search/store/backends/ets/state.ex
+++ b/apps/expert/lib/expert/search/store/backends/ets/state.ex
@@ -153,6 +153,16 @@ defmodule Expert.Search.Store.Backends.Ets.State do
     |> List.flatten()
   end
 
+  def path_to_ids(%__MODULE__{} = state) do
+    reduce(state, %{}, fn
+      %Entry{path: path} = entry, path_to_ids when is_integer(entry.id) ->
+        Map.update(path_to_ids, path, entry.id, &max(&1, entry.id))
+
+      _entry, path_to_ids ->
+        path_to_ids
+    end)
+  end
+
   def replace_all(%__MODULE__{} = state, entries) do
     rows = Schema.entries_to_rows(entries, current_schema())
 

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -53,8 +53,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   def destroy_all(%Project{} = project), do: project |> root_path() |> File.rm_rf!()
 
   @impl Backend
-  def reduce(%Project{} = project, acc, reducer_fun) do
-    GenServer.call(name(project), {:reduce, acc, reducer_fun}, :infinity)
+  def path_to_ids(%Project{} = project) do
+    GenServer.call(name(project), :path_to_ids, :infinity)
   end
 
   @impl Backend
@@ -188,8 +188,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   def handle_call({:insert, entries}, _from, %State{} = state),
     do: reply(do_insert(state, entries), state)
 
-  def handle_call({:reduce, acc, reducer_fun}, _from, %State{} = state),
-    do: reply(do_reduce(state, acc, reducer_fun), state)
+  def handle_call(:path_to_ids, _from, %State{} = state),
+    do: reply(do_path_to_ids(state), state)
 
   def handle_call({:replace_all, entries}, _from, %State{} = state),
     do: reply(do_replace_all(state, entries), state)
@@ -244,15 +244,10 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     end)
   end
 
-  def do_reduce(%State{} = state, acc, reducer_fun) do
-    case query(state, "SELECT entry FROM entries ORDER BY id") do
-      {:ok, rows} ->
-        Enum.reduce(rows, acc, fn [entry_blob], acc ->
-          reducer_fun.(decode_term(entry_blob), acc)
-        end)
-
-      {:error, _} = error ->
-        error
+  def do_path_to_ids(%State{} = state) do
+    case query(state, "SELECT path, MAX(id) FROM entries WHERE id IS NOT NULL GROUP BY path") do
+      {:ok, rows} -> Map.new(rows, fn [path, id] -> {path, id} end)
+      {:error, _} = error -> error
     end
   end
 

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -502,10 +502,19 @@ defmodule Expert.Search.Store.Backends.Sqlite do
              state,
              "CREATE INDEX IF NOT EXISTS entries_subject_idx ON entries (subject, type, subtype)"
            ),
-         :ok <- exec(state, "CREATE INDEX IF NOT EXISTS entries_path_idx ON entries (path)"),
          :ok <-
-           exec(state, "CREATE INDEX IF NOT EXISTS entries_block_idx ON entries (block_id, path)") do
-      exec(state, "CREATE INDEX IF NOT EXISTS entries_id_idx ON entries (id, type, subtype)")
+           exec(state, "CREATE INDEX IF NOT EXISTS entries_block_idx ON entries (block_id, path)"),
+         :ok <-
+           exec(state, "CREATE INDEX IF NOT EXISTS entries_id_idx ON entries (id, type, subtype)"),
+         :ok <-
+           exec(
+             state,
+             "CREATE INDEX IF NOT EXISTS entries_path_id_idx ON entries (path, id)"
+           ) do
+      exec(
+        state,
+        "CREATE INDEX IF NOT EXISTS entries_subtype_idx ON entries (subtype)"
+      )
     end
   end
 

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -513,7 +513,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
            ) do
       exec(
         state,
-        "CREATE INDEX IF NOT EXISTS entries_subtype_idx ON entries (subtype)"
+        "CREATE INDEX IF NOT EXISTS entries_subtype_subject_idx ON entries (subtype, subject)"
       )
     end
   end

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -58,6 +58,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   @impl Backend
+  def definitions_for_fuzzy(%Project{} = project) do
+    GenServer.call(name(project), :definitions_for_fuzzy, :infinity)
+  end
+
+  @impl Backend
   def replace_all(%Project{} = project, entries) do
     GenServer.call(name(project), {:replace_all, entries}, :infinity)
   end
@@ -191,6 +196,9 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   def handle_call(:path_to_ids, _from, %State{} = state),
     do: reply(do_path_to_ids(state), state)
 
+  def handle_call(:definitions_for_fuzzy, _from, %State{} = state),
+    do: reply(do_find_definitions_for_fuzzy(state), state)
+
   def handle_call({:replace_all, entries}, _from, %State{} = state),
     do: reply(do_replace_all(state, entries), state)
 
@@ -248,6 +256,26 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     case query(state, "SELECT path, MAX(id) FROM entries WHERE id IS NOT NULL GROUP BY path") do
       {:ok, rows} -> Map.new(rows, fn [path, id] -> {path, id} end)
       {:error, _} = error -> error
+    end
+  end
+
+  def do_find_definitions_for_fuzzy(%State{} = state) do
+    sql = "SELECT id, path, subject, type, subtype FROM entries WHERE subtype = 'definition'"
+
+    case query(state, sql) do
+      {:ok, rows} ->
+        Enum.map(rows, fn [id, path, subject, type_blob, subtype] ->
+          %Entry{
+            id: id,
+            path: path,
+            subject: subject,
+            type: decode_term(type_blob),
+            subtype: String.to_existing_atom(subtype)
+          }
+        end)
+
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -510,6 +538,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
            exec(
              state,
              "CREATE INDEX IF NOT EXISTS entries_path_id_idx ON entries (path, id)"
+           ),
+         :ok <-
+           exec(
+             state,
+             "CREATE INDEX IF NOT EXISTS entries_type_subtype_idx ON entries (type, subtype)"
            ) do
       exec(
         state,

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -281,7 +281,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   def do_replace_all(%State{} = state, entries) when is_list(entries) do
     transaction(state, fn ->
-      with :ok <- exec(state, "DELETE FROM entries"),
+      with :ok <- exec(state, "DELETE FROM entry_blobs"),
+           :ok <- exec(state, "DELETE FROM entries"),
            :ok <- exec(state, "DELETE FROM structures") do
         insert_entries(state, entries)
       end
@@ -345,7 +346,16 @@ defmodule Expert.Search.Store.Backends.Sqlite do
         {where, args} = constraints(["id IN (#{placeholders(ids)})"], ids, type, subtype)
 
         with {:ok, rows} <-
-               query(state, "SELECT id, entry FROM entries #{where_clause(where)}", args) do
+               query(
+                 state,
+                 """
+                 SELECT entries.id, entry_blobs.entry
+                 FROM entries
+                 JOIN entry_blobs ON entry_blobs.entry_rowid = entries.rowid
+                 #{where_clause(where)}
+                 """,
+                 args
+               ) do
           entries_by_id =
             Enum.group_by(
               rows,
@@ -369,7 +379,13 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   def do_siblings(%State{} = state, %Entry{} = entry) do
     case query(
            state,
-           "SELECT entry FROM entries WHERE block_id = ? AND path = ? ORDER BY id",
+           """
+           SELECT entry_blobs.entry
+           FROM entries
+           JOIN entry_blobs ON entry_blobs.entry_rowid = entries.rowid
+           WHERE block_id = ? AND path = ?
+           ORDER BY id
+           """,
            [block_id_key(entry.block_id), entry.path]
          ) do
       {:ok, rows} ->
@@ -474,8 +490,10 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   defp reset_schema(%State{} = state) do
     with :ok <- exec(state, "DROP TABLE IF EXISTS entries"),
+         :ok <- exec(state, "DROP TABLE IF EXISTS entry_blobs"),
          :ok <- exec(state, "DROP TABLE IF EXISTS structures"),
          :ok <- create_entries_table(state),
+         :ok <- create_entry_blobs_table(state),
          :ok <- create_structures_table(state),
          :ok <- create_indexes(state),
          :ok <- exec(state, "INSERT INTO schema (version) VALUES (?)", [@schema_version]) do
@@ -486,6 +504,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp reset_database_schema(%State{} = state) do
     with :ok <- exec(state, "DROP TABLE IF EXISTS schema"),
          :ok <- exec(state, "DROP TABLE IF EXISTS entries"),
+         :ok <- exec(state, "DROP TABLE IF EXISTS entry_blobs"),
          :ok <- exec(state, "DROP TABLE IF EXISTS structures"),
          :ok <- create_schema_table(state) do
       reset_schema(state)
@@ -494,6 +513,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   defp load_status(%State{} = state) do
     with :ok <- create_entries_table(state),
+         :ok <- create_entry_blobs_table(state),
          :ok <- create_structures_table(state),
          :ok <- create_indexes(state),
          {:ok, [[count]]} <- query(state, "SELECT COUNT(*) FROM entries") do
@@ -509,7 +529,15 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       subject TEXT NOT NULL,
       type BLOB NOT NULL,
       subtype TEXT NOT NULL,
-      block_id INTEGER NOT NULL,
+      block_id INTEGER NOT NULL
+    )
+    """)
+  end
+
+  defp create_entry_blobs_table(%State{} = state) do
+    exec(state, """
+    CREATE TABLE IF NOT EXISTS entry_blobs (
+      entry_rowid INTEGER PRIMARY KEY,
       entry BLOB NOT NULL
     )
     """)
@@ -556,14 +584,21 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       state,
       [
         """
-        INSERT INTO entries (id, path, subject, type, subtype, block_id, entry)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO entries (id, path, subject, type, subtype, block_id)
+        VALUES (?, ?, ?, ?, ?, ?)
         """,
+        "INSERT INTO entry_blobs (entry_rowid, entry) VALUES (?, ?)",
         "INSERT OR REPLACE INTO structures (path, structure) VALUES (?, ?)"
       ],
-      fn [entry_statement, structure_statement] ->
+      fn [entry_statement, entry_blob_statement, structure_statement] ->
         Enum.reduce_while(entries, :ok, fn entry, :ok ->
-          case insert_entry(state, entry_statement, structure_statement, entry) do
+          case insert_entry(
+                 state,
+                 entry_statement,
+                 entry_blob_statement,
+                 structure_statement,
+                 entry
+               ) do
             :ok -> {:cont, :ok}
             {:error, _} = error -> {:halt, error}
           end
@@ -572,25 +607,40 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     )
   end
 
-  defp insert_entry(%State{} = state, _entry_statement, structure_statement, %Entry{} = entry)
+  defp insert_entry(
+         %State{} = state,
+         _entry_statement,
+         _entry_blob_statement,
+         structure_statement,
+         %Entry{} = entry
+       )
        when Entry.is_structure(entry) do
     exec_statement(state, structure_statement, [entry.path, blob(entry.subject)])
   end
 
-  defp insert_entry(%State{} = state, entry_statement, _structure_statement, %Entry{} = entry) do
-    exec_statement(
-      state,
-      entry_statement,
-      [
-        entry.id,
-        entry.path,
-        subject_key(entry.subject),
-        blob(entry.type),
-        subtype_key(entry.subtype),
-        block_id_key(entry.block_id),
-        blob(entry)
-      ]
-    )
+  defp insert_entry(
+         %State{} = state,
+         entry_statement,
+         entry_blob_statement,
+         _structure_statement,
+         %Entry{} = entry
+       ) do
+    with :ok <-
+           exec_statement(
+             state,
+             entry_statement,
+             [
+               entry.id,
+               entry.path,
+               subject_key(entry.subject),
+               blob(entry.type),
+               subtype_key(entry.subtype),
+               block_id_key(entry.block_id)
+             ]
+           ),
+         {:ok, rowid} <- last_insert_rowid(state) do
+      exec_statement(state, entry_blob_statement, [rowid, blob(entry)])
+    end
   end
 
   defp affected_paths(updated_entries, paths_to_clear) do
@@ -607,11 +657,30 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     with {:ok, rows} <-
            query(
              state,
-             "DELETE FROM entries WHERE path IN (#{placeholders(paths)}) RETURNING id",
+             "SELECT rowid, id FROM entries WHERE path IN (#{placeholders(paths)})",
              paths
-           ) do
-      {:ok, rows |> List.flatten() |> Enum.reject(&is_nil/1)}
+           ),
+         :ok <- delete_entry_blobs_for_rows(state, rows),
+         :ok <- exec(state, "DELETE FROM entries WHERE path IN (#{placeholders(paths)})", paths) do
+      deleted_ids =
+        rows
+        |> Enum.map(fn [_rowid, id] -> id end)
+        |> Enum.reject(&is_nil/1)
+
+      {:ok, deleted_ids}
     end
+  end
+
+  defp delete_entry_blobs_for_rows(%State{}, []), do: :ok
+
+  defp delete_entry_blobs_for_rows(%State{} = state, rows) do
+    rowids = Enum.map(rows, fn [rowid, _id] -> rowid end)
+
+    exec(
+      state,
+      "DELETE FROM entry_blobs WHERE entry_rowid IN (#{placeholders(rowids)})",
+      rowids
+    )
   end
 
   defp delete_structures_for_paths(%State{}, []), do: :ok
@@ -621,7 +690,16 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   defp query_entries(%State{} = state, where, args) do
-    query(state, "SELECT entry FROM entries #{where}", args)
+    query(
+      state,
+      """
+      SELECT entry_blobs.entry
+      FROM entries
+      JOIN entry_blobs ON entry_blobs.entry_rowid = entries.rowid
+      #{where}
+      """,
+      args
+    )
   end
 
   defp entries_result({:ok, rows}) do
@@ -813,6 +891,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       result
     end
   end
+
+  defp last_insert_rowid(%State{conn: %{db: database}}), do: Sqlite3.last_insert_rowid(database)
 
   defp release_statement(%State{conn: %{db: database}}, statement),
     do: Sqlite3.release(database, statement)

--- a/apps/expert/lib/expert/search/store/state.ex
+++ b/apps/expert/lib/expert/search/store/state.ex
@@ -131,29 +131,14 @@ defmodule Expert.Search.Store.State do
     type = Keyword.get(constraints, :type, :_)
     subtype = Keyword.get(constraints, :subtype, :_)
 
-    result =
-      state.backend.reduce(state.project, [], fn
-        %Entry{} = entry, acc ->
-          if matches_constraints?(entry, type, subtype), do: [entry | acc], else: acc
-
-        _, acc ->
-          acc
-      end)
-
-    case result do
+    case state.backend.find_by_subject(state.project, :_, type, subtype) do
       {:error, _} = error -> error
       entries -> {:ok, entries}
     end
   end
 
   def path_to_ids(%__MODULE__{} = state) do
-    state.backend.reduce(state.project, %{}, fn
-      %Entry{path: path} = entry, path_to_ids when is_integer(entry.id) ->
-        Map.update(path_to_ids, path, entry.id, &max(&1, entry.id))
-
-      _entry, path_to_ids ->
-        path_to_ids
-    end)
+    state.backend.path_to_ids(state.project)
   end
 
   def resolve_mfa(%__MODULE__{} = state, module, function, arity) do
@@ -288,9 +273,5 @@ defmodule Expert.Search.Store.State do
       {:ok, fuzzy} -> %__MODULE__{state | fuzzy: fuzzy}
       {:error, _} = error -> error
     end
-  end
-
-  defp matches_constraints?(%Entry{type: t, subtype: st}, type, subtype) do
-    (type == :_ or t == type) and (subtype == :_ or st == subtype)
   end
 end

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -17,6 +17,44 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
   end
 
   describe "prepare/1" do
+    test "creates an index for wildcard subject searches constrained by type and subtype", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      database_path = Sqlite.database_path(project, runtime_versions)
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+
+      {:ok, conn} = Exqlite.Basic.open(database_path)
+
+      result =
+        Exqlite.Basic.exec(
+          conn,
+          """
+          EXPLAIN QUERY PLAN
+          SELECT entry FROM entries WHERE type = ? AND subtype = ?
+          """,
+          [{:blob, :erlang.term_to_binary(:module)}, "definition"]
+        )
+
+      assert {:ok, rows, _columns} = Exqlite.Basic.rows(result)
+      assert :ok = Exqlite.Basic.close(conn)
+
+      assert Enum.any?(rows, fn row ->
+               plan = row |> List.last() |> to_string()
+
+               String.contains?(plan, "entries_type_subtype_idx") and
+                 String.contains?(plan, "type=?") and
+                 String.contains?(plan, "subtype=?")
+             end)
+    end
+
     test "recreates a database with a different schema version", %{
       project: project,
       runtime_versions: runtime_versions

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -38,7 +38,10 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
           conn,
           """
           EXPLAIN QUERY PLAN
-          SELECT entry FROM entries WHERE type = ? AND subtype = ?
+          SELECT entry_blobs.entry
+          FROM entries
+          JOIN entry_blobs ON entry_blobs.entry_rowid = entries.rowid
+          WHERE type = ? AND subtype = ?
           """,
           [{:blob, :erlang.term_to_binary(:module)}, "definition"]
         )
@@ -53,6 +56,34 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
                  String.contains?(plan, "type=?") and
                  String.contains?(plan, "subtype=?")
              end)
+    end
+
+    test "stores full entry blobs outside the entries metadata table", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      database_path = Sqlite.database_path(project, runtime_versions)
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+
+      {:ok, conn} = Exqlite.Basic.open(database_path)
+
+      result = Exqlite.Basic.exec(conn, "PRAGMA table_info(entries)")
+      assert {:ok, entry_columns, _columns} = Exqlite.Basic.rows(result)
+
+      result = Exqlite.Basic.exec(conn, "PRAGMA table_info(entry_blobs)")
+      assert {:ok, blob_columns, _columns} = Exqlite.Basic.rows(result)
+
+      assert :ok = Exqlite.Basic.close(conn)
+
+      refute Enum.any?(entry_columns, fn [_cid, name | _] -> name == "entry" end)
+      assert Enum.any?(blob_columns, fn [_cid, name | _] -> name == "entry" end)
     end
 
     test "recreates a database with a different schema version", %{
@@ -192,6 +223,17 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
 
       assert [] = Sqlite.find_by_subject(project, Replaced.Old, :_, :_)
       assert [^new_entry] = Sqlite.find_by_subject(project, Replaced.New, :_, :_)
+
+      database_path = Sqlite.database_path(project, runtime_versions)
+      {:ok, conn} = Exqlite.Basic.open(database_path)
+
+      result =
+        Exqlite.Basic.exec(conn, """
+        SELECT (SELECT COUNT(*) FROM entries), (SELECT COUNT(*) FROM entry_blobs)
+        """)
+
+      assert {:ok, [[1, 1]], _columns} = Exqlite.Basic.rows(result)
+      assert :ok = Exqlite.Basic.close(conn)
     end
   end
 

--- a/apps/expert/test/expert/search/store/state_test.exs
+++ b/apps/expert/test/expert/search/store/state_test.exs
@@ -26,6 +26,7 @@ defmodule Expert.Search.Store.StateTest do
     def find_by_ids(_project, [2], :module, :definition), do: [entry(2)]
     def find_by_ids(_project, _ids, _type, _subtype), do: []
     def path_to_ids(_project), do: %{}
+    def definitions_for_fuzzy(_project), do: []
     def siblings(_project, _entry), do: []
     def parent(_project, _entry), do: nil
     def structure_for_path(_project, _path), do: {:ok, %{}}
@@ -60,6 +61,7 @@ defmodule Expert.Search.Store.StateTest do
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, _ids, _type, _subtype), do: []
     def path_to_ids(_project), do: %{}
+    def definitions_for_fuzzy(_project), do: []
     def siblings(_project, _entry), do: []
     def parent(_project, _entry), do: nil
     def structure_for_path(_project, _path), do: {:ok, %{}}

--- a/apps/expert/test/expert/search/store/state_test.exs
+++ b/apps/expert/test/expert/search/store/state_test.exs
@@ -20,11 +20,12 @@ defmodule Expert.Search.Store.StateTest do
     def apply_index_update(_project, _entries, _paths),
       do: {:ok, []}
 
+    def find_by_subject(_project, :_, :module, :definition), do: [entry(1)]
     def find_by_subject(_project, _subject, _type, _subtype), do: []
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, [2], :module, :definition), do: [entry(2)]
     def find_by_ids(_project, _ids, _type, _subtype), do: []
-    def reduce(_project, acc, fun), do: fun.(entry(1), acc)
+    def path_to_ids(_project), do: %{}
     def siblings(_project, _entry), do: []
     def parent(_project, _entry), do: nil
     def structure_for_path(_project, _path), do: {:ok, %{}}
@@ -58,7 +59,7 @@ defmodule Expert.Search.Store.StateTest do
     def find_by_subject(_project, _subject, _type, _subtype), do: []
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, _ids, _type, _subtype), do: []
-    def reduce(_project, acc, _fun), do: acc
+    def path_to_ids(_project), do: %{}
     def siblings(_project, _entry), do: []
     def parent(_project, _entry), do: nil
     def structure_for_path(_project, _path), do: {:ok, %{}}


### PR DESCRIPTION
Apply performance improvements for SQLite indexer found in a large project. Details: https://github.com/expert-lsp/expert/pull/683#issuecomment-4855923028

- add missing indices
- skip `backend.reduce` completely
- select only needed columns in few places
- extract `entry_blobs` table to keep most heavy data for an entry - joined on demand now