### PR TITLE
feat(expert): autodetect Elixir source

### DIFF
--- a/apps/engine/lib/engine/code_intelligence/elixir_source.ex
+++ b/apps/engine/lib/engine/code_intelligence/elixir_source.ex
@@ -4,7 +4,7 @@ defmodule Engine.CodeIntelligence.ElixirSource do
   """
 
   # A stable file that every standard Elixir install ships under its root.
-  @sentinel Path.join("lib", "elixir/lib/kernel.ex")
+  @sentinel "lib/elixir/lib/kernel.ex"
 
   @doc """
   Returns the root of the Elixir source tree for the current installation, or

--- a/apps/engine/lib/engine/code_intelligence/elixir_source.ex
+++ b/apps/engine/lib/engine/code_intelligence/elixir_source.ex
@@ -1,0 +1,25 @@
+defmodule Engine.CodeIntelligence.ElixirSource do
+  @moduledoc """
+  Autodetection of the Elixir standard library source path.
+  """
+
+  # A stable file that every standard Elixir install ships under its root.
+  @sentinel Path.join("lib", "elixir/lib/kernel.ex")
+
+  @doc """
+  Returns the root of the Elixir source tree for the current installation, or
+  `nil` when it cannot be determined or does not ship sources.
+
+  The returned path is such that `<root>/lib/elixir/lib/kernel.ex` exists.
+  """
+  @spec detect() :: String.t() | nil
+  def detect do
+    with dir when is_list(dir) <- :code.lib_dir(:elixir),
+         root = dir |> List.to_string() |> Path.join("../..") |> Path.expand(),
+         true <- File.exists?(Path.join(root, @sentinel)) do
+      root
+    else
+      _ -> nil
+    end
+  end
+end

--- a/apps/engine/test/engine/code_intelligence/elixir_source_test.exs
+++ b/apps/engine/test/engine/code_intelligence/elixir_source_test.exs
@@ -1,0 +1,14 @@
+defmodule Engine.CodeIntelligence.ElixirSourceTest do
+  use ExUnit.Case, async: true
+
+  alias Engine.CodeIntelligence.ElixirSource
+
+  describe "detect/0" do
+    test "returns the source root of the running Elixir installation" do
+      root = ElixirSource.detect()
+
+      assert is_binary(root)
+      assert File.exists?(Path.join(root, "lib/elixir/lib/kernel.ex"))
+    end
+  end
+end

--- a/apps/expert/lib/expert.ex
+++ b/apps/expert/lib/expert.ex
@@ -236,6 +236,8 @@ defmodule Expert do
   def handle_info({:engine_initialized, project, {:ok, _pid}}, lsp) do
     Store.transition(project, :ready)
 
+    State.propagate_elixir_source_path_for(project)
+
     Logger.info(
       "Engine initialized for project #{Project.name(project)}",
       project: project

--- a/apps/expert/lib/expert/state.ex
+++ b/apps/expert/lib/expert/state.ex
@@ -296,24 +296,49 @@ defmodule Expert.State do
     %__MODULE__{state | deps_declined_projects: MapSet.put(declined, project.root_uri)}
   end
 
-  defp propagate_elixir_source_path(%Configuration{elixir_source_path: nil}) do
+  @doc """
+  Resolves and applies the Elixir source path for a single project that has just
+  become ready.
+  """
+  def propagate_elixir_source_path_for(%Project{} = project) do
+    if Store.ready?(project) do
+      apply_elixir_source_path(project, Configuration.get())
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp propagate_elixir_source_path(%Configuration{} = config) do
     for project <- Store.projects(), Store.ready?(project) do
-      EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_src])
+      apply_elixir_source_path(project, config)
     end
   rescue
     _ -> :ok
   end
 
-  defp propagate_elixir_source_path(%Configuration{elixir_source_path: elixir_source_path}) do
-    for project <- Store.projects(), Store.ready?(project) do
-      EngineApi.call(project, Application, :put_env, [
-        :language_server,
-        :elixir_src,
-        elixir_source_path
-      ])
+  defp apply_elixir_source_path(%Project{} = project, %Configuration{} = config) do
+    source_path =
+      case config.elixir_source_path do
+        nil ->
+          EngineApi.call(project, Engine.CodeIntelligence.ElixirSource, :detect, [])
+
+        path ->
+          path
+      end
+
+    case source_path do
+      nil ->
+        EngineApi.call(project, Application, :delete_env, [:language_server, :elixir_src])
+
+      elixir_source_path ->
+        EngineApi.call(project, Application, :put_env, [
+          :language_server,
+          :elixir_src,
+          elixir_source_path
+        ])
     end
-  rescue
-    _ -> :ok
   end
 
   defp apply_configuration_side_effects(%Configuration{} = old_config, %Configuration{} = config) do

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -67,13 +67,8 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
     EngineApi.register_listener(project, self(), [:all])
     EngineApi.schedule_compile(project, true)
 
-    # point ElixirSense at the project node's Elixir source
-    elixir_src =
-      project
-      |> EngineApi.call(:code, :lib_dir, [:elixir])
-      |> to_string()
-      |> Path.join("../..")
-      |> Path.expand()
+    elixir_src = EngineApi.call(project, Engine.CodeIntelligence.ElixirSource, :detect, [])
+    assert is_binary(elixir_src)
 
     :ok =
       EngineApi.call(project, Application, :put_env, [:language_server, :elixir_src, elixir_src])


### PR DESCRIPTION
In #760 we found a way to autodetect the Elixir source path for tests and figured it could be promoted as a feature - when there is no setting for `elixirSourcePath` we can derive it in Engine.

Only tested with `mise` installation, because I don't have any other configs at hand. But I think it degrades gracefully anyway. If the source is not detected, Expert will operate like it's not present (so as if `elixirSourcePath` is not passed).