### PR TITLE
perf: don't gate indexing on compliation completing

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -8,6 +8,7 @@ defmodule Engine do
   alias Engine.Api.Proxy
   alias Engine.CodeAction
   alias Engine.CodeIntelligence
+  alias Engine.Commands
   alias Engine.Progress
   alias Forge.Project
 
@@ -20,9 +21,9 @@ defmodule Engine do
 
   defdelegate format(document), to: Proxy
 
-  defdelegate reindex, to: Proxy
+  defdelegate reindex, to: Commands.Reindex, as: :perform
 
-  defdelegate index_running?, to: Proxy
+  defdelegate index_running?, to: Commands.Reindex, as: :running?
 
   defdelegate broadcast(message), to: Proxy
 

--- a/apps/engine/lib/engine/api/proxy.ex
+++ b/apps/engine/lib/engine/api/proxy.ex
@@ -16,8 +16,6 @@ defmodule Engine.Api.Proxy do
     `schedule_compile` - Buffered - Only one call is kept
     `compile_document` - Buffered, though only one call per URI is kept, and if a `schedule_compile` call
                          was buffered, all `compile_document` calls are dropped
-    `reindex`  - Buffered, though only one call is kept and it is the last thing run.
-    `index_running?` - Dropped because it requires an immediate response
     `format`  - Dropped, as it requires an immediate response. Responds immediately with empty changes
 
   Internally, there are three states: proxying, draining and buffering.
@@ -38,7 +36,6 @@ defmodule Engine.Api.Proxy do
   alias Engine.Api.Proxy.DrainingState
   alias Engine.Api.Proxy.ProxyingState
   alias Engine.CodeMod
-  alias Engine.Commands
   alias Forge.Document
   alias Forge.Document.Changes
 
@@ -75,16 +72,6 @@ defmodule Engine.Api.Proxy do
     mfa = to_mfa(Engine.Build.compile_document(project, document))
 
     :gen_statem.call(__MODULE__, buffer(contents: mfa))
-  end
-
-  def reindex do
-    mfa = to_mfa(Commands.Reindex.perform())
-    :gen_statem.call(__MODULE__, buffer(contents: mfa))
-  end
-
-  def index_running? do
-    mfa = to_mfa(Commands.Reindex.running?())
-    :gen_statem.call(__MODULE__, drop(contents: mfa, return: false))
   end
 
   def format(%Document{} = document) do

--- a/apps/engine/lib/engine/api/proxy/buffering_state.ex
+++ b/apps/engine/lib/engine/api/proxy/buffering_state.ex
@@ -3,7 +3,6 @@ defmodule Engine.Api.Proxy.BufferingState do
   import Forge.EngineApi.Messages
 
   alias Engine.Build
-  alias Engine.Commands
   alias Forge.Document
 
   defstruct initiator_pid: nil, buffer: []
@@ -24,7 +23,7 @@ defmodule Engine.Api.Proxy.BufferingState do
         match?(mfa(module: Engine.Dispatch, function: :broadcast), value)
       end)
 
-    {project_compile, document_compiles, reindex} = collapse_commands(commands)
+    {project_compile, document_compiles} = collapse_commands(commands)
 
     all_commands = [project_compile | Map.values(document_compiles)]
 
@@ -32,22 +31,14 @@ defmodule Engine.Api.Proxy.BufferingState do
     |> Enum.concat(collapse_messages(messages, project_compile, document_compiles))
     |> Enum.filter(&match?(mfa(), &1))
     |> Enum.sort_by(fn mfa(seq: seq) -> seq end)
-    |> then(fn commands ->
-      if reindex do
-        commands ++ [reindex]
-      else
-        commands
-      end
-    end)
   end
 
   defp collapse_commands(commands) do
     # Rules for collapsing commands
     # 1. If there's a project compilation requested, remove all document compilations
     # 2. Formats can be dropped, as they're only valid for a short time.
-    # 3. If there's a reindex, do it after the project compilation has finished
 
-    initial_state = %{project_compiles: [], document_compiles: %{}, reindex: nil}
+    initial_state = %{project_compiles: [], document_compiles: %{}}
 
     grouped =
       commands
@@ -62,9 +53,6 @@ defmodule Engine.Api.Proxy.BufferingState do
             uri = document.uri
             put_in(acc, [:document_compiles, uri], mfa)
 
-          mfa(module: Commands.Reindex) = mfa, acc ->
-            Map.put(acc, :reindex, mfa)
-
           _, acc ->
             acc
         end
@@ -72,8 +60,7 @@ defmodule Engine.Api.Proxy.BufferingState do
 
     %{
       project_compiles: project_compiles,
-      document_compiles: document_compiles,
-      reindex: reindex
+      document_compiles: document_compiles
     } = grouped
 
     project_compile =
@@ -100,7 +87,7 @@ defmodule Engine.Api.Proxy.BufferingState do
         end
       end
 
-    {project_compile, document_compiles, reindex}
+    {project_compile, document_compiles}
   end
 
   defp collapse_messages(messages, project_compile, document_compiles) do

--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -62,7 +62,7 @@ defmodule Engine.Build.Project do
     compile_fun = fn ->
       Mix.Task.clear()
       Progress.report(token, message: "Compiling #{Project.display_name(project)}")
-      result = compile_in_isolation()
+      result = compile_in_isolation(project)
       maybe_load_modules()
       Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:loadpaths)
@@ -101,7 +101,7 @@ defmodule Engine.Build.Project do
     end
   end
 
-  defp compile_in_isolation do
+  defp compile_in_isolation(%Project{} = project) do
     compile_fun = fn ->
       Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:compile, mix_compile_opts())
@@ -111,13 +111,28 @@ defmodule Engine.Build.Project do
       {:ok, result} ->
         result
 
-      {:error, {exception, [{_mod, _fun, _arity, meta} | _]}} ->
+      {:error, {exception, [{_mod, _fun, _arity, meta} | _]}} when is_exception(exception) ->
         diagnostic = %Diagnostic{
           file: Keyword.get(meta, :file),
           severity: :error,
           message: Exception.message(exception),
           compiler_name: "Elixir",
           position: Keyword.get(meta, :line, 1)
+        }
+
+        {:error, [diagnostic]}
+
+      {:error, reason} ->
+        # Mix exits rather than raises when a dependency fails to compile, so
+        # the exit reason carries no exception or location. The project's
+        # build file is the natural home for a build-wide failure, and unlike
+        # the failing dependency's files, it's part of the workspace.
+        diagnostic = %Diagnostic{
+          file: Project.mix_exs_path(project),
+          severity: :error,
+          message: "Compilation failed: #{Exception.format_exit(reason)}",
+          compiler_name: "Elixir",
+          position: 1
         }
 
         {:error, [diagnostic]}

--- a/apps/engine/test/engine/api/proxy/buffering_state_test.exs
+++ b/apps/engine/test/engine/api/proxy/buffering_state_test.exs
@@ -7,7 +7,6 @@ defmodule Engine.Api.Proxy.BufferingStateStateTest do
 
   alias Engine.Api.Proxy.BufferingState
   alias Engine.Build
-  alias Engine.Commands
   alias Forge.Document
 
   setup do
@@ -94,35 +93,6 @@ defmodule Engine.Api.Proxy.BufferingStateStateTest do
       assert [{:mfa, Build, :compile_document, [^project, ^document], _}] = flushed_messages
     end
 
-    test "there can only be one reindex", %{project: project} do
-      flushed_messages =
-        [
-          to_mfa(Commands.Reindex.perform()),
-          to_mfa(Commands.Reindex.perform(project))
-        ]
-        |> add_to_state_and_flush()
-
-      assert [{:mfa, Commands.Reindex, :perform, [^project], _}] = flushed_messages
-    end
-
-    test "a reindex is the last thing", %{project: project} do
-      other = open_document("file:///other.uri")
-      third = open_document("file:///third.uri")
-
-      flushed_messages =
-        [
-          to_mfa(Commands.Reindex.perform()),
-          to_mfa(Build.compile_document(project, other)),
-          to_mfa(Build.compile_document(project, third))
-        ]
-        |> add_to_state_and_flush()
-
-      assert [
-               {:mfa, Build, :compile_document, [^project, ^other], _},
-               {:mfa, Build, :compile_document, [^project, ^third], _},
-               {:mfa, Commands.Reindex, :perform, [], _}
-             ] = flushed_messages
-    end
   end
 
   defp wrap_broadcasts(messages) do

--- a/apps/engine/test/engine/api/proxy/buffering_state_test.exs
+++ b/apps/engine/test/engine/api/proxy/buffering_state_test.exs
@@ -92,7 +92,6 @@ defmodule Engine.Api.Proxy.BufferingStateStateTest do
 
       assert [{:mfa, Build, :compile_document, [^project, ^document], _}] = flushed_messages
     end
-
   end
 
   defp wrap_broadcasts(messages) do

--- a/apps/engine/test/engine/api/proxy_test.exs
+++ b/apps/engine/test/engine/api/proxy_test.exs
@@ -214,6 +214,5 @@ defmodule Engine.Api.ProxyTest do
 
       assert_called(Build.compile_document(^project, ^doc), 1)
     end
-
   end
 end

--- a/apps/engine/test/engine/api/proxy_test.exs
+++ b/apps/engine/test/engine/api/proxy_test.exs
@@ -10,7 +10,6 @@ defmodule Engine.Api.ProxyTest do
   alias Engine.Api.Proxy.DrainingState
   alias Engine.Build
   alias Engine.CodeMod
-  alias Engine.Commands
   alias Engine.Dispatch
   alias Forge.Document
   alias Forge.Document.Changes
@@ -48,16 +47,6 @@ defmodule Engine.Api.ProxyTest do
       assert_called(Build.compile_document(^project, ^document))
     end
 
-    test "reindex is proxied" do
-      patch(Commands.Reindex, :perform, :ok)
-      patch(Commands.Reindex, :running?, false)
-
-      refute Proxy.index_running?()
-      assert :ok = Proxy.reindex()
-      assert_called(Commands.Reindex.perform())
-      assert_called(Commands.Reindex.running?())
-    end
-
     test "formatting is proxied" do
       document = %Document{}
       patch(CodeMod.Format, :edits, {:ok, Changes.new(document, [])})
@@ -68,7 +57,7 @@ defmodule Engine.Api.ProxyTest do
   end
 
   def with_draining_mode(ctx) do
-    patch(Commands.Reindex, :perform, fn ->
+    patch(Build, :compile_document, fn _, _ ->
       Process.sleep(100)
       :ok
     end)
@@ -77,7 +66,7 @@ defmodule Engine.Api.ProxyTest do
 
     spawn_link(fn ->
       send(me, :ready)
-      result = Proxy.reindex()
+      result = Proxy.compile_document(%Document{})
       send(me, {:proxy_result, result})
     end)
 
@@ -164,16 +153,6 @@ defmodule Engine.Api.ProxyTest do
       refute_any_call(Build.compile_document())
     end
 
-    test "buffers reindex" do
-      patch(Commands.Reindex, :perform, :ok)
-      patch(Commands.Reindex, :running?, false)
-
-      refute Proxy.index_running?()
-      assert :ok = Proxy.reindex()
-      refute_any_call(Commands.Reindex.perform())
-      refute_any_call(Commands.Reindex.running?())
-    end
-
     test "buffers formatting" do
       document = %Document{}
       patch(CodeMod.Format, :edits, {:ok, Changes.new(document, [])})
@@ -236,32 +215,5 @@ defmodule Engine.Api.ProxyTest do
       assert_called(Build.compile_document(^project, ^doc), 1)
     end
 
-    test "reindex calls are buffered", %{stop_buffering: stop_buffering} do
-      patch(Commands.Reindex, :perform, :ok)
-
-      Proxy.reindex()
-      Proxy.reindex()
-      Proxy.reindex()
-
-      refute_any_call(Commands.Reindex.perform())
-
-      stop_buffering.()
-
-      assert_called(Commands.Reindex.perform())
-    end
-
-    test "calls to Reindex.running?() are dropped", %{stop_buffering: stop_buffering} do
-      patch(Commands.Reindex, :running?, false)
-
-      Proxy.index_running?()
-      Proxy.index_running?()
-      Proxy.index_running?()
-
-      refute_any_call(Commands.Reindex.running?())
-
-      stop_buffering.()
-
-      refute_any_call(Commands.Reindex.running?())
-    end
   end
 end

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -85,14 +85,18 @@ defmodule Expert.Project.Indexer do
   @impl GenServer
   def handle_continue(:maybe_initial_compile, %State{initial_compile?: true} = state) do
     Node.trigger_build(state.project)
-    {:noreply, state}
+    {:noreply, start_or_queue_index(state)}
   end
 
-  def handle_continue(:maybe_initial_compile, %State{} = state), do: {:noreply, state}
+  def handle_continue(:maybe_initial_compile, %State{} = state) do
+    {:noreply, start_or_queue_index(state)}
+  end
 
+  # Indexing isn't gated on compilation; the initial index starts at boot and
+  # compile completions (successful or not) trigger a refresh to pick up
+  # whatever the compile produced.
   @impl GenServer
-  def handle_info(project_compiled(status: status), %State{} = state)
-      when status in [:success, :successful] do
+  def handle_info(project_compiled(), %State{} = state) do
     {:noreply, start_or_queue_index(state)}
   end
 

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -33,7 +33,7 @@ defmodule Expert.Project.IndexerTest do
     {:ok, project: project, task_supervisor: task_supervisor}
   end
 
-  test "creates the initial index after a successful project compile", %{
+  test "updates the initial index after a successful initial project compile", %{
     project: project,
     task_supervisor: task_supervisor
   } do
@@ -61,10 +61,11 @@ defmodule Expert.Project.IndexerTest do
        ]}
     )
 
+    assert_receive :create_index
+
     EngineApi.broadcast(project, project_compiled(project: project, status: :success))
 
-    assert_receive :create_index
-    refute_receive :update_index
+    assert_receive :update_index
     assert_receive {:after_apply, {:ok, [^entry]}}
     assert_receive project_index_ready(project: ^project)
     assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.Initial, [])


### PR DESCRIPTION
When reindex was run at the same time as compilation, it caused something in the BEAM vm to soak up CPU. This was a permanent condition that would affect the project node until it was restarted.

Since we swapped out the ETS based index backend for a SQLite one, we should be able to reindex and compile at the same time. This will dramatically reduce the amount of time the project node takes to boot.

This change makes it so indexing and compilation occur at the same time, and we fix up the index after compilation completes