### PR TITLE
feat: defer code action execution

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -32,9 +32,13 @@ defmodule Engine do
 
   defdelegate list_modules, to: :code, as: :all_available
 
-  defdelegate code_actions(document, range, diagnostics, kinds, trigger_kind),
+  defdelegate code_actions(document, range, diagnostics, kinds, trigger_kind, opts),
     to: CodeAction,
     as: :for_range
+
+  defdelegate resolve_code_action(document, range, module_name),
+    to: CodeAction,
+    as: :resolve_refactor
 
   defdelegate complete(env), to: Engine.Completion, as: :elixir_sense_expand
 

--- a/apps/engine/lib/engine/code_action.ex
+++ b/apps/engine/lib/engine/code_action.ex
@@ -1,4 +1,11 @@
 defmodule Engine.CodeAction do
+  @moduledoc """
+  Handles `textDocument/codeAction` requests, which language server clients frequently send while
+  users are editing. Frequently computing all possible code actions can be expensive due to the
+  hot-path nature, so Language Server Protocol provides a mechanism to deouple the list of
+  possible actions from executing them. See `Expert.Configuration.client_resolves_code_action_edits?/1`.
+  """
+
   alias Engine.CodeAction.Handlers
   alias Forge.CodeAction.Diagnostic
   alias Forge.Document
@@ -15,21 +22,42 @@ defmodule Engine.CodeAction do
     Handlers.CreateUndefinedFunction
   ]
 
+  @doc """
+  Fans the request out to every handler whose advertised kinds and trigger kind match, and concats their actions.
+
+  ## Options
+
+    * `defer_edits?` - when `true`, handlers supporting deferral return actions without edits,
+      carrying a `data` payload for a later `codeAction/resolve` request (see `resolve_refactor/3`).
+      Handlers without deferral support ignore the option and return their edits inline. Defaults
+      to `false`.
+  """
   @spec for_range(
           Document.t(),
           Range.t(),
           [Diagnostic.t()],
           [Forge.CodeAction.code_action_kind()] | :all,
-          Forge.CodeAction.trigger_kind()
+          Forge.CodeAction.trigger_kind(),
+          keyword()
         ) :: [Forge.CodeAction.t()]
-  def for_range(%Document{} = doc, %Range{} = range, diagnostics, kinds, trigger_kind) do
+  def for_range(%Document{} = doc, %Range{} = range, diagnostics, kinds, trigger_kind, opts \\ []) do
     Enum.flat_map(@handlers, fn handler ->
       if handle_kinds?(handler, kinds) and handle_trigger_kind?(handler, trigger_kind) do
-        handler.actions(doc, range, diagnostics)
+        handler.actions(doc, range, diagnostics, opts)
       else
         []
       end
     end)
+  end
+
+  @doc """
+  Resolves the edits for a deferred refactor action, namely those listed by `Engine.CodeAction.Handlers.Refactorex`.
+  """
+  @spec resolve_refactor(Document.t(), Range.t(), String.t()) ::
+          {:ok, Forge.Document.Changes.t()} | :error
+
+  def resolve_refactor(%Document{} = doc, %Range{} = range, module_name) do
+    Handlers.Refactorex.resolve(doc, range, module_name)
   end
 
   defp handle_kinds?(_handler, :all), do: true

--- a/apps/engine/lib/engine/code_action.ex
+++ b/apps/engine/lib/engine/code_action.ex
@@ -1,9 +1,8 @@
 defmodule Engine.CodeAction do
   @moduledoc """
-  Handles `textDocument/codeAction` requests, which language server clients frequently send while
-  users are editing. Frequently computing all possible code actions can be expensive due to the
-  hot-path nature, so Language Server Protocol provides a mechanism to deouple the list of
-  possible actions from executing them. See `Expert.Configuration.client_resolves_code_action_edits?/1`.
+  Handles `textDocument/codeAction` requests.
+
+  Language clients frequently emit these while users are editing.
   """
 
   alias Engine.CodeAction.Handlers

--- a/apps/engine/lib/engine/code_action/handler.ex
+++ b/apps/engine/lib/engine/code_action/handler.ex
@@ -1,10 +1,32 @@
 defmodule Engine.CodeAction.Handler do
+  @moduledoc """
+  Behaviour for individual code action definitions, invoked in `Engine.CodeAction.for_range/6`.
+  """
+
   alias Forge.CodeAction
   alias Forge.CodeAction.Diagnostic
   alias Forge.Document
   alias Forge.Document.Range
 
-  @callback actions(Document.t(), Range.t(), [Diagnostic.t()]) :: [CodeAction.t()]
+  @doc """
+  Returns the handler's actions for the given document and range.
+
+  The diagnostics come from the request's context: those the client knows to overlap the range,
+  which diagnostic-driven handlers match against to offer fixes.
+
+  `opts` carries the request options (see the "Options" section of `Engine.CodeAction.for_range/6`).
+  Code actions that support deferred edits to `codeAction/resolve` honor `defer_edits?`
+  there; the rest ignore `opts` and always return their edits inline.
+  """
+  @callback actions(Document.t(), Range.t(), [Diagnostic.t()], keyword()) :: [CodeAction.t()]
+
+  @doc """
+  Returns the code action kinds the handler can produce, matched against the request's `only` filter.
+  """
   @callback kinds() :: [CodeAction.code_action_kind()]
+
+  @doc """
+  Returns the trigger kind the handler serves.
+  """
   @callback trigger_kind() :: CodeAction.trigger_kind() | :all
 end

--- a/apps/engine/lib/engine/code_action/handler.ex
+++ b/apps/engine/lib/engine/code_action/handler.ex
@@ -13,10 +13,6 @@ defmodule Engine.CodeAction.Handler do
 
   The diagnostics come from the request's context: those the client knows to overlap the range,
   which diagnostic-driven handlers match against to offer fixes.
-
-  `opts` carries the request options (see the "Options" section of `Engine.CodeAction.for_range/6`).
-  Code actions that support deferred edits to `codeAction/resolve` honor `defer_edits?`
-  there; the rest ignore `opts` and always return their edits inline.
   """
   @callback actions(Document.t(), Range.t(), [Diagnostic.t()], keyword()) :: [CodeAction.t()]
 

--- a/apps/engine/lib/engine/code_action/handlers/add_alias.ex
+++ b/apps/engine/lib/engine/code_action/handlers/add_alias.ex
@@ -20,7 +20,7 @@ defmodule Engine.CodeAction.Handlers.AddAlias do
   alias Sourceror.Zipper
 
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
+  def actions(%Document{} = doc, %Range{} = range, _diagnostics, _opts \\ []) do
     with {:ok, _doc, %Analysis{valid?: true} = analysis} <-
            Document.Store.fetch(doc.uri, :analysis),
          {:ok, resolved, _} <- Entity.resolve(analysis, range.start),

--- a/apps/engine/lib/engine/code_action/handlers/create_undefined_function.ex
+++ b/apps/engine/lib/engine/code_action/handlers/create_undefined_function.ex
@@ -14,7 +14,7 @@ defmodule Engine.CodeAction.Handlers.CreateUndefinedFunction do
   alias GenLSP.Enumerations.CodeActionKind
 
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{}, diagnostics) do
+  def actions(%Document{} = doc, %Range{}, diagnostics, _opts \\ []) do
     Enum.flat_map(diagnostics, fn %Diagnostic{} = diagnostic ->
       with {:ok, function_name, arity} <- extract_function_info(diagnostic),
            {:ok, _doc, %Analysis{valid?: true} = analysis} <-
@@ -30,9 +30,7 @@ defmodule Engine.CodeAction.Handlers.CreateUndefinedFunction do
   end
 
   @impl CodeAction.Handler
-  def kinds do
-    [CodeActionKind.quick_fix()]
-  end
+  def kinds, do: [CodeActionKind.quick_fix()]
 
   @impl CodeAction.Handler
   def trigger_kind, do: :all

--- a/apps/engine/lib/engine/code_action/handlers/organize_aliases.ex
+++ b/apps/engine/lib/engine/code_action/handlers/organize_aliases.ex
@@ -11,7 +11,7 @@ defmodule Engine.CodeAction.Handlers.OrganizeAliases do
   alias GenLSP.Enumerations.CodeActionKind
 
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
+  def actions(%Document{} = doc, %Range{} = range, _diagnostics, _opts \\ []) do
     with {:ok, _doc, analysis} <- Document.Store.fetch(doc.uri, :analysis),
          :ok <- check_aliases(doc, analysis, range) do
       aliases = CodeMod.Aliases.in_scope(analysis, range)

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -21,7 +21,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
       if Keyword.get(opts, :defer_edits?, false) do
         Enum.map(refactorings, &to_deferred_action(doc, range, &1))
       else
-        Enum.flat_map(refactorings, &execute_eagerly(doc, zipper, target, &1))
+        execute_all(doc, zipper, target, refactorings)
       end
     else
       _ -> []
@@ -41,7 +41,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
          {:ok, ast} <- Sourceror.parse_string(Document.to_string(doc)),
          {:ok, refactoring} <-
            ast |> Sourceror.Zipper.zip() |> Refactor.execute(target, module_name) do
-      {:ok, ast_to_changes(doc, refactoring.refactored)}
+      {:ok, ast_to_changes(doc, refactoring.refactored, sourceror_opts(doc))}
     else
       _ -> :error
     end
@@ -68,10 +68,20 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     Forge.CodeAction.deferred(doc.uri, refactoring.title, refactoring.kind, data)
   end
 
-  # Eager fallback for clients without codeAction/resolve support. Each
-  # refactoring is isolated: a broken rewrite loses that one action instead
+  # Eager fallback for clients without codeAction/resolve support. The formatter
+  # configuration depends only on the project and file, so it is resolved once
+  # per request and shared across refactorings (and skipped entirely when none
+  # apply, keeping the common empty case off the formatter lookup).
+  defp execute_all(_doc, _zipper, _target, []), do: []
+
+  defp execute_all(doc, zipper, target, refactorings) do
+    sourceror_opts = sourceror_opts(doc)
+    Enum.flat_map(refactorings, &execute_eagerly(doc, zipper, target, &1, sourceror_opts))
+  end
+
+  # Each refactoring is isolated: a broken rewrite loses that one action instead
   # of failing the whole codeAction request.
-  defp execute_eagerly(doc, zipper, target, refactoring) do
+  defp execute_eagerly(doc, zipper, target, refactoring, sourceror_opts) do
     case Refactor.execute(zipper, target, refactoring.module) do
       {:ok, executed} ->
         [
@@ -79,7 +89,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
             doc.uri,
             executed.title,
             executed.kind,
-            ast_to_changes(doc, executed.refactored)
+            ast_to_changes(doc, executed.refactored, sourceror_opts)
           )
         ]
 
@@ -107,19 +117,20 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     |> Sourceror.parse_string(line: start.line, column: start.character)
   end
 
-  defp ast_to_changes(doc, ast) do
+  defp sourceror_opts(doc) do
     {formatter, opts} = CodeMod.Format.formatter_for_file(Engine.get_project(), doc.uri)
 
-    sourceror_opts =
-      Keyword.reject(
-        [
-          formatter: formatter,
-          locals_without_parens: opts[:locals_without_parens] || [],
-          line_length: opts[:line_length]
-        ],
-        fn {_k, v} -> is_nil(v) end
-      )
+    Keyword.reject(
+      [
+        formatter: formatter,
+        locals_without_parens: opts[:locals_without_parens] || [],
+        line_length: opts[:line_length]
+      ],
+      fn {_k, v} -> is_nil(v) end
+    )
+  end
 
+  defp ast_to_changes(doc, ast, sourceror_opts) do
     ast
     |> Sourceror.to_string(sourceror_opts)
     |> then(&CodeMod.Diff.diff(doc, &1))

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -31,9 +31,6 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   @doc """
   Computes the edits for a single refactoring previously listed with `defer_edits?: true`, as
   part of the `codeAction/resolve` flow.
-
-  Availability is re-checked against the current document. Rewrite crashes intentionally surface
-  to the caller: they fail only this resolve request, and silently dropping them would hide bugs.
   """
   @spec resolve(Document.t(), Range.t(), String.t()) :: {:ok, Changes.t()} | :error
   def resolve(%Document{} = doc, %Range{} = range, module_name) do
@@ -91,13 +88,6 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     error ->
       Logger.warning(
         "Refactoring #{inspect(refactoring.module)} failed: #{Exception.message(error)}"
-      )
-
-      []
-  catch
-    kind, reason ->
-      Logger.warning(
-        "Refactoring #{inspect(refactoring.module)} failed (#{kind}): #{inspect(reason)}"
       )
 
       []

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -87,7 +87,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   rescue
     error ->
       Logger.error(
-        "refactoring #{inspect(refactoring.module)}: #{Exception.message(error)}: #{Exception.format_stacktrace(error)}"
+        "refactor: #{inspect(refactoring.module)}: #{Exception.format(:error, error, __STACKTRACE__)}"
       )
 
       []

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -70,7 +70,8 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   end
 
   # Each refactoring is isolated: a broken rewrite loses that one action instead
-  # of failing the whole codeAction request.
+  # of failing the whole codeAction request. Raises, throws, and exits are all
+  # caught here so one misbehaving refactoring can't take down the listing.
   defp execute_eagerly(doc, zipper, target, refactoring, sourceror_opts) do
     case Refactor.execute(zipper, target, refactoring.module) do
       {:ok, executed} ->
@@ -90,6 +91,13 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     error ->
       Logger.warning(
         "Refactoring #{inspect(refactoring.module)} failed: #{Exception.message(error)}"
+      )
+
+      []
+  catch
+    kind, reason ->
+      Logger.warning(
+        "Refactoring #{inspect(refactoring.module)} failed (#{kind}): #{inspect(reason)}"
       )
 
       []

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -54,17 +54,7 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   def trigger_kind, do: :all
 
   defp to_deferred_action(%Document{} = doc, %Range{} = range, refactoring) do
-    data = %{
-      "provider" => "refactor",
-      "module" => Atom.to_string(refactoring.module),
-      "uri" => doc.uri,
-      "version" => doc.version,
-      "range" => %{
-        "start" => %{"line" => range.start.line, "character" => range.start.character},
-        "end" => %{"line" => range.end.line, "character" => range.end.character}
-      }
-    }
-
+    data = Forge.CodeAction.to_refactor_data(doc.uri, doc.version, range, refactoring.module)
     Forge.CodeAction.deferred(doc.uri, refactoring.title, refactoring.kind, data)
   end
 

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -86,8 +86,8 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     end
   rescue
     error ->
-      Logger.warning(
-        "Refactoring #{inspect(refactoring.module)} failed: #{Exception.message(error)}"
+      Logger.error(
+        "refactoring #{inspect(refactoring.module)}: #{Exception.message(error)}: #{Exception.format_stacktrace(error)}"
       )
 
       []

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -9,23 +9,41 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   alias Forge.Refactor
   alias GenLSP.Enumerations
 
+  require Logger
+
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{} = range, _diagnostics) do
+  def actions(%Document{} = doc, %Range{} = range, _diagnostics, opts \\ []) do
     with {:ok, target} <- line_or_selection(doc, range),
          {:ok, ast} <- Sourceror.parse_string(Document.to_string(doc)) do
-      ast
-      |> Sourceror.Zipper.zip()
-      |> Refactor.available_refactorings(target, true)
-      |> Enum.map(fn refactoring ->
-        Forge.CodeAction.new(
-          doc.uri,
-          refactoring.title,
-          refactoring.kind,
-          ast_to_changes(doc, refactoring.refactored)
-        )
-      end)
+      zipper = Sourceror.Zipper.zip(ast)
+      refactorings = Refactor.list(zipper, target)
+
+      if Keyword.get(opts, :defer_edits?, false) do
+        Enum.map(refactorings, &to_deferred_action(doc, range, &1))
+      else
+        Enum.flat_map(refactorings, &execute_eagerly(doc, zipper, target, &1))
+      end
     else
       _ -> []
+    end
+  end
+
+  @doc """
+  Computes the edits for a single refactoring previously listed with `defer_edits?: true`, as
+  part of the `codeAction/resolve` flow.
+
+  Availability is re-checked against the current document. Rewrite crashes intentionally surface
+  to the caller: they fail only this resolve request, and silently dropping them would hide bugs.
+  """
+  @spec resolve(Document.t(), Range.t(), String.t()) :: {:ok, Changes.t()} | :error
+  def resolve(%Document{} = doc, %Range{} = range, module_name) do
+    with {:ok, target} <- line_or_selection(doc, range),
+         {:ok, ast} <- Sourceror.parse_string(Document.to_string(doc)),
+         {:ok, refactoring} <-
+           ast |> Sourceror.Zipper.zip() |> Refactor.execute(target, module_name) do
+      {:ok, ast_to_changes(doc, refactoring.refactored)}
+    else
+      _ -> :error
     end
   end
 
@@ -34,6 +52,48 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
 
   @impl CodeAction.Handler
   def trigger_kind, do: :all
+
+  defp to_deferred_action(%Document{} = doc, %Range{} = range, refactoring) do
+    data = %{
+      "provider" => "refactor",
+      "module" => Atom.to_string(refactoring.module),
+      "uri" => doc.uri,
+      "version" => doc.version,
+      "range" => %{
+        "start" => %{"line" => range.start.line, "character" => range.start.character},
+        "end" => %{"line" => range.end.line, "character" => range.end.character}
+      }
+    }
+
+    Forge.CodeAction.deferred(doc.uri, refactoring.title, refactoring.kind, data)
+  end
+
+  # Eager fallback for clients without codeAction/resolve support. Each
+  # refactoring is isolated: a broken rewrite loses that one action instead
+  # of failing the whole codeAction request.
+  defp execute_eagerly(doc, zipper, target, refactoring) do
+    case Refactor.execute(zipper, target, refactoring.module) do
+      {:ok, executed} ->
+        [
+          Forge.CodeAction.new(
+            doc.uri,
+            executed.title,
+            executed.kind,
+            ast_to_changes(doc, executed.refactored)
+          )
+        ]
+
+      :error ->
+        []
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "Refactoring #{inspect(refactoring.module)} failed: #{Exception.message(error)}"
+      )
+
+      []
+  end
 
   defp line_or_selection(_, %{
          start: %{line: line, character: char},

--- a/apps/engine/lib/engine/code_action/handlers/remove_unused_alias.ex
+++ b/apps/engine/lib/engine/code_action/handlers/remove_unused_alias.ex
@@ -47,7 +47,7 @@ defmodule Engine.CodeAction.Handlers.RemoveUnusedAlias do
 
   defrecordp :single_alias_metadata, [:document, :range]
   @impl CodeAction.Handler
-  def actions(%Document{} = document, %Range{} = range, diagnostics) do
+  def actions(%Document{} = document, %Range{} = range, diagnostics, _opts \\ []) do
     Enum.reduce(diagnostics, [], fn %Diagnostic{} = diagnostic, acc ->
       case to_edit(document, range.start, diagnostic) do
         {:ok, module_name, edit} ->

--- a/apps/engine/lib/engine/code_action/handlers/replace_remote_function.ex
+++ b/apps/engine/lib/engine/code_action/handlers/replace_remote_function.ex
@@ -13,7 +13,7 @@ defmodule Engine.CodeAction.Handlers.ReplaceRemoteFunction do
   alias Sourceror.Zipper
 
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{}, diagnostics) do
+  def actions(%Document{} = doc, %Range{}, diagnostics, _opts \\ []) do
     Enum.flat_map(diagnostics, fn %Diagnostic{} = diagnostic ->
       with {:ok, module, function, arity, line_number} <- extract_function_and_line(diagnostic),
            {:ok, suggestions} <- prepare_suggestions(module, function, arity) do

--- a/apps/engine/lib/engine/code_action/handlers/replace_with_underscore.ex
+++ b/apps/engine/lib/engine/code_action/handlers/replace_with_underscore.ex
@@ -11,7 +11,7 @@ defmodule Engine.CodeAction.Handlers.ReplaceWithUnderscore do
   alias Sourceror.Zipper
 
   @impl CodeAction.Handler
-  def actions(%Document{} = doc, %Range{}, diagnostics) do
+  def actions(%Document{} = doc, %Range{}, diagnostics, _opts \\ []) do
     Enum.reduce(diagnostics, [], fn %Diagnostic{} = diagnostic, acc ->
       with {:ok, variable_name, line_number} <- extract_variable_and_line(diagnostic),
            {:ok, changes} <- to_changes(doc, line_number, variable_name) do

--- a/apps/engine/lib/engine/code_action/handlers/require.ex
+++ b/apps/engine/lib/engine/code_action/handlers/require.ex
@@ -9,7 +9,7 @@ defmodule Engine.CodeAction.Handlers.Require do
   alias GenLSP.Enumerations.CodeActionKind
 
   @impl CodeAction.Handler
-  def actions(document, range, diagnostics) do
+  def actions(document, range, diagnostics, _opts \\ []) do
     with {:ok, _doc, %Analysis{valid?: true} = analysis} <-
            Document.Store.fetch(document.uri, :analysis),
          diagnostic when not is_nil(diagnostic) <-

--- a/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
@@ -135,6 +135,63 @@ defmodule Engine.CodeAction.Handlers.RefactorexTest do
     )
   end
 
+  describe "deferred edits and resolve" do
+    test "defers edits when requested and resolves them to the eager result" do
+      {range, original} =
+        pop_range(~q[
+          def my_«»func(unused) do
+          end
+        ])
+
+      document = Document.new("file:///file.ex", original, 7)
+
+      eager_actions = Refactorex.actions(document, range, [])
+      deferred_actions = Refactorex.actions(document, range, [], defer_edits?: true)
+
+      assert not Enum.empty?(deferred_actions)
+      assert length(deferred_actions) == length(eager_actions)
+
+      for action <- deferred_actions do
+        assert action.changes == nil
+
+        assert %{
+                 "provider" => "refactor",
+                 "module" => "Elixir." <> _,
+                 "uri" => "file:///file.ex",
+                 "version" => 7,
+                 "range" => %{"start" => %{"line" => _, "character" => _}, "end" => _}
+               } = action.data
+      end
+
+      for eager <- eager_actions do
+        deferred = Enum.find(deferred_actions, &(&1.title == eager.title))
+        assert deferred, "no deferred action for #{eager.title}"
+
+        assert {:ok, changes} = Refactorex.resolve(document, range, deferred.data["module"])
+        assert changes.edits == eager.changes.edits
+      end
+    end
+
+    test "resolve rejects unknown and no-longer-applicable refactorings" do
+      {range, original} =
+        pop_range(~q[
+          def my_«»func(unused) do
+          end
+        ])
+
+      document = Document.new("file:///file.ex", original, 0)
+
+      assert :error = Refactorex.resolve(document, range, "Elixir.NotARefactoring")
+
+      assert :error =
+               Refactorex.resolve(
+                 document,
+                 range,
+                 "Elixir.Forge.Refactor.Pipeline.RemovePipe"
+               )
+    end
+  end
+
   describe "line_or_selection field-level comparison" do
     test "detects cursor position when start and end share same line/character but differ in metadata" do
       code = ~q[

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -173,6 +173,12 @@ defmodule Expert do
   end
 
   defp document_request?(%{text_document: %{uri: _}}), do: true
+
+  # codeAction/resolve echoes back a CodeAction whose document uri lives in the data payload.
+  defp document_request?(%Structures.CodeAction{data: %{"uri" => uri}}) when is_binary(uri) do
+    true
+  end
+
   defp document_request?(_), do: false
 
   def handle_notification(%GenLSP.Notifications.Initialized{}, lsp) do

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -174,8 +174,11 @@ defmodule Expert do
 
   defp document_request?(%{text_document: %{uri: _}}), do: true
 
-  # codeAction/resolve echoes back a CodeAction whose document uri lives in the data payload.
-  defp document_request?(%Structures.CodeAction{data: %{"uri" => uri}}) when is_binary(uri) do
+  # These code actions carry a document uri in their data payload, so we treat them as document
+  # requests by virtue of that uri (rather than by strict LSP taxonomy). Matched to the "refactor"
+  # provider for now so other requests are unaffected - can be broadened later if desired.
+  defp document_request?(%Structures.CodeAction{data: %{"provider" => "refactor", "uri" => uri}})
+       when is_binary(uri) do
     true
   end
 

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -524,6 +524,9 @@ defmodule Expert do
       %Requests.TextDocumentCodeAction{} ->
         {:ok, Handlers.CodeAction}
 
+      %Requests.CodeActionResolve{} ->
+        {:ok, Handlers.CodeActionResolve}
+
       %Requests.TextDocumentCodeLens{} ->
         {:ok, Handlers.CodeLens}
 

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -175,8 +175,8 @@ defmodule Expert do
   defp document_request?(%{text_document: %{uri: _}}), do: true
 
   # These code actions carry a document uri in their data payload, so we treat them as document
-  # requests by virtue of that uri (rather than by strict LSP taxonomy). Matched to the "refactor"
-  # provider for now so other requests are unaffected - can be broadened later if desired.
+  # requests by virtue of that uri (rather than by strict LSP taxonomy). Scoped to the "refactor"
+  # provider for now so other requests are unaffected; can be broadened later.
   defp document_request?(%Structures.CodeAction{data: %{"provider" => "refactor", "uri" => uri}})
        when is_binary(uri) do
     true

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -130,14 +130,10 @@ defmodule Expert.Configuration do
   """
   @spec client_resolves_code_action_edits?() :: boolean()
   def client_resolves_code_action_edits? do
-    properties =
-      case client_support(:code_action_resolve) do
-        %{properties: properties} -> properties
-        %{"properties" => properties} -> properties
-        _ -> nil
-      end
-
-    is_list(properties) and "edit" in properties
+    case client_support(:code_action_resolve) do
+      %{properties: properties} when is_list(properties) -> "edit" in properties
+      _ -> false
+    end
   end
 
   @spec log_level() :: lsp_level()

--- a/apps/expert/lib/expert/configuration.ex
+++ b/apps/expert/lib/expert/configuration.ex
@@ -122,6 +122,24 @@ defmodule Expert.Configuration do
     client_support(get().support, key)
   end
 
+  @doc """
+  Whether the client can lazily resolve a code action's `edit` property via `codeAction/resolve`.
+  When true, the server defers computing refactor edits until an action is actually invoked.
+
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#clientCodeActionResolveOptions
+  """
+  @spec client_resolves_code_action_edits?() :: boolean()
+  def client_resolves_code_action_edits? do
+    properties =
+      case client_support(:code_action_resolve) do
+        %{properties: properties} -> properties
+        %{"properties" => properties} -> properties
+        _ -> nil
+      end
+
+    is_list(properties) and "edit" in properties
+  end
+
   @spec log_level() :: lsp_level()
   def log_level do
     get().log_level

--- a/apps/expert/lib/expert/configuration/support.ex
+++ b/apps/expert/lib/expert/configuration/support.ex
@@ -12,6 +12,11 @@ defmodule Expert.Configuration.Support do
       :code_action,
       :dynamic_registration
     ],
+    code_action_resolve: [
+      :text_document,
+      :code_action,
+      :resolve_support
+    ],
     hierarchical_symbols: [
       :text_document,
       :document_symbol,
@@ -50,6 +55,7 @@ defmodule Expert.Configuration.Support do
   ]
 
   defstruct code_action_dynamic_registration: false,
+            code_action_resolve: false,
             hierarchical_symbols: false,
             snippet: false,
             deprecated: false,

--- a/apps/expert/lib/expert/document/lookup.ex
+++ b/apps/expert/lib/expert/document/lookup.ex
@@ -282,7 +282,9 @@ defmodule Expert.Document.Lookup do
   defp extract_uri(%{text_document: %{uri: uri}}) when is_binary(uri), do: uri
   defp extract_uri(%{uri: uri}) when is_binary(uri), do: uri
   defp extract_uri(%{params: params}) when is_map(params), do: extract_uri(params)
-  # codeAction/resolve carries the document uri in the round-tripped data payload.
-  defp extract_uri(%{data: %{"uri" => uri}}) when is_binary(uri), do: uri
+  # These code actions carry a document uri in their data payload rather than a text_document
+  # field (see the note in `Expert.document_request?/1`).
+  defp extract_uri(%{data: %{"provider" => "refactor", "uri" => uri}}) when is_binary(uri),
+    do: uri
   defp extract_uri(_), do: nil
 end

--- a/apps/expert/lib/expert/document/lookup.ex
+++ b/apps/expert/lib/expert/document/lookup.ex
@@ -282,10 +282,6 @@ defmodule Expert.Document.Lookup do
   defp extract_uri(%{text_document: %{uri: uri}}) when is_binary(uri), do: uri
   defp extract_uri(%{uri: uri}) when is_binary(uri), do: uri
   defp extract_uri(%{params: params}) when is_map(params), do: extract_uri(params)
-  # These code actions carry a document uri in their data payload rather than a text_document
-  # field (see the note in `Expert.document_request?/1`).
-  defp extract_uri(%{data: %{"provider" => "refactor", "uri" => uri}}) when is_binary(uri),
-    do: uri
-
+  defp extract_uri(%{data: %{"uri" => uri}}) when is_binary(uri), do: uri
   defp extract_uri(_), do: nil
 end

--- a/apps/expert/lib/expert/document/lookup.ex
+++ b/apps/expert/lib/expert/document/lookup.ex
@@ -286,5 +286,6 @@ defmodule Expert.Document.Lookup do
   # field (see the note in `Expert.document_request?/1`).
   defp extract_uri(%{data: %{"provider" => "refactor", "uri" => uri}}) when is_binary(uri),
     do: uri
+
   defp extract_uri(_), do: nil
 end

--- a/apps/expert/lib/expert/document/lookup.ex
+++ b/apps/expert/lib/expert/document/lookup.ex
@@ -282,5 +282,7 @@ defmodule Expert.Document.Lookup do
   defp extract_uri(%{text_document: %{uri: uri}}) when is_binary(uri), do: uri
   defp extract_uri(%{uri: uri}) when is_binary(uri), do: uri
   defp extract_uri(%{params: params}) when is_map(params), do: extract_uri(params)
+  # codeAction/resolve carries the document uri in the round-tripped data payload.
+  defp extract_uri(%{data: %{"uri" => uri}}) when is_binary(uri), do: uri
   defp extract_uri(_), do: nil
 end

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -59,15 +59,26 @@ defmodule Expert.EngineApi do
         %Range{} = range,
         diagnostics,
         kinds,
-        trigger_kind
+        trigger_kind,
+        opts \\ []
       ) do
     call(project, Engine, :code_actions, [
       document,
       range,
       diagnostics,
       kinds,
-      trigger_kind
+      trigger_kind,
+      opts
     ])
+  end
+
+  def resolve_code_action(
+        %Project{} = project,
+        %Document{} = document,
+        %Range{} = range,
+        module_name
+      ) do
+    call(project, Engine, :resolve_code_action, [document, range, module_name])
   end
 
   def complete(%Project{} = project, %Env{} = env) do

--- a/apps/expert/lib/expert/provider/handlers/code_action.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action.ex
@@ -1,6 +1,7 @@
 defmodule Expert.Provider.Handlers.CodeAction do
   @behaviour Expert.Provider.Handler
 
+  alias Expert.Configuration
   alias Expert.Document.Context
   alias Expert.EngineApi
   alias Forge.CodeAction
@@ -14,6 +15,7 @@ defmodule Expert.Provider.Handlers.CodeAction do
       ) do
     %Context{document: document, project: project} = context
     diagnostics = Enum.map(params.context.diagnostics, &to_code_action_diagnostic/1)
+    defer_edits? = Configuration.client_resolves_code_action_edits?()
 
     code_actions =
       EngineApi.code_actions(
@@ -22,7 +24,8 @@ defmodule Expert.Provider.Handlers.CodeAction do
         params.range,
         diagnostics,
         params.context.only || :all,
-        params.context.trigger_kind
+        params.context.trigger_kind,
+        defer_edits?: defer_edits?
       )
 
     results = Enum.map(code_actions, &to_result/1)
@@ -35,6 +38,16 @@ defmodule Expert.Provider.Handlers.CodeAction do
       range: diagnostic.range,
       message: diagnostic.message,
       source: diagnostic.source
+    }
+  end
+
+  # Deferred action: the edit is computed on codeAction/resolve, identified by the data payload
+  # the client round-trips back to us.
+  defp to_result(%CodeAction{changes: nil, data: data} = action) when not is_nil(data) do
+    %Structures.CodeAction{
+      title: action.title,
+      kind: action.kind,
+      data: data
     }
   end
 

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -76,7 +76,7 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
     end
   end
 
-  # decode_refactor guarantees integer coordinates, but we validate them against
+  # from_refactor_data guarantees integer coordinates, but we validate them against
   # the current document rather than trust them: an out-of-bounds line/character
   # would otherwise crash deep in Document.fragment. Position.new rejects an
   # out-of-range line (valid?: false) but does not check the character against the

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -38,14 +38,15 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
   end
 
   # One of our deferred refactor actions, resolved against the current document.
+  # The payload's field schema is owned by Forge.CodeAction.from_refactor_data/1.
   defp resolve(
          %CodeAction{data: %{"provider" => "refactor"} = data} = action,
          %Context{document: document, project: project}
        ) do
-    with :ok <- check_version(document, data["version"]),
-         {:ok, module_name} <- fetch_module(data),
-         {:ok, range} <- build_range(document, data["range"]),
-         {:ok, changes} <- resolve_changes(project, document, range, module_name) do
+    with {:ok, payload} <- Forge.CodeAction.from_refactor_data(data),
+         :ok <- check_version(document, payload.version),
+         {:ok, range} <- build_range(document, payload.range),
+         {:ok, changes} <- resolve_changes(project, document, range, payload.module) do
       edit = %WorkspaceEdit{changes: %{document.uri => changes}}
       {:ok, %CodeAction{action | edit: edit}}
     end
@@ -60,9 +61,6 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
   defp check_version(%Document{version: version}, version), do: :ok
   defp check_version(_document, _version), do: {:error, :stale_code_action}
 
-  defp fetch_module(%{"module" => module_name}) when is_binary(module_name), do: {:ok, module_name}
-  defp fetch_module(_data), do: {:error, :invalid_data}
-
   defp resolve_changes(project, document, range, module_name) do
     case EngineApi.resolve_code_action(project, document, range, module_name) do
       {:ok, changes} -> {:ok, changes}
@@ -70,23 +68,20 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
     end
   end
 
-  defp build_range(%Document{} = document, %{"start" => start_map, "end" => end_map}) do
-    with {:ok, start_pos} <- build_position(document, start_map),
-         {:ok, end_pos} <- build_position(document, end_map),
+  defp build_range(document, {start_coord, end_coord}) do
+    with {:ok, start_pos} <- build_position(document, start_coord),
+         {:ok, end_pos} <- build_position(document, end_coord),
          :ok <- validate_order(start_pos, end_pos) do
       {:ok, Range.new(start_pos, end_pos)}
     end
   end
 
-  defp build_range(_document, _range), do: {:error, :invalid_range}
-
-  # Coordinates are the client's round-tripped copy of our own payload, but we
-  # validate them against the current document rather than trust them: an
-  # out-of-bounds line/character would otherwise crash deep in Document.fragment.
-  # Position.new rejects an out-of-range line (valid?: false) but does not check
-  # the character against the line's length, so we bound the character here.
-  defp build_position(document, %{"line" => line, "character" => character})
-       when is_integer(line) and is_integer(character) and character >= 1 do
+  # decode_refactor guarantees integer coordinates, but we validate them against
+  # the current document rather than trust them: an out-of-bounds line/character
+  # would otherwise crash deep in Document.fragment. Position.new rejects an
+  # out-of-range line (valid?: false) but does not check the character against the
+  # line's length, so we bound the character here.
+  defp build_position(document, {line, character}) when character >= 1 do
     case Position.new(document, line, character) do
       %Position{valid?: true, context_line: context_line} = position ->
         if character <= line_length(context_line) + 1 do
@@ -100,7 +95,7 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
     end
   end
 
-  defp build_position(_document, _position), do: {:error, :invalid_range}
+  defp build_position(_document, _coord), do: {:error, :invalid_range}
 
   defp validate_order(start_pos, end_pos) do
     case Position.compare(start_pos, end_pos) do
@@ -126,7 +121,7 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
   end
 
   defp error_response(:invalid_data) do
-    invalid_params("The code action was missing required data")
+    invalid_params("The code action carried malformed data")
   end
 
   defp content_modified(message) do

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -37,8 +37,6 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
     end
   end
 
-  # One of our deferred refactor actions, resolved against the current document.
-  # The payload's field schema is owned by Forge.CodeAction.from_refactor_data/1.
   defp resolve(
          %CodeAction{data: %{"provider" => "refactor"} = data} = action,
          %Context{document: document, project: project}

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -1,77 +1,137 @@
 defmodule Expert.Provider.Handlers.CodeActionResolve do
   @moduledoc """
   Resolves the `edit` for a deferred code action produced by
-  `Expert.Provider.Handlers.CodeAction` when the client supports
-  `codeAction/resolve`.
+  `Expert.Provider.Handlers.CodeAction` when the client supports `codeAction/resolve`.
 
-  The action's `data` payload identifies the document (uri and version), the
-  original request range, and the refactoring to execute. Edits are computed
-  against the current document; if the document has changed since the action
-  was listed, the resolve is rejected and the client is expected to request
-  code actions again.
+  The action's `data` payload identifies the document (uri and version), the original request
+  range, and the refactoring to execute. The request is routed through the standard
+  document-request pipeline (via the `data` uri), so by the time it reaches this handler the
+  engine is known to be ready and `context` holds the current document and its project.
+
+  Edits are computed against the current document. If the document changed since the action was
+  listed, or the refactoring no longer applies, the resolve is rejected with `ContentModified`.
+
+  A code action that isn't one of ours is echoed back unchanged.
   """
   @behaviour Expert.Provider.Handler
 
-  alias Expert.Document.Lookup
+  alias Expert.Document.Context
   alias Expert.EngineApi
-  alias Expert.Project.Store
   alias Forge.Document
+  alias Forge.Document.Line
   alias Forge.Document.Position
   alias Forge.Document.Range
-  alias GenLSP.Requests
-  alias GenLSP.Structures
+  alias GenLSP.Enumerations.ErrorCodes
+  alias GenLSP.Enumerations.LSPErrorCodes
+  alias GenLSP.Requests.CodeActionResolve
+  alias GenLSP.Structures.CodeAction
+  alias GenLSP.Structures.WorkspaceEdit
+
+  require Line
 
   @impl Expert.Provider.Handler
-  def handle(%Requests.CodeActionResolve{params: %Structures.CodeAction{} = action}, _context) do
-    with {:ok, data} <- fetch_data(action),
-         {:ok, context} <- fetch_context(data["uri"]),
-         :ok <- check_version(context.document, data["version"]),
-         {:ok, range} <- build_range(context.document, data["range"]),
-         {:ok, changes} <-
-           resolve_changes(context.project, context.document, range, data["module"]) do
-      edit = %Structures.WorkspaceEdit{changes: %{context.document.uri => changes}}
-      {:ok, %Structures.CodeAction{action | edit: edit}}
+  def handle(%CodeActionResolve{params: %CodeAction{} = action}, context) do
+    case resolve(action, context) do
+      {:ok, %CodeAction{} = resolved} -> {:ok, resolved}
+      {:error, reason} -> {:ok, error_response(reason)}
     end
   end
 
-  defp fetch_data(%Structures.CodeAction{data: %{"provider" => "refactor"} = data}) do
-    {:ok, data}
+  # One of our deferred refactor actions, resolved against the current document.
+  defp resolve(
+         %CodeAction{data: %{"provider" => "refactor"} = data} = action,
+         %Context{document: document, project: project}
+       ) do
+    with :ok <- check_version(document, data["version"]),
+         {:ok, module_name} <- fetch_module(data),
+         {:ok, range} <- build_range(document, data["range"]),
+         {:ok, changes} <- resolve_changes(project, document, range, module_name) do
+      edit = %WorkspaceEdit{changes: %{document.uri => changes}}
+      {:ok, %CodeAction{action | edit: edit}}
+    end
   end
 
-  defp fetch_data(_action), do: {:error, :not_resolvable}
-
-  defp fetch_context(uri) when is_binary(uri) do
-    {:ok, Lookup.resolve(uri, Store.projects())}
+  # Not one of our deferred actions (or no document context) — per LSP, echo the
+  # action back unchanged when there is nothing to resolve.
+  defp resolve(%CodeAction{} = action, _context) do
+    {:ok, action}
   end
-
-  defp fetch_context(_uri), do: {:error, :invalid_uri}
 
   defp check_version(%Document{version: version}, version), do: :ok
   defp check_version(_document, _version), do: {:error, :stale_code_action}
 
-  defp resolve_changes(project, document, range, module_name) when is_binary(module_name) do
+  defp fetch_module(%{"module" => module_name}) when is_binary(module_name), do: {:ok, module_name}
+  defp fetch_module(_data), do: {:error, :invalid_data}
+
+  defp resolve_changes(project, document, range, module_name) do
     case EngineApi.resolve_code_action(project, document, range, module_name) do
       {:ok, changes} -> {:ok, changes}
       _ -> {:error, :refactoring_no_longer_available}
     end
   end
 
-  defp resolve_changes(_project, _document, _range, _module_name),
-    do: {:error, :invalid_module}
-
-  defp build_range(%Document{} = document, %{"start" => start_pos, "end" => end_pos}) do
-    with {:ok, start_position} <- build_position(document, start_pos),
-         {:ok, end_position} <- build_position(document, end_pos) do
-      {:ok, Range.new(start_position, end_position)}
+  defp build_range(%Document{} = document, %{"start" => start_map, "end" => end_map}) do
+    with {:ok, start_pos} <- build_position(document, start_map),
+         {:ok, end_pos} <- build_position(document, end_map),
+         :ok <- validate_order(start_pos, end_pos) do
+      {:ok, Range.new(start_pos, end_pos)}
     end
   end
 
   defp build_range(_document, _range), do: {:error, :invalid_range}
 
+  # Coordinates are the client's round-tripped copy of our own payload, but we
+  # validate them against the current document rather than trust them: an
+  # out-of-bounds line/character would otherwise crash deep in Document.fragment.
   defp build_position(document, %{"line" => line, "character" => character})
-       when is_integer(line) and is_integer(character) do
-    {:ok, Position.new(document, line, character)}
+       when is_integer(line) and is_integer(character) and line >= 1 and character >= 1 do
+    case Position.new(document, line, character) do
+      %Position{valid?: true, context_line: context_line} = position ->
+        if character <= line_length(context_line) + 1 do
+          {:ok, position}
+        else
+          {:error, :invalid_range}
+        end
+
+      _ ->
+        {:error, :invalid_range}
+    end
   end
 
   defp build_position(_document, _position), do: {:error, :invalid_range}
+
+  defp validate_order(start_pos, end_pos) do
+    case Position.compare(start_pos, end_pos) do
+      :gt -> {:error, :invalid_range}
+      _ -> :ok
+    end
+  end
+
+  defp line_length(context_line) do
+    context_line |> Line.line(:text) |> String.length()
+  end
+
+  defp error_response(:stale_code_action) do
+    content_modified("The document changed after the code action was requested")
+  end
+
+  defp error_response(:refactoring_no_longer_available) do
+    content_modified("The refactoring no longer applies to the document")
+  end
+
+  defp error_response(:invalid_range) do
+    invalid_params("The code action targeted an invalid range")
+  end
+
+  defp error_response(:invalid_data) do
+    invalid_params("The code action was missing required data")
+  end
+
+  defp content_modified(message) do
+    %GenLSP.ErrorResponse{code: LSPErrorCodes.content_modified(), message: message}
+  end
+
+  defp invalid_params(message) do
+    %GenLSP.ErrorResponse{code: ErrorCodes.invalid_params(), message: message}
+  end
 end

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -83,8 +83,10 @@ defmodule Expert.Provider.Handlers.CodeActionResolve do
   # Coordinates are the client's round-tripped copy of our own payload, but we
   # validate them against the current document rather than trust them: an
   # out-of-bounds line/character would otherwise crash deep in Document.fragment.
+  # Position.new rejects an out-of-range line (valid?: false) but does not check
+  # the character against the line's length, so we bound the character here.
   defp build_position(document, %{"line" => line, "character" => character})
-       when is_integer(line) and is_integer(character) and line >= 1 and character >= 1 do
+       when is_integer(line) and is_integer(character) and character >= 1 do
     case Position.new(document, line, character) do
       %Position{valid?: true, context_line: context_line} = position ->
         if character <= line_length(context_line) + 1 do

--- a/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
+++ b/apps/expert/lib/expert/provider/handlers/code_action_resolve.ex
@@ -1,0 +1,77 @@
+defmodule Expert.Provider.Handlers.CodeActionResolve do
+  @moduledoc """
+  Resolves the `edit` for a deferred code action produced by
+  `Expert.Provider.Handlers.CodeAction` when the client supports
+  `codeAction/resolve`.
+
+  The action's `data` payload identifies the document (uri and version), the
+  original request range, and the refactoring to execute. Edits are computed
+  against the current document; if the document has changed since the action
+  was listed, the resolve is rejected and the client is expected to request
+  code actions again.
+  """
+  @behaviour Expert.Provider.Handler
+
+  alias Expert.Document.Lookup
+  alias Expert.EngineApi
+  alias Expert.Project.Store
+  alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  @impl Expert.Provider.Handler
+  def handle(%Requests.CodeActionResolve{params: %Structures.CodeAction{} = action}, _context) do
+    with {:ok, data} <- fetch_data(action),
+         {:ok, context} <- fetch_context(data["uri"]),
+         :ok <- check_version(context.document, data["version"]),
+         {:ok, range} <- build_range(context.document, data["range"]),
+         {:ok, changes} <-
+           resolve_changes(context.project, context.document, range, data["module"]) do
+      edit = %Structures.WorkspaceEdit{changes: %{context.document.uri => changes}}
+      {:ok, %Structures.CodeAction{action | edit: edit}}
+    end
+  end
+
+  defp fetch_data(%Structures.CodeAction{data: %{"provider" => "refactor"} = data}) do
+    {:ok, data}
+  end
+
+  defp fetch_data(_action), do: {:error, :not_resolvable}
+
+  defp fetch_context(uri) when is_binary(uri) do
+    {:ok, Lookup.resolve(uri, Store.projects())}
+  end
+
+  defp fetch_context(_uri), do: {:error, :invalid_uri}
+
+  defp check_version(%Document{version: version}, version), do: :ok
+  defp check_version(_document, _version), do: {:error, :stale_code_action}
+
+  defp resolve_changes(project, document, range, module_name) when is_binary(module_name) do
+    case EngineApi.resolve_code_action(project, document, range, module_name) do
+      {:ok, changes} -> {:ok, changes}
+      _ -> {:error, :refactoring_no_longer_available}
+    end
+  end
+
+  defp resolve_changes(_project, _document, _range, _module_name),
+    do: {:error, :invalid_module}
+
+  defp build_range(%Document{} = document, %{"start" => start_pos, "end" => end_pos}) do
+    with {:ok, start_position} <- build_position(document, start_pos),
+         {:ok, end_position} <- build_position(document, end_pos) do
+      {:ok, Range.new(start_position, end_position)}
+    end
+  end
+
+  defp build_range(_document, _range), do: {:error, :invalid_range}
+
+  defp build_position(document, %{"line" => line, "character" => character})
+       when is_integer(line) and is_integer(character) do
+    {:ok, Position.new(document, line, character)}
+  end
+
+  defp build_position(_document, _position), do: {:error, :invalid_range}
+end

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -389,7 +389,7 @@ defmodule Expert.State do
     code_action_options =
       %GenLSP.Structures.CodeActionOptions{
         code_action_kinds: @supported_code_actions,
-        resolve_provider: false
+        resolve_provider: Configuration.client_resolves_code_action_edits?()
       }
 
     code_lens_options =

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -231,6 +231,44 @@ defmodule Expert.ConfigurationTest do
     end
   end
 
+  describe "client_resolves_code_action_edits?/0" do
+    defp set_config_with_resolve_support(resolve_support) do
+      capabilities = %GenLSP.Structures.ClientCapabilities{
+        text_document: %GenLSP.Structures.TextDocumentClientCapabilities{
+          code_action: %GenLSP.Structures.CodeActionClientCapabilities{
+            resolve_support: resolve_support
+          }
+        }
+      }
+
+      capabilities
+      |> Configuration.new("test-client")
+      |> Configuration.set()
+    end
+
+    test "true when the client can resolve the edit property" do
+      set_config_with_resolve_support(%{properties: ["edit"]})
+
+      assert Configuration.client_resolves_code_action_edits?()
+    end
+
+    test "false when the client resolves other properties only" do
+      set_config_with_resolve_support(%{properties: ["command"]})
+
+      refute Configuration.client_resolves_code_action_edits?()
+    end
+
+    test "false when the client declares no resolve support" do
+      set_config_with_resolve_support(nil)
+
+      refute Configuration.client_resolves_code_action_edits?()
+    end
+
+    test "false with default configuration" do
+      refute Configuration.client_resolves_code_action_edits?()
+    end
+  end
+
   describe "on_change/1 with workspace_symbols.min_query_length" do
     test "parses nested setting correctly" do
       settings = %{"workspaceSymbols" => %{"minQueryLength" => 0}}

--- a/apps/expert/test/expert/configuration_test.exs
+++ b/apps/expert/test/expert/configuration_test.exs
@@ -1,6 +1,8 @@
 defmodule Expert.ConfigurationTest do
   use ExUnit.Case, async: false
 
+  import Expert.Test.ConfigurationSupport
+
   alias Expert.Configuration
   alias Expert.Configuration.WorkspaceSymbols
   alias GenLSP.Notifications.WorkspaceDidChangeConfiguration
@@ -232,34 +234,20 @@ defmodule Expert.ConfigurationTest do
   end
 
   describe "client_resolves_code_action_edits?/0" do
-    defp set_config_with_resolve_support(resolve_support) do
-      capabilities = %GenLSP.Structures.ClientCapabilities{
-        text_document: %GenLSP.Structures.TextDocumentClientCapabilities{
-          code_action: %GenLSP.Structures.CodeActionClientCapabilities{
-            resolve_support: resolve_support
-          }
-        }
-      }
-
-      capabilities
-      |> Configuration.new("test-client")
-      |> Configuration.set()
-    end
-
     test "true when the client can resolve the edit property" do
-      set_config_with_resolve_support(%{properties: ["edit"]})
+      put_resolve_support(%{properties: ["edit"]})
 
       assert Configuration.client_resolves_code_action_edits?()
     end
 
     test "false when the client resolves other properties only" do
-      set_config_with_resolve_support(%{properties: ["command"]})
+      put_resolve_support(%{properties: ["command"]})
 
       refute Configuration.client_resolves_code_action_edits?()
     end
 
     test "false when the client declares no resolve support" do
-      set_config_with_resolve_support(nil)
+      put_resolve_support(nil)
 
       refute Configuration.client_resolves_code_action_edits?()
     end

--- a/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
@@ -1,29 +1,34 @@
 defmodule Expert.Provider.Handlers.CodeActionResolveTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
+  alias Expert.Document.Context
   alias Expert.Provider.Handlers
   alias Forge.Document
+  alias Forge.Project
+  alias GenLSP.Enumerations.ErrorCodes
+  alias GenLSP.Enumerations.LSPErrorCodes
   alias GenLSP.Requests.CodeActionResolve
   alias GenLSP.Structures
 
-  setup do
-    start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
-    start_supervised!({Expert.Project.Store, []})
-    Expert.Project.Store.set_projects([])
-    :ok
+  @uri "file:///resolve_test.ex"
+  @text "arg1\n|> foo()\n"
+
+  defp context(version) do
+    document = Document.new(@uri, @text, version)
+    Context.new(@uri, document, Project.new("file:///project"))
   end
 
   defp resolve_request(action) do
     %CodeActionResolve{id: 1, params: action}
   end
 
-  defp deferred_action(uri, data_overrides) do
+  defp deferred_action(data_overrides) do
     data =
       Map.merge(
         %{
           "provider" => "refactor",
           "module" => "Elixir.Forge.Refactor.Pipeline.IntroducePipe",
-          "uri" => uri,
+          "uri" => @uri,
           "version" => 1,
           "range" => %{
             "start" => %{"line" => 1, "character" => 1},
@@ -36,37 +41,96 @@ defmodule Expert.Provider.Handlers.CodeActionResolveTest do
     %Structures.CodeAction{title: "Introduce pipe", kind: "refactor.rewrite", data: data}
   end
 
-  test "rejects actions without a resolvable data payload" do
-    action = %Structures.CodeAction{title: "Some action", data: nil}
-
-    assert {:error, :not_resolvable} =
-             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+  defp handle(action, context) do
+    Handlers.CodeActionResolve.handle(resolve_request(action), context)
   end
 
-  test "rejects payloads without a document uri" do
-    action = deferred_action(nil, %{"uri" => nil})
+  describe "stale documents" do
+    test "rejects with ContentModified when the document version has moved on" do
+      action = deferred_action(%{"version" => 1})
 
-    assert {:error, :invalid_uri} =
-             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+      assert {:ok, %GenLSP.ErrorResponse{code: code, message: message}} =
+               handle(action, context(2))
+
+      assert code == LSPErrorCodes.content_modified()
+      assert message =~ "changed"
+    end
   end
 
-  test "rejects resolve when the document version has moved on" do
-    uri = "file:///stale_resolve_test.ex"
-    :ok = Document.Store.open(uri, "x |> foo()\n", 3, "elixir")
+  describe "malformed payloads" do
+    test "rejects a non-integer range with InvalidParams" do
+      action = deferred_action(%{"version" => 1, "range" => %{"start" => "wat"}})
 
-    action = deferred_action(uri, %{"version" => 2})
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} = handle(action, context(1))
+      assert code == ErrorCodes.invalid_params()
+    end
 
-    assert {:error, :stale_code_action} =
-             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+    test "rejects an out-of-bounds line with InvalidParams" do
+      action =
+        deferred_action(%{
+          "version" => 1,
+          "range" => %{
+            "start" => %{"line" => 9999, "character" => 1},
+            "end" => %{"line" => 9999, "character" => 1}
+          }
+        })
+
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} = handle(action, context(1))
+      assert code == ErrorCodes.invalid_params()
+    end
+
+    test "rejects an out-of-bounds character with InvalidParams" do
+      # line 1 is "arg1" (4 chars); character 9999 is past its end
+      action =
+        deferred_action(%{
+          "version" => 1,
+          "range" => %{
+            "start" => %{"line" => 1, "character" => 9999},
+            "end" => %{"line" => 2, "character" => 1}
+          }
+        })
+
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} = handle(action, context(1))
+      assert code == ErrorCodes.invalid_params()
+    end
+
+    test "rejects a reversed range with InvalidParams" do
+      action =
+        deferred_action(%{
+          "version" => 1,
+          "range" => %{
+            "start" => %{"line" => 2, "character" => 1},
+            "end" => %{"line" => 1, "character" => 1}
+          }
+        })
+
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} = handle(action, context(1))
+      assert code == ErrorCodes.invalid_params()
+    end
+
+    test "rejects a missing module with InvalidParams" do
+      action = deferred_action(%{"version" => 1, "module" => nil})
+
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} = handle(action, context(1))
+      assert code == ErrorCodes.invalid_params()
+    end
   end
 
-  test "rejects payloads with a malformed range" do
-    uri = "file:///bad_range_resolve_test.ex"
-    :ok = Document.Store.open(uri, "x |> foo()\n", 1, "elixir")
+  describe "actions that are not ours" do
+    test "echoes back an action without a resolvable data payload" do
+      action = %Structures.CodeAction{title: "Some other action", data: nil}
 
-    action = deferred_action(uri, %{"range" => %{"start" => "wat"}})
+      assert {:ok, ^action} = handle(action, nil)
+    end
 
-    assert {:error, :invalid_range} =
-             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+    test "echoes back a foreign action carrying inline edits" do
+      action = %Structures.CodeAction{
+        title: "Quick fix",
+        edit: %Structures.WorkspaceEdit{changes: %{}},
+        data: %{"provider" => "something-else"}
+      }
+
+      assert {:ok, ^action} = handle(action, nil)
+    end
   end
 end

--- a/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
@@ -4,6 +4,8 @@ defmodule Expert.Provider.Handlers.CodeActionResolveTest do
   alias Expert.Document.Context
   alias Expert.Provider.Handlers
   alias Forge.Document
+  alias Forge.Document.Position
+  alias Forge.Document.Range
   alias Forge.Project
   alias GenLSP.Enumerations.ErrorCodes
   alias GenLSP.Enumerations.LSPErrorCodes
@@ -12,6 +14,7 @@ defmodule Expert.Provider.Handlers.CodeActionResolveTest do
 
   @uri "file:///resolve_test.ex"
   @text "arg1\n|> foo()\n"
+  @module Forge.Refactor.Pipeline.IntroducePipe
 
   defp context(version) do
     document = Document.new(@uri, @text, version)
@@ -22,21 +25,12 @@ defmodule Expert.Provider.Handlers.CodeActionResolveTest do
     %CodeActionResolve{id: 1, params: action}
   end
 
+  # The valid base payload is built through the real encoder so it can't drift
+  # from the schema; malformed cases override individual keys with raw values.
   defp deferred_action(data_overrides) do
-    data =
-      Map.merge(
-        %{
-          "provider" => "refactor",
-          "module" => "Elixir.Forge.Refactor.Pipeline.IntroducePipe",
-          "uri" => @uri,
-          "version" => 1,
-          "range" => %{
-            "start" => %{"line" => 1, "character" => 1},
-            "end" => %{"line" => 1, "character" => 1}
-          }
-        },
-        data_overrides
-      )
+    range = Range.new(%Position{line: 1, character: 1}, %Position{line: 1, character: 1})
+    base = Forge.CodeAction.to_refactor_data(@uri, 1, range, @module)
+    data = Map.merge(base, data_overrides)
 
     %Structures.CodeAction{title: "Introduce pipe", kind: "refactor.rewrite", data: data}
   end
@@ -123,14 +117,14 @@ defmodule Expert.Provider.Handlers.CodeActionResolveTest do
       assert {:ok, ^action} = handle(action, nil)
     end
 
-    test "echoes back a foreign action carrying inline edits" do
+    test "echoes back a foreign action even when a document context is present" do
       action = %Structures.CodeAction{
         title: "Quick fix",
         edit: %Structures.WorkspaceEdit{changes: %{}},
         data: %{"provider" => "something-else"}
       }
 
-      assert {:ok, ^action} = handle(action, nil)
+      assert {:ok, ^action} = handle(action, context(1))
     end
   end
 end

--- a/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_resolve_test.exs
@@ -1,0 +1,72 @@
+defmodule Expert.Provider.Handlers.CodeActionResolveTest do
+  use ExUnit.Case, async: false
+
+  alias Expert.Provider.Handlers
+  alias Forge.Document
+  alias GenLSP.Requests.CodeActionResolve
+  alias GenLSP.Structures
+
+  setup do
+    start_supervised!({Document.Store, derive: [analysis: &Forge.Ast.analyze/1]})
+    start_supervised!({Expert.Project.Store, []})
+    Expert.Project.Store.set_projects([])
+    :ok
+  end
+
+  defp resolve_request(action) do
+    %CodeActionResolve{id: 1, params: action}
+  end
+
+  defp deferred_action(uri, data_overrides) do
+    data =
+      Map.merge(
+        %{
+          "provider" => "refactor",
+          "module" => "Elixir.Forge.Refactor.Pipeline.IntroducePipe",
+          "uri" => uri,
+          "version" => 1,
+          "range" => %{
+            "start" => %{"line" => 1, "character" => 1},
+            "end" => %{"line" => 1, "character" => 1}
+          }
+        },
+        data_overrides
+      )
+
+    %Structures.CodeAction{title: "Introduce pipe", kind: "refactor.rewrite", data: data}
+  end
+
+  test "rejects actions without a resolvable data payload" do
+    action = %Structures.CodeAction{title: "Some action", data: nil}
+
+    assert {:error, :not_resolvable} =
+             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+  end
+
+  test "rejects payloads without a document uri" do
+    action = deferred_action(nil, %{"uri" => nil})
+
+    assert {:error, :invalid_uri} =
+             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+  end
+
+  test "rejects resolve when the document version has moved on" do
+    uri = "file:///stale_resolve_test.ex"
+    :ok = Document.Store.open(uri, "x |> foo()\n", 3, "elixir")
+
+    action = deferred_action(uri, %{"version" => 2})
+
+    assert {:error, :stale_code_action} =
+             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+  end
+
+  test "rejects payloads with a malformed range" do
+    uri = "file:///bad_range_resolve_test.ex"
+    :ok = Document.Store.open(uri, "x |> foo()\n", 1, "elixir")
+
+    action = deferred_action(uri, %{"range" => %{"start" => "wat"}})
+
+    assert {:error, :invalid_range} =
+             Handlers.CodeActionResolve.handle(resolve_request(action), nil)
+  end
+end

--- a/apps/expert/test/expert/provider/handlers/code_action_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_test.exs
@@ -143,10 +143,12 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
         params: action
       }
 
-      assert {:ok, %Structures.CodeAction{} = resolved} =
-               Handlers.CodeActionResolve.handle(resolve_request, nil)
-
       uri = action.data["uri"]
+      {:ok, document} = Document.Store.fetch(uri)
+      context = Context.new(uri, document, project)
+
+      assert {:ok, %Structures.CodeAction{} = resolved} =
+               Handlers.CodeActionResolve.handle(resolve_request, context)
 
       assert %Structures.WorkspaceEdit{changes: %{^uri => %Document.Changes{edits: edits}}} =
                resolved.edit
@@ -186,8 +188,14 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
         params: stale_action
       }
 
-      assert {:error, :stale_code_action} =
-               Handlers.CodeActionResolve.handle(resolve_request, nil)
+      uri = action.data["uri"]
+      {:ok, document} = Document.Store.fetch(uri)
+      context = Context.new(uri, document, project)
+
+      assert {:ok, %GenLSP.ErrorResponse{code: code}} =
+               Handlers.CodeActionResolve.handle(resolve_request, context)
+
+      assert code == GenLSP.Enumerations.LSPErrorCodes.content_modified()
     end
   end
 end

--- a/apps/expert/test/expert/provider/handlers/code_action_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_test.exs
@@ -100,4 +100,94 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
       assert {:ok, _actions} = handle(request, project)
     end
   end
+
+  describe "codeAction/resolve" do
+    defp set_resolve_capable_configuration do
+      capabilities = %Structures.ClientCapabilities{
+        text_document: %Structures.TextDocumentClientCapabilities{
+          code_action: %Structures.CodeActionClientCapabilities{
+            resolve_support: %{properties: ["edit"]}
+          }
+        }
+      }
+
+      capabilities
+      |> Expert.Configuration.new("test-client")
+      |> Expert.Configuration.set()
+    end
+
+    defp deferred_refactors(actions) do
+      Enum.filter(
+        actions,
+        &match?(%Structures.CodeAction{data: %{"provider" => "refactor"}}, &1)
+      )
+    end
+
+    test "defers refactor edits and resolves them on demand", %{project: project} do
+      set_resolve_capable_configuration()
+
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, {4, 4}, {4, 4})
+
+      assert {:ok, actions} = handle(request, project)
+
+      deferred = deferred_refactors(actions)
+
+      assert deferred != []
+      assert Enum.all?(deferred, &is_nil(&1.edit))
+
+      action = Enum.find(deferred, &(&1.title == "Introduce pipe")) || hd(deferred)
+
+      resolve_request = %GenLSP.Requests.CodeActionResolve{
+        id: Expert.Protocol.Id.next(),
+        params: action
+      }
+
+      assert {:ok, %Structures.CodeAction{} = resolved} =
+               Handlers.CodeActionResolve.handle(resolve_request, nil)
+
+      uri = action.data["uri"]
+
+      assert %Structures.WorkspaceEdit{changes: %{^uri => %Document.Changes{edits: edits}}} =
+               resolved.edit
+
+      assert edits != []
+    end
+
+    test "keeps eager edits for clients without resolve support", %{project: project} do
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, {4, 4}, {4, 4})
+
+      assert {:ok, actions} = handle(request, project)
+
+      refactors = Enum.filter(actions, &(&1.kind == "refactor.rewrite"))
+
+      assert refactors != []
+      assert Enum.all?(refactors, &(not is_nil(&1.edit)))
+      assert Enum.all?(actions, &is_nil(&1.data))
+    end
+
+    test "rejects resolve for a stale document version", %{project: project} do
+      set_resolve_capable_configuration()
+
+      uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
+      {:ok, request} = build_request(uses_file_path, {4, 4}, {4, 4})
+
+      assert {:ok, actions} = handle(request, project)
+      assert [%Structures.CodeAction{} = action | _] = deferred_refactors(actions)
+
+      stale_action = %Structures.CodeAction{
+        action
+        | data: Map.update!(action.data, "version", &(&1 + 1))
+      }
+
+      resolve_request = %GenLSP.Requests.CodeActionResolve{
+        id: Expert.Protocol.Id.next(),
+        params: stale_action
+      }
+
+      assert {:error, :stale_code_action} =
+               Handlers.CodeActionResolve.handle(resolve_request, nil)
+    end
+  end
 end

--- a/apps/expert/test/expert/provider/handlers/code_action_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_test.exs
@@ -1,6 +1,7 @@
 defmodule Expert.Provider.Handlers.CodeActionTest do
   use ExUnit.Case, async: false
 
+  import Expert.Test.ConfigurationSupport
   import Forge.EngineApi.Messages
   import Forge.Test.Fixtures
 
@@ -102,20 +103,6 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
   end
 
   describe "codeAction/resolve" do
-    defp set_resolve_capable_configuration do
-      capabilities = %Structures.ClientCapabilities{
-        text_document: %Structures.TextDocumentClientCapabilities{
-          code_action: %Structures.CodeActionClientCapabilities{
-            resolve_support: %{properties: ["edit"]}
-          }
-        }
-      }
-
-      capabilities
-      |> Expert.Configuration.new("test-client")
-      |> Expert.Configuration.set()
-    end
-
     defp deferred_refactors(actions) do
       Enum.filter(
         actions,
@@ -124,7 +111,7 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
     end
 
     test "defers refactor edits and resolves them on demand", %{project: project} do
-      set_resolve_capable_configuration()
+      put_resolve_support(%{properties: ["edit"]})
 
       uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
       {:ok, request} = build_request(uses_file_path, {4, 4}, {4, 4})
@@ -170,7 +157,7 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
     end
 
     test "rejects resolve for a stale document version", %{project: project} do
-      set_resolve_capable_configuration()
+      put_resolve_support(%{properties: ["edit"]})
 
       uses_file_path = file_path(project, Path.join("lib", "uses.ex"))
       {:ok, request} = build_request(uses_file_path, {4, 4}, {4, 4})

--- a/apps/expert/test/expert/provider/handlers/code_action_test.exs
+++ b/apps/expert/test/expert/provider/handlers/code_action_test.exs
@@ -110,6 +110,16 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
       )
     end
 
+    # build_request opens the document temporarily; on a slow runner that window
+    # can lapse during handle/2's engine round-trip, unloading it before we build
+    # the resolve context. Re-acquire it (open_temporary returns the still-open
+    # doc or re-opens it at the same version) so the context holds a live document
+    # regardless of the store's temporary lifecycle.
+    defp resolve_document(uri) do
+      {:ok, document} = Document.Store.open_temporary(uri)
+      document
+    end
+
     test "defers refactor edits and resolves them on demand", %{project: project} do
       put_resolve_support(%{properties: ["edit"]})
 
@@ -131,8 +141,7 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
       }
 
       uri = action.data["uri"]
-      {:ok, document} = Document.Store.fetch(uri)
-      context = Context.new(uri, document, project)
+      context = Context.new(uri, resolve_document(uri), project)
 
       assert {:ok, %Structures.CodeAction{} = resolved} =
                Handlers.CodeActionResolve.handle(resolve_request, context)
@@ -176,8 +185,7 @@ defmodule Expert.Provider.Handlers.CodeActionTest do
       }
 
       uri = action.data["uri"]
-      {:ok, document} = Document.Store.fetch(uri)
-      context = Context.new(uri, document, project)
+      context = Context.new(uri, resolve_document(uri), project)
 
       assert {:ok, %GenLSP.ErrorResponse{code: code}} =
                Handlers.CodeActionResolve.handle(resolve_request, context)

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -320,6 +320,38 @@ defmodule Expert.ExpertTest do
     assert code == GenLSP.Enumerations.ErrorCodes.invalid_request()
   end
 
+  test "codeAction/resolve for a foreign action is echoed back, not routed as a document request" do
+    project = Fixtures.project()
+    lsp = initialize_lsp(project)
+
+    Expert.Project.Store.add_projects([project])
+    Expert.Project.Store.transition(project, :ready)
+
+    # A code action from some other provider, carrying a uri for a document that
+    # is not open. It must not be treated as a document request (which would fail
+    # with "Document could not be loaded"); the resolve handler echoes it back.
+    uri =
+      project
+      |> Forge.Project.root_path()
+      |> Path.join("lib/not_open.ex")
+      |> Forge.Document.Path.to_uri()
+
+    action = %GenLSP.Structures.CodeAction{
+      title: "Some other action",
+      data: %{"provider" => "something-else", "uri" => uri}
+    }
+
+    request = %GenLSP.Requests.CodeActionResolve{
+      id: 1,
+      jsonrpc: "2.0",
+      method: "codeAction/resolve",
+      params: action
+    }
+
+    assert {:reply, %GenLSP.Structures.CodeAction{title: "Some other action"}, ^lsp} =
+             Expert.handle_request(request, lsp)
+  end
+
   test "document request conversion uses the resolved context document as fallback" do
     project = Fixtures.project()
     lsp = initialize_lsp(project)

--- a/apps/expert/test/expert_test.exs
+++ b/apps/expert/test/expert_test.exs
@@ -380,7 +380,8 @@ defmodule Expert.ExpertTest do
       %Document.Range{} = native_range,
       [%CodeAction.Diagnostic{range: %Document.Range{}}] = diagnostics,
       :all,
-      1 ->
+      1,
+      _opts ->
         send(test_pid, {:code_actions, native_range, diagnostics})
         []
     end)

--- a/apps/expert/test/support/test/configuration_support.ex
+++ b/apps/expert/test/support/test/configuration_support.ex
@@ -1,0 +1,24 @@
+defmodule Expert.Test.ConfigurationSupport do
+  @moduledoc false
+
+  alias Expert.Configuration
+  alias GenLSP.Structures.ClientCapabilities
+  alias GenLSP.Structures.CodeActionClientCapabilities
+  alias GenLSP.Structures.TextDocumentClientCapabilities
+
+  @doc """
+  Installs a client configuration whose `textDocument.codeAction.resolveSupport` is
+  `resolve_support`, returning the stored configuration.
+  """
+  def put_resolve_support(resolve_support) do
+    %ClientCapabilities{
+      text_document: %TextDocumentClientCapabilities{
+        code_action: %CodeActionClientCapabilities{
+          resolve_support: resolve_support
+        }
+      }
+    }
+    |> Configuration.new("test-client")
+    |> Configuration.set()
+  end
+end

--- a/apps/forge/lib/forge/code_action.ex
+++ b/apps/forge/lib/forge/code_action.ex
@@ -1,5 +1,7 @@
 defmodule Forge.CodeAction do
   alias Forge.Document.Changes
+  alias Forge.Document.Position
+  alias Forge.Document.Range
 
   defstruct [:title, :kind, :changes, :uri, :data]
 
@@ -14,6 +16,18 @@ defmodule Forge.CodeAction do
   """
   @type data :: %{optional(String.t()) => term()}
 
+  @typedoc """
+  A deferred refactor payload parsed from its round-tripped `data`. Coordinates are the raw
+  one-based line/character integers from the original request; the caller validates them against
+  the current document.
+  """
+  @type refactor_data :: %{
+          module: String.t(),
+          uri: Forge.uri(),
+          version: non_neg_integer(),
+          range: {{integer(), integer()}, {integer(), integer()}}
+        }
+
   @type t :: %__MODULE__{
           title: String.t(),
           kind: code_action_kind,
@@ -21,6 +35,12 @@ defmodule Forge.CodeAction do
           uri: Forge.uri(),
           data: data() | nil
         }
+
+  # Marks a deferred action owned by the refactor resolver. Callers routing the
+  # request head-match this tag directly; this module owns the *payload* schema
+  # (the field set and range structure) so those aren't spelled out in more than
+  # one place.
+  @refactor_provider "refactor"
 
   @spec new(Forge.uri(), String.t(), code_action_kind(), Changes.t()) :: t()
   def new(uri, title, kind, changes) do
@@ -31,4 +51,71 @@ defmodule Forge.CodeAction do
   def deferred(uri, title, kind, data) do
     %__MODULE__{uri: uri, title: title, kind: kind, data: data}
   end
+
+  @doc """
+  Builds the `data` payload for a deferred refactor action.
+
+  The payload round-trips through the client and is parsed back by `from_refactor_data/1`.
+  """
+  @spec to_refactor_data(Forge.uri(), non_neg_integer(), Range.t(), module()) :: data()
+  def to_refactor_data(uri, version, %Range{} = range, module)
+      when is_binary(uri) and is_integer(version) and is_atom(module) do
+    %{
+      "provider" => @refactor_provider,
+      "module" => Atom.to_string(module),
+      "uri" => uri,
+      "version" => version,
+      "range" => to_range_data(range)
+    }
+  end
+
+  @doc """
+  Parses a round-tripped deferred refactor payload into its fields.
+
+  Returns `{:error, :invalid_data}` when the payload is not well-formed refactor data.
+  Coordinates are returned as raw integers; the caller validates them against the current document.
+  """
+  @spec from_refactor_data(term()) :: {:ok, refactor_data()} | {:error, :invalid_data}
+  def from_refactor_data(%{
+        "provider" => @refactor_provider,
+        "module" => module,
+        "uri" => uri,
+        "version" => version,
+        "range" => range
+      })
+      when is_binary(module) and is_binary(uri) and is_integer(version) do
+    case to_coordinates(range) do
+      {:ok, coordinates} ->
+        {:ok, %{module: module, uri: uri, version: version, range: coordinates}}
+
+      :error ->
+        {:error, :invalid_data}
+    end
+  end
+
+  def from_refactor_data(_data), do: {:error, :invalid_data}
+
+  defp to_range_data(%Range{start: start_pos, end: end_pos}) do
+    %{"start" => to_position_data(start_pos), "end" => to_position_data(end_pos)}
+  end
+
+  defp to_position_data(%Position{line: line, character: character}) do
+    %{"line" => line, "character" => character}
+  end
+
+  defp to_coordinates(%{"start" => start_pos, "end" => end_pos}) do
+    with {:ok, start_coord} <- to_coordinate(start_pos),
+         {:ok, end_coord} <- to_coordinate(end_pos) do
+      {:ok, {start_coord, end_coord}}
+    end
+  end
+
+  defp to_coordinates(_range), do: :error
+
+  defp to_coordinate(%{"line" => line, "character" => character})
+       when is_integer(line) and is_integer(character) do
+    {:ok, {line, character}}
+  end
+
+  defp to_coordinate(_position), do: :error
 end

--- a/apps/forge/lib/forge/code_action.ex
+++ b/apps/forge/lib/forge/code_action.ex
@@ -1,21 +1,34 @@
 defmodule Forge.CodeAction do
   alias Forge.Document.Changes
 
-  defstruct [:title, :kind, :changes, :uri]
+  defstruct [:title, :kind, :changes, :uri, :data]
 
   @type code_action_kind :: GenLSP.Enumerations.CodeActionKind.t()
 
   @type trigger_kind :: GenLSP.Enumerations.CodeActionTriggerKind.t()
 
+  @typedoc """
+  JSON-serializable payload round-tripped through the client for `codeAction/resolve`. Actions
+  carrying `data` defer their edits until resolved; actions carrying `changes` ship their edits
+  inline.
+  """
+  @type data :: %{optional(String.t()) => term()}
+
   @type t :: %__MODULE__{
           title: String.t(),
           kind: code_action_kind,
-          changes: Changes.t(),
-          uri: Forge.uri()
+          changes: Changes.t() | nil,
+          uri: Forge.uri(),
+          data: data() | nil
         }
 
   @spec new(Forge.uri(), String.t(), code_action_kind(), Changes.t()) :: t()
   def new(uri, title, kind, changes) do
     %__MODULE__{uri: uri, title: title, changes: changes, kind: kind}
+  end
+
+  @spec deferred(Forge.uri(), String.t(), code_action_kind(), data()) :: t()
+  def deferred(uri, title, kind, data) do
+    %__MODULE__{uri: uri, title: title, kind: kind, data: data}
   end
 end

--- a/apps/forge/lib/forge/refactor.ex
+++ b/apps/forge/lib/forge/refactor.ex
@@ -116,23 +116,48 @@ defmodule Forge.Refactor do
     __MODULE__.Variable.UnderscoreNotUsed
   ]
 
-  def available_refactorings(zipper, selection_or_line, execute? \\ false, modules \\ @refactors) do
+  @doc """
+  Lists the refactorings available for the given selection or line.
+  """
+  def list(zipper, selection_or_line, modules \\ @refactors) do
     Enum.reduce(modules, [], fn module, refactorings ->
-      case available_refactoring(module, zipper, selection_or_line, execute?) do
+      case available_refactoring(module, zipper, selection_or_line) do
         nil -> refactorings
         refactoring -> [refactoring | refactorings]
       end
     end)
   end
 
-  defp available_refactoring(module, zipper, selection_or_line, execute?) do
-    if execute? do
-      if refactored = module.execute(zipper, selection_or_line),
-        do: module.refactoring(refactored)
+  @doc """
+  Executes a refactor, returning it with its rewritten AST.
+
+  `module` may be an atom or its string form, but must be one of the known refactorings;
+  arbitrary module names are rejected. Unlike `list/3`, failures are not caught here — a broken
+  rewrite should surface to the caller rather than be silently dropped.
+  """
+  def execute(zipper, selection_or_line, module) do
+    with {:ok, module} <- fetch_module(module),
+         refactored when refactored != nil <- module.execute(zipper, selection_or_line) do
+      {:ok, module.refactoring(refactored)}
     else
-      if module.available?(zipper, selection_or_line),
-        do: module.refactoring()
+      _ -> :error
     end
+  end
+
+  defp fetch_module(module) when is_atom(module) do
+    if module in @refactors, do: {:ok, module}, else: :error
+  end
+
+  defp fetch_module(module_name) when is_binary(module_name) do
+    case Enum.find(@refactors, &(Atom.to_string(&1) == module_name)) do
+      nil -> :error
+      module -> {:ok, module}
+    end
+  end
+
+  defp available_refactoring(module, zipper, selection_or_line) do
+    if module.available?(zipper, selection_or_line),
+      do: module.refactoring()
   rescue
     _ -> nil
   catch

--- a/apps/forge/lib/forge/refactor/pipeline/remove_pipe.ex
+++ b/apps/forge/lib/forge/refactor/pipeline/remove_pipe.ex
@@ -15,7 +15,7 @@ defmodule Forge.Refactor.Pipeline.RemovePipe do
   def refactor(zipper, _) do
     zipper
     |> Zipper.update(fn {:|>, _, [arg, {id, meta, rest}]} ->
-      {id, meta, [arg | rest]}
+      {id, meta, [arg | rest || []]}
     end)
   end
 end

--- a/apps/forge/test/forge/code_action_test.exs
+++ b/apps/forge/test/forge/code_action_test.exs
@@ -1,0 +1,58 @@
+defmodule Forge.CodeActionTest do
+  use ExUnit.Case, async: true
+
+  alias Forge.CodeAction
+  alias Forge.Document.Position
+  alias Forge.Document.Range
+
+  defp range(start_line, start_char, end_line, end_char) do
+    Range.new(
+      %Position{line: start_line, character: start_char},
+      %Position{line: end_line, character: end_char}
+    )
+  end
+
+  describe "to_refactor_data/4 and from_refactor_data/1" do
+    test "round-trips a payload through to_ and from_" do
+      data = CodeAction.to_refactor_data("file:///a.ex", 7, range(2, 3, 4, 5), Some.Module)
+
+      assert {:ok, payload} = CodeAction.from_refactor_data(data)
+      assert payload.module == "Elixir.Some.Module"
+      assert payload.uri == "file:///a.ex"
+      assert payload.version == 7
+      assert payload.range == {{2, 3}, {4, 5}}
+    end
+
+    test "the encoded payload is JSON-object shaped (string keys only)" do
+      data = CodeAction.to_refactor_data("file:///a.ex", 1, range(1, 1, 1, 2), Some.Module)
+
+      assert Enum.all?(Map.keys(data), &is_binary/1)
+      assert Enum.all?(Map.keys(data["range"]), &is_binary/1)
+    end
+  end
+
+  describe "from_refactor_data/1 rejection" do
+    test "rejects payloads that are not refactor data" do
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(%{"provider" => "other"})
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(%{"uri" => "file:///a.ex"})
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(nil)
+    end
+
+    test "rejects our payloads with a missing field" do
+      data = CodeAction.to_refactor_data("file:///a.ex", 1, range(1, 1, 1, 2), Some.Module)
+
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(Map.delete(data, "module"))
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(Map.delete(data, "range"))
+    end
+
+    test "rejects our payloads with a wrongly-typed field" do
+      data = CodeAction.to_refactor_data("file:///a.ex", 1, range(1, 1, 1, 2), Some.Module)
+
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(%{data | "version" => "1"})
+      assert {:error, :invalid_data} = CodeAction.from_refactor_data(%{data | "module" => nil})
+
+      assert {:error, :invalid_data} =
+               CodeAction.from_refactor_data(%{data | "range" => %{"start" => "wat"}})
+    end
+  end
+end

--- a/apps/forge/test/forge/refactor/pipeline/remove_pipe_test.exs
+++ b/apps/forge/test/forge/refactor/pipeline/remove_pipe_test.exs
@@ -79,6 +79,19 @@ defmodule Forge.Refactor.Pipeline.RemovePipeTest do
     )
   end
 
+  test "removes pipe into parenless call" do
+    assert_refactored(
+      RemovePipe,
+      """
+      #       v
+      arg1 |> foo
+      """,
+      """
+      foo(arg1)
+      """
+    )
+  end
+
   test "ignores range without pipes" do
     assert_ignored(
       RemovePipe,


### PR DESCRIPTION
This pull request implements support for [`codeAction/resolve` requests](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeAction_resolve).

Prior to this pull request, Expert did not support `codeAction/resolve`, which meant all possible code actions (including refactors) were evaluated eagerly and sent to the client, even when a user did not expressly request them. This led to an outsized number of errors and excess processing that would effectively be discarded. Language server clients frequently make [`textDocument/codeAction` requests](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeAction) as users are editing, and the resolve request exists exactly to offload things accordingly.

## How it works

The server now advertises `resolveProvider` based on client capability. When a client declares it can resolve the edit property (`textDocument.codeAction.resolveSupport.properties` contains `"edit"`), Expert responds to `textDocument/codeAction` with a list of actions that carry only their title, kind, and an opaque data payload — not their edits. When the user actually invokes one, the client sends `codeAction/resolve` with that payload, and only then does Expert compute the edit for that single action.

Clients that don't support resolve fall back to the previous eager behavior where edits are computed inline, so no client regresses.

## Ancillary: RemovePipe crash fix

This addresses a specific crash I ran into, which begot all the above. Included here since it's what surfaced the problem, but it stands on its own.

## Implementation notes

- `Forge.CodeAction` owns the deferred payload's schema via `to_refactor_data/4` and `from_refactor_data/1`, so the wire format lives in one place rather than being spelled out at each producer and consumer.
- The code-action Handler behaviour is unified on `actions/4`, removing per-handler reflection over an optional callback.
- Formatter configuration is resolved once per request and shared across a request's refactorings, rather than re-read per action.

## Not in scope / follow-ups

- **Request -> document discovery:** Routing `codeAction/resolve` (whose document URI lives in its data payload rather than a textDocument field) currently adds small special-case clauses to the request-dispatch predicates. If more special cases accrete, the dispatch mechanism can be reconsidered.
