### PR TITLE
chore: fix find references

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/references.ex
+++ b/apps/engine/lib/engine/code_intelligence/references.ex
@@ -48,11 +48,16 @@ defmodule Engine.CodeIntelligence.References do
     subtype = subtype(include_definitions?)
 
     case ManagerApi.search_store_prefix(Engine.get_project(), subject,
-           type: {:function, :_},
+           type: :_,
            subtype: subtype
          ) do
-      {:ok, entries} -> Enum.map(entries, &to_location/1)
-      _ -> []
+      {:ok, entries} ->
+        entries
+        |> Enum.filter(&function_entry?/1)
+        |> Enum.map(&to_location/1)
+
+      _ ->
+        []
     end
   end
 
@@ -78,6 +83,9 @@ defmodule Engine.CodeIntelligence.References do
     Logger.info("Not attempting to find references for unhandled type: #{inspect(resolved)}")
     :error
   end
+
+  defp function_entry?(%Entry{type: {:function, _}}), do: true
+  defp function_entry?(_), do: false
 
   def maybe_rewrite_resolution({:call, Kernel, :defstruct, 1}, analysis, position) do
     case Analyzer.current_module(analysis, position) do

--- a/apps/engine/test/engine/code_intelligence/references_test.exs
+++ b/apps/engine/test/engine/code_intelligence/references_test.exs
@@ -57,7 +57,6 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
     do: String.starts_with?(entry_subject, subject)
 
   defp matches_constraint?(_value, :_), do: true
-  defp matches_constraint?({kind, _}, {kind, :_}), do: true
   defp matches_constraint?(value, value), do: true
   defp matches_constraint?(_, _), do: false
 
@@ -133,6 +132,30 @@ defmodule Engine.CodeIntelligence.ReferencesTest do
       /
       assert [%Location{} = location] = references(project, "Functions.do_map|(a, b)", code)
       assert decorate(code, location.range) =~ "def func(x), do: «do_map(x, & &1 + 1)»"
+    end
+
+    test "finds local and remote calls to the same function", %{project: project} do
+      referenced = ~q/
+        defmodule Functions do
+          def do_map|(a, b), do: Enum.map(a, b)
+
+          def local_call(x), do: do_map(x, & &1 + 1)
+        end
+
+        defmodule Caller do
+          def remote_call(x), do: Functions.do_map(x, & &1 + 1)
+        end
+      /
+
+      {_, code} = pop_cursor(referenced)
+
+      references = references(project, referenced, code)
+
+      assert [local, remote] = Enum.sort_by(references, & &1.range.start.line)
+      assert decorate(code, local.range) =~ "def local_call(x), do: «do_map(x, & &1 + 1)»"
+
+      assert decorate(code, remote.range) =~
+               "def remote_call(x), do: «Functions.do_map(x, & &1 + 1)»"
     end
 
     test "are found in function definitions with optional arguments", %{project: project} do


### PR DESCRIPTION
Fixes find references, it broke when we switched to sqlite

`chore` commit because it's a fix for a new unreleased feature, it's not changelog worthy