### PR TITLE
fix: correctly pass Elixir source path config

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -131,7 +131,8 @@ defmodule Engine.CodeIntelligence.Definition do
     position = Position.new(document, line, column)
 
     with {:ok, zipper} <- Ast.zipper_at(document, position),
-         %{node: {entity_name, meta, _}} <- Sourceror.Zipper.next(zipper) do
+         zipper = Sourceror.Zipper.next(zipper),
+         %{node: {entity_name, meta, _}} <- zipper do
       meta =
         if entity_name == :when do
           %{node: {_entity_name, meta, _}} = Sourceror.Zipper.next(zipper)

--- a/apps/expert/lib/expert/engine_node.ex
+++ b/apps/expert/lib/expert/engine_node.ex
@@ -405,7 +405,7 @@ defmodule Expert.EngineNode do
         configs
 
       elixir_source_path ->
-        [{:language_server, [elixir_source_path: elixir_source_path]} | configs]
+        [{:language_server, [elixir_src: elixir_source_path]} | configs]
     end
   end
 end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -298,7 +298,7 @@ defmodule Expert.State do
 
   defp propagate_elixir_source_path(%Configuration{elixir_source_path: nil}) do
     for project <- Store.projects(), Store.ready?(project) do
-      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_source_path])
+      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_src])
     end
   rescue
     _ -> :ok
@@ -308,7 +308,7 @@ defmodule Expert.State do
     for project <- Store.projects(), Store.ready?(project) do
       EngineApi.call(project, Application, :put_env, [
         :language_server,
-        :elixir_source_path,
+        :elixir_src,
         elixir_source_path
       ])
     end

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -67,6 +67,17 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
     EngineApi.register_listener(project, self(), [:all])
     EngineApi.schedule_compile(project, true)
 
+    # point ElixirSense at the project node's Elixir source
+    elixir_src =
+      project
+      |> EngineApi.call(:code, :lib_dir, [:elixir])
+      |> to_string()
+      |> Path.join("../..")
+      |> Path.expand()
+
+    :ok =
+      EngineApi.call(project, Application, :put_env, [:language_server, :elixir_src, elixir_src])
+
     assert_receive project_compiled(), @project_compile_timeout
     assert_receive project_index_ready(project: ^project), @project_index_timeout
 
@@ -426,12 +437,6 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
       assert referenced_uri =~ "navigations/lib/my_module.ex"
     end
 
-    @doc """
-    This is a limitation of the ElixirSense.
-    like the `subject_module` below, it can't find the correct definition of `String.to_integer/1`,
-    currently, it will always return `{:ok, nil}`
-    """
-    @tag :skip
     test "find the definition when calling a Elixir std module function",
          %{project: project, subject_uri: subject_uri} do
       subject_module = ~q[


### PR DESCRIPTION
Before merging #568 I did a rename of the configuration key and renamed too much. As a result, ElixirSense was receiving `elixir_source_path` setting when is expected `elixir_src`.

This fixes that, also unskipping a test verifying jump to definition to Elixir source and fixes a bug with Zipper when a guard is present.