### PR TITLE
fix(expert): correct use translation

### DIFF
--- a/apps/expert/lib/expert/code_intelligence/completion/translations/macro.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion/translations/macro.ex
@@ -234,7 +234,7 @@ defmodule Expert.CodeIntelligence.Completion.Translations.Macro do
     |> builder.set_sort_scope(SortScope.global())
   end
 
-  def translate(%Candidate.Macro{name: "use", arity: 1}, builder, env) do
+  def translate(%Candidate.Macro{name: "use", arity: 2}, builder, env) do
     label = "use (invoke another module's __using__ macro)"
     snippet = "use $0"
 


### PR DESCRIPTION
This is super small fix, but `use` is actually `use/2`, like `alias`, `require` etc. already are. The most recent version of ElixirSense on master returns only the candidate with higher arity, so only `use/2`, and this translation becomes a miss, leading to non-working completion.