### PR TITLE
fix(nix): pass elixir_sense grammar and deps to expert in nix

### DIFF
--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -2,8 +2,7 @@
   beamPackages,
   callPackages,
   lib,
-}:
-let
+}: let
   version = builtins.readFile ../version.txt;
 
   engineDeps = callPackages ../apps/engine/deps.nix {
@@ -18,62 +17,80 @@ let
     # so it survives `nix run .#update-deps` regenerating that file.
     overrides = _final: prev: {
       elixir_sense = prev.elixir_sense.overrideAttrs (old: {
-        postInstall = (old.postInstall or "") + ''
-          grammar="$out/src/src/elixir_sense_parser.yrl"
-          if [ -f "$grammar" ]; then
-            chmod -R u+w "$out/src/src"
-            ${beamPackages.erlang}/bin/erlc -o "$out/src/src" "$grammar"
-            test -f "$out/src/src/elixir_sense_parser.erl"
-          fi
-        '';
+        postInstall =
+          (old.postInstall or "")
+          + ''
+            grammar="$out/src/src/elixir_sense_parser.yrl"
+            if [ -f "$grammar" ]; then
+              chmod -R u+w "$out/src/src"
+              ${beamPackages.erlang}/bin/erlc -o "$out/src/src" "$grammar"
+              test -f "$out/src/src/elixir_sense_parser.erl"
+            fi
+          '';
       });
     };
   };
 in
-beamPackages.mixRelease rec {
-  pname = "expert";
-  inherit version;
+  beamPackages.mixRelease rec {
+    pname = "expert";
+    inherit version;
 
-  src = lib.fileset.toSource {
-    root = ./..;
-    fileset = lib.fileset.unions [
-      ../apps
-      ../mix_credo.exs
-      ../mix_dialyzer.exs
-      ../mix_includes.exs
-      ../version.txt
-    ];
-  };
+    src = lib.fileset.toSource {
+      root = ./..;
+      fileset = lib.fileset.unions [
+        ../apps
+        ../mix_credo.exs
+        ../mix_dialyzer.exs
+        ../mix_includes.exs
+        ../version.txt
+      ];
+    };
 
-  mixNixDeps = callPackages ../apps/expert/deps.nix { inherit lib beamPackages; };
+    mixNixDeps = callPackages ../apps/expert/deps.nix {inherit lib beamPackages;};
 
-  mixReleaseName = "plain";
+    mixReleaseName = "plain";
 
-  preConfigure = ''
-    # copy the logic from mixRelease to build a deps dir for engine
-    mkdir -p apps/engine/deps
-    ${lib.concatMapAttrsStringSep "\n" (name: dep: ''
-      dep_path="apps/engine/deps/${name}"
-      if [ -d "${dep}/src" ]; then
-        ln -sv ${dep}/src $dep_path
-      fi
-    '') engineDeps}
+    preConfigure = ''
+      # copy the logic from mixRelease to build a deps dir for engine
+      mkdir -p apps/engine/deps
+      ${lib.concatMapAttrsStringSep "\n" (name: dep: ''
+          dep_path="apps/engine/deps/${name}"
+          if [ -d "${dep}/src" ]; then
+            ln -sv ${dep}/src $dep_path
+          fi
+        '')
+        engineDeps}
 
-      cd apps/expert
-  '';
+        cd apps/expert
+    '';
 
-  postInstall = ''
-    mv $out/bin/plain $out/bin/expert
-    wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
-  '';
+    postInstall = ''
+      mv $out/bin/plain $out/bin/expert
+      wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
 
-  removeCookie = false;
+      for dep in "$out"/lib/xp_expert-*/priv/engine_source/apps/engine/deps/elixir_sense; do
+        if [ -L "$dep" ]; then
+          target="$(readlink -f "$dep")"
+          rm "$dep"
+          cp -R "$target" "$dep"
+          chmod -R u+w "$dep"
+        fi
 
-  passthru = {
-    # not used by package, but exposed for repl and direct build access
-    # e.g. nix build .#expert.mixNixDeps.jason
-    inherit engineDeps mixNixDeps;
-  };
+        grammar="$dep/src/elixir_sense_parser.yrl"
+        if [ -f "$grammar" ] && [ ! -f "$dep/src/elixir_sense_parser.erl" ]; then
+          ${beamPackages.erlang}/bin/erlc -o "$dep/src" "$grammar"
+          test -f "$dep/src/elixir_sense_parser.erl"
+        fi
+      done
+    '';
 
-  meta.mainProgram = "expert";
-}
+    removeCookie = false;
+
+    passthru = {
+      # not used by package, but exposed for repl and direct build access
+      # e.g. nix build .#expert.mixNixDeps.jason
+      inherit engineDeps mixNixDeps;
+    };
+
+    meta.mainProgram = "expert";
+  }

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -8,6 +8,26 @@ let
 
   engineDeps = callPackages ../apps/engine/deps.nix {
     inherit lib beamPackages;
+    # The runtime engine build compiles dependencies directly from their packaged
+    # sources. Generate ElixirSense's parser here and remove the grammar so Mix
+    # cannot try to regenerate it through a read-only Nix store symlink.
+    #
+    # Keep this outside the generated deps.nix so `nix run .#update-deps` does
+    # not remove the workaround.
+    overrides = _final: prev: {
+      elixir_sense = prev.elixir_sense.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          grammar="src/elixir_sense_parser.yrl"
+          parser="src/elixir_sense_parser.erl"
+
+          if [ -f "$grammar" ]; then
+            ${beamPackages.erlang}/bin/erlc -o src "$grammar"
+            test -f "$parser"
+            rm "$grammar"
+          fi
+        '';
+      });
+    };
   };
 in
 beamPackages.mixRelease rec {
@@ -45,21 +65,6 @@ beamPackages.mixRelease rec {
   postInstall = ''
     mv $out/bin/plain $out/bin/expert
     wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
-
-    for dep in "$out"/lib/xp_expert-*/priv/engine_source/apps/engine/deps/elixir_sense; do
-      if [ -L "$dep" ]; then
-        target="$(readlink -f "$dep")"
-        rm "$dep"
-        cp -R "$target" "$dep"
-        chmod -R u+w "$dep"
-      fi
-
-      grammar="$dep/src/elixir_sense_parser.yrl"
-      if [ -f "$grammar" ] && [ ! -f "$dep/src/elixir_sense_parser.erl" ]; then
-        ${beamPackages.erlang}/bin/erlc -o "$dep/src" "$grammar"
-        test -f "$dep/src/elixir_sense_parser.erl"
-      fi
-    done
   '';
 
   removeCookie = false;

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -7,28 +7,6 @@
 
   engineDeps = callPackages ../apps/engine/deps.nix {
     inherit lib beamPackages;
-    # elixir_sense ships a yecc grammar (src/elixir_sense_parser.yrl). Mix normally
-    # compiles it into src/elixir_sense_parser.erl, but at runtime the engine builds
-    # against these sources straight from the read-only Nix store, so that in-tree
-    # write fails. Pre-generate the parser so Mix finds it and skips regenerating
-    # (Nix zeroes mtimes, so the .erl is never considered stale relative to the .yrl).
-    #
-    # This lives here, in deps.nix's `overrides` hook, rather than in deps.nix itself
-    # so it survives `nix run .#update-deps` regenerating that file.
-    overrides = _final: prev: {
-      elixir_sense = prev.elixir_sense.overrideAttrs (old: {
-        postInstall =
-          (old.postInstall or "")
-          + ''
-            grammar="$out/src/src/elixir_sense_parser.yrl"
-            if [ -f "$grammar" ]; then
-              chmod -R u+w "$out/src/src"
-              ${beamPackages.erlang}/bin/erlc -o "$out/src/src" "$grammar"
-              test -f "$out/src/src/elixir_sense_parser.erl"
-            fi
-          '';
-      });
-    };
   };
 in
   beamPackages.mixRelease rec {

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -2,73 +2,73 @@
   beamPackages,
   callPackages,
   lib,
-}: let
+}:
+let
   version = builtins.readFile ../version.txt;
 
   engineDeps = callPackages ../apps/engine/deps.nix {
     inherit lib beamPackages;
   };
 in
-  beamPackages.mixRelease rec {
-    pname = "expert";
-    inherit version;
+beamPackages.mixRelease rec {
+  pname = "expert";
+  inherit version;
 
-    src = lib.fileset.toSource {
-      root = ./..;
-      fileset = lib.fileset.unions [
-        ../apps
-        ../mix_credo.exs
-        ../mix_dialyzer.exs
-        ../mix_includes.exs
-        ../version.txt
-      ];
-    };
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ../apps
+      ../mix_credo.exs
+      ../mix_dialyzer.exs
+      ../mix_includes.exs
+      ../version.txt
+    ];
+  };
 
-    mixNixDeps = callPackages ../apps/expert/deps.nix {inherit lib beamPackages;};
+  mixNixDeps = callPackages ../apps/expert/deps.nix { inherit lib beamPackages; };
 
-    mixReleaseName = "plain";
+  mixReleaseName = "plain";
 
-    preConfigure = ''
-      # copy the logic from mixRelease to build a deps dir for engine
-      mkdir -p apps/engine/deps
-      ${lib.concatMapAttrsStringSep "\n" (name: dep: ''
-          dep_path="apps/engine/deps/${name}"
-          if [ -d "${dep}/src" ]; then
-            ln -sv ${dep}/src $dep_path
-          fi
-        '')
-        engineDeps}
+  preConfigure = ''
+    # copy the logic from mixRelease to build a deps dir for engine
+    mkdir -p apps/engine/deps
+    ${lib.concatMapAttrsStringSep "\n" (name: dep: ''
+      dep_path="apps/engine/deps/${name}"
+      if [ -d "${dep}/src" ]; then
+        ln -sv ${dep}/src $dep_path
+      fi
+    '') engineDeps}
 
-        cd apps/expert
-    '';
+      cd apps/expert
+  '';
 
-    postInstall = ''
-      mv $out/bin/plain $out/bin/expert
-      wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
+  postInstall = ''
+    mv $out/bin/plain $out/bin/expert
+    wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
 
-      for dep in "$out"/lib/xp_expert-*/priv/engine_source/apps/engine/deps/elixir_sense; do
-        if [ -L "$dep" ]; then
-          target="$(readlink -f "$dep")"
-          rm "$dep"
-          cp -R "$target" "$dep"
-          chmod -R u+w "$dep"
-        fi
+    for dep in "$out"/lib/xp_expert-*/priv/engine_source/apps/engine/deps/elixir_sense; do
+      if [ -L "$dep" ]; then
+        target="$(readlink -f "$dep")"
+        rm "$dep"
+        cp -R "$target" "$dep"
+        chmod -R u+w "$dep"
+      fi
 
-        grammar="$dep/src/elixir_sense_parser.yrl"
-        if [ -f "$grammar" ] && [ ! -f "$dep/src/elixir_sense_parser.erl" ]; then
-          ${beamPackages.erlang}/bin/erlc -o "$dep/src" "$grammar"
-          test -f "$dep/src/elixir_sense_parser.erl"
-        fi
-      done
-    '';
+      grammar="$dep/src/elixir_sense_parser.yrl"
+      if [ -f "$grammar" ] && [ ! -f "$dep/src/elixir_sense_parser.erl" ]; then
+        ${beamPackages.erlang}/bin/erlc -o "$dep/src" "$grammar"
+        test -f "$dep/src/elixir_sense_parser.erl"
+      fi
+    done
+  '';
 
-    removeCookie = false;
+  removeCookie = false;
 
-    passthru = {
-      # not used by package, but exposed for repl and direct build access
-      # e.g. nix build .#expert.mixNixDeps.jason
-      inherit engineDeps mixNixDeps;
-    };
+  passthru = {
+    # not used by package, but exposed for repl and direct build access
+    # e.g. nix build .#expert.mixNixDeps.jason
+    inherit engineDeps mixNixDeps;
+  };
 
-    meta.mainProgram = "expert";
-  }
+  meta.mainProgram = "expert";
+}


### PR DESCRIPTION
Fixes #777 I have tested it in `x86_64 nixos` and `arm64 darwin`, simply passes some deps and grammars so that it may build `elixir_sense` properly 