### PR TITLE
fix: improve struct reference completion handling errors in struct completions

### DIFF
--- a/apps/engine/lib/engine/completion.ex
+++ b/apps/engine/lib/engine/completion.ex
@@ -134,18 +134,10 @@ defmodule Engine.Completion do
   end
 
   defp fetch_struct_completion_length(env) do
-    # `StructReference.reference_length/1` is the shared authority on what a
-    # struct reference is: detection admits exactly the contexts it accepts, so
-    # anything reaching here as a `:struct` context resolves without crashing.
     case Code.Fragment.cursor_context(env.prefix) do
-      {:struct, context} ->
-        StructReference.reference_length(context)
-
-      {:local_or_var, local_name} ->
-        {:ok, length(local_name)}
-
-      _ ->
-        :error
+      {:struct, context} -> StructReference.reference_length(context)
+      {:local_or_var, local_name} -> {:ok, length(local_name)}
+      _ -> :error
     end
   end
 end

--- a/apps/engine/lib/engine/completion.ex
+++ b/apps/engine/lib/engine/completion.ex
@@ -5,6 +5,7 @@ defmodule Engine.Completion do
   alias Engine.CodeMod.Format
   alias Engine.Module.Loader
   alias Forge.Ast.Analysis
+  alias Forge.Ast.Detection.StructReference
   alias Forge.Ast.Env
   alias Forge.Completion.Candidate
   alias Forge.Document
@@ -133,19 +134,18 @@ defmodule Engine.Completion do
   end
 
   defp fetch_struct_completion_length(env) do
+    # `StructReference.reference_length/1` is the shared authority on what a
+    # struct reference is: detection admits exactly the contexts it accepts, so
+    # anything reaching here as a `:struct` context resolves without crashing.
     case Code.Fragment.cursor_context(env.prefix) do
-      {:struct, {:dot, {:alias, struct_name}, []}} ->
-        # add one because of the trailing period
-        {:ok, length(struct_name) + 1}
-
-      {:struct, {:local_or_var, local_name}} ->
-        {:ok, length(local_name)}
-
-      {:struct, struct_name} ->
-        {:ok, length(struct_name)}
+      {:struct, context} ->
+        StructReference.reference_length(context)
 
       {:local_or_var, local_name} ->
         {:ok, length(local_name)}
+
+      _ ->
+        :error
     end
   end
 end

--- a/apps/engine/test/engine/completion_test.exs
+++ b/apps/engine/test/engine/completion_test.exs
@@ -134,6 +134,45 @@ defmodule Engine.CompletionTest do
       assert doc == "Module.Sub"
     end
 
+    # `%Foo.bar` is a remote call carrying a stray `%`, not a struct reference,
+    # so it isn't detected as one and the operator is left untouched (rather
+    # than crashing while computing the completion length).
+    for invalid <- ["%IO.inspe", "%Some.Random.cra", "%IO.inspe."] do
+      test "leaves a remote call prefixed with % untouched: #{invalid}" do
+        env = new_env(unquote(invalid))
+        {doc, _position} = private(Completion.strip_struct_operator(env))
+
+        assert doc == Document.to_string(env.document)
+      end
+    end
+
+    test "with a reference to a submodule of __MODULE__" do
+      {doc, _position} =
+        "%__MODULE__.Sub"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "__MODULE__.Sub"
+    end
+
+    test "with a reference to __MODULE__ followed by a dot" do
+      {doc, _position} =
+        "%__MODULE__."
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "__MODULE__."
+    end
+
+    test "with a module attribute reference" do
+      {doc, _position} =
+        "%@my_struct"
+        |> new_env()
+        |> private(Completion.strip_struct_operator())
+
+      assert doc == "@my_struct"
+    end
+
     test "with a reference followed by an alias" do
       code = ~q[
         alias Something.Else

--- a/apps/forge/lib/forge/ast/detection/struct_reference.ex
+++ b/apps/forge/lib/forge/ast/detection/struct_reference.ex
@@ -1,4 +1,7 @@
 defmodule Forge.Ast.Detection.StructReference do
+  @moduledoc """
+  A struct reference is a `%` followed by some valid module path.
+  """
   use Forge.Ast.Detection
 
   alias Forge.Ast
@@ -10,15 +13,11 @@ defmodule Forge.Ast.Detection.StructReference do
   @impl Detection
   def detected?(%Analysis{} = analysis, %Position{} = position) do
     case Ast.cursor_context(analysis, position) do
-      {:ok, {:struct, []}} ->
-        false
-
-      {:ok, {:struct, _}} ->
-        true
+      {:ok, {:struct, context}} ->
+        match?({:ok, _}, reference_length(context))
 
       {:ok, {:local_or_var, [?_ | _rest] = possible_module_struct}} ->
-        # a reference to `%__MODULE`, often in a function head, as in
-        # def foo(%__)
+        # a reference to `%__MODULE`, often in a function head, as in def foo(%__)
 
         starts_with_percent? =
           analysis.document
@@ -40,4 +39,46 @@ defmodule Forge.Ast.Detection.StructReference do
   def possible_dunder_module(charlist) do
     String.starts_with?("__MODULE__", to_string(charlist))
   end
+
+  @doc """
+  Measures the module path in a `:struct` cursor context, while also providing authority on what
+  actually counts as a *struct reference*. Expects a `{:struct, _}` context from `Code.Fragment.cursor_context/1`.
+
+  Returns `{:ok, length}` (# of characters following `%`) for a valid module path, or `:error`
+  otherwise — a bare `%`, or a lowercase call segment such as `%Foo.bar`, which is a remote call
+  carrying a stray `%` rather than a struct.
+
+  ## Examples
+
+      iex> alias Forge.Ast.Detection.StructReference
+      iex> StructReference.reference_length(~c"Foo")
+      {:ok, 3}
+      iex> StructReference.reference_length({:dot, {:alias, ~c"Foo"}, []})
+      {:ok, 4}
+      iex> StructReference.reference_length({:dot, {:alias, ~c"Foo"}, ~c"bar"})
+      :error
+  """
+  @spec reference_length(term()) :: {:ok, non_neg_integer()} | :error
+  def reference_length([]), do: :error
+  def reference_length(name) when is_list(name), do: {:ok, length(name)}
+  def reference_length({:local_or_var, name}), do: {:ok, length(name)}
+  # add one for the leading `@`
+  def reference_length({:module_attribute, name}), do: {:ok, length(name) + 1}
+  def reference_length({:alias, name}) when is_list(name), do: {:ok, length(name)}
+
+  def reference_length({:alias, base, name}) do
+    with {:ok, base_length} <- reference_length(base) do
+      # add one for the dot between the base and the trailing alias segment
+      {:ok, base_length + 1 + length(name)}
+    end
+  end
+
+  def reference_length({:dot, inner, []}) do
+    with {:ok, inner_length} <- reference_length(inner) do
+      # add one for the trailing period
+      {:ok, inner_length + 1}
+    end
+  end
+
+  def reference_length(_), do: :error
 end

--- a/apps/forge/test/forge/ast/detection/struct_reference_test.exs
+++ b/apps/forge/test/forge/ast/detection/struct_reference_test.exs
@@ -5,6 +5,8 @@ defmodule Forge.Ast.Detection.StructReferenceTest do
     skip: [[:struct_fields, :*], [:struct_field_value, :*], [:struct_field_key, :*]],
     variations: [:match, :function_arguments]
 
+  doctest Forge.Ast.Detection.StructReference
+
   test "is detected if a module reference starts in function arguments" do
     assert_detected ~q[def my_function(%_«»)]
   end
@@ -39,5 +41,40 @@ defmodule Forge.Ast.Detection.StructReferenceTest do
 
   test "is not detected if a module reference lacks a %" do
     refute_detected ~q[def my_function(__)]
+  end
+
+  test "is detected while typing a submodule after a trailing dot" do
+    assert_detected ~q[%F«oo.»]
+  end
+
+  test "is detected while typing a submodule after a nested trailing dot" do
+    assert_detected ~q[%F«oo.Bar.»]
+  end
+
+  test "is detected for a variable module reference" do
+    assert_detected ~q[%f«oo»]
+  end
+
+  test "is not detected past a lowercase call segment, only through the trailing dot" do
+    # `%Foo.bar` is a remote call carrying a stray `%` and can never be a
+    # struct. Detection holds through `%Foo.` (a valid in-progress reference)
+    # but the range stops at the `.`, so the `bar` positions must be refuted.
+    assert_detected ~q[%F«oo.»bar]
+  end
+
+  test "is detected for a submodule of __MODULE__" do
+    assert_detected ~q[%_«_MODULE__.Sub»]
+  end
+
+  test "is detected while typing a submodule after __MODULE__ and a trailing dot" do
+    assert_detected ~q[%_«_MODULE__.»]
+  end
+
+  test "is not detected for a call on __MODULE__, only through the trailing dot" do
+    assert_detected ~q[%_«_MODULE__.»foo]
+  end
+
+  test "is detected for a module attribute struct" do
+    assert_detected ~q[%@t«»]
   end
 end

--- a/apps/forge/test/forge/ast/detection/struct_reference_test.exs
+++ b/apps/forge/test/forge/ast/detection/struct_reference_test.exs
@@ -56,9 +56,6 @@ defmodule Forge.Ast.Detection.StructReferenceTest do
   end
 
   test "is not detected past a lowercase call segment, only through the trailing dot" do
-    # `%Foo.bar` is a remote call carrying a stray `%` and can never be a
-    # struct. Detection holds through `%Foo.` (a valid in-progress reference)
-    # but the range stops at the `.`, so the `bar` positions must be refuted.
     assert_detected ~q[%F«oo.»bar]
   end
 


### PR DESCRIPTION
* Add `reference_length/1` as an authority on what counts as a struct reference.
* Have `StructReference.detected?/2` and the engine's completion-length calculation both consume it so they agree.
* This stops `length/1` from being called on non-module `{:dot, ...}` payloads, and correctly admits `%__MODULE__.Foo`, `%__MODULE__.`, and `%@attr` — which the previous detection accepted but the length calc crashed on.