### PR TITLE
fix(engine): preload deps and don't prune code paths

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -76,14 +76,33 @@ defmodule Engine do
   def ensure_apps_started(token \\ Progress.noop_token()) do
     apps_to_start = [:elixir, :runtime_tools | @allowed_apps]
 
-    Enum.reduce_while(apps_to_start, :ok, fn app_name, _ ->
-      Progress.report(token, message: "Starting #{app_name}...")
+    result =
+      Enum.reduce_while(apps_to_start, :ok, fn app_name, _ ->
+        Progress.report(token, message: "Starting #{app_name}...")
 
-      case :application.ensure_all_started(app_name) do
-        {:ok, _} -> {:cont, :ok}
-        error -> {:halt, error}
-      end
-    end)
+        case :application.ensure_all_started(app_name) do
+          {:ok, _} -> {:cont, :ok}
+          error -> {:halt, error}
+        end
+      end)
+
+    with :ok <- result do
+      Progress.report(token, message: "Loading engine modules...")
+      ensure_modules_loaded()
+    end
+  end
+
+  # Compiling a dependency prunes the code paths to the dependency's own
+  # deps, which removes the engine's paths from the code server. Any engine
+  # module that isn't already resident becomes unloadable during that window,
+  # so all engine modules are loaded up front.
+  def ensure_modules_loaded do
+    for app <- @allowed_apps,
+        {:ok, modules} <- [:application.get_key(app, :modules)] do
+      :code.ensure_modules_loaded(modules)
+    end
+
+    :ok
   end
 
   def deps_paths do

--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -151,6 +151,10 @@ defmodule Engine.Build.Project do
   end
 
   defp mix_compile_opts do
+    # --no-prune-code-paths keeps mix from deleting the engine's own code
+    # paths during the project compile. It only applies to the top-level
+    # compile; dependencies each compile in their own project frame with
+    # pruning enabled, which is what isolates them from undeclared siblings.
     ~w(
         --return-errors
         --ignore-module-conflict
@@ -158,6 +162,7 @@ defmodule Engine.Build.Project do
         --docs
         --debug-info
         --no-protocol-consolidation
+        --no-prune-code-paths
     )
   end
 end

--- a/apps/engine/lib/engine/mix.ex
+++ b/apps/engine/lib/engine/mix.ex
@@ -60,7 +60,7 @@ defmodule Engine.Mix do
       Mix.Project.in_project(
         Project.atom_name(project),
         mix_exs_dir,
-        [prune_code_paths: false, build_path: build_path],
+        [build_path: build_path],
         fn project_module ->
           Project.set_project_module(project, project_module)
         end
@@ -84,10 +84,7 @@ defmodule Engine.Mix do
 
   defp push_project(%Project{} = project) do
     Engine.with_lock(Engine.Mix.StackMutation, fn ->
-      Mix.ProjectStack.post_config(
-        prune_code_paths: false,
-        build_path: Project.versioned_build_path(project)
-      )
+      Mix.ProjectStack.post_config(build_path: Project.versioned_build_path(project))
 
       Mix.Project.push(
         project.project_module,


### PR DESCRIPTION
I found a doozy of a bug when compiling a work project. For reasons, one of our erlang libraries is a fork of a well-known http client, but its application name isn't the same as the library's app name.

Another dep does checks for the client module being present, and if it's present, then reads the app config's vsn with the library's name. The problem is there is no app config, since the app name doesn't match the library name. This causes the build to fail, but only in expert.

The reason is that expert has previously loaded the app name when compiling other deps, and because module pruning was disabled, that old dep carried through and caused the compile issue. This does not happen on the command line, because when the project stack changes, the dep's modules are unloaded.

Expert originally disabled module pruning because it needs to have its own deps' modules available, but this can be accomplished by passing an argument to the project-level builds instead of always doing it when we need to be in a mix context.