### PR TITLE
ci: add check for Nix dependencies

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -53,15 +53,7 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
       - name: Regenerate deps.nix
-        run: |
-          nix develop --command bash -c '
-            set -euo pipefail
-            mix local.hex --force
-            mix local.rebar --force
-            for app in expert engine forge expert_credo; do
-              (cd "apps/$app" && mix deps.get && mix deps.nix)
-            done
-          '
+        run: nix run .#update-deps
 
       - name: Ensure deps.nix is up to date
         run: |

--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -35,3 +35,37 @@ jobs:
 
       - name: Build
         run: nix build .#expert
+
+  deps:
+    runs-on: ubuntu-latest
+    name: Nix Deps Up-To-Date
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+
+      - name: Setup Nix GHA Cache
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+
+      - name: Regenerate deps.nix
+        run: |
+          nix develop --command bash -c '
+            set -euo pipefail
+            mix local.hex --force
+            mix local.rebar --force
+            for app in expert engine forge expert_credo; do
+              (cd "apps/$app" && mix deps.get && mix deps.nix)
+            done
+          '
+
+      - name: Ensure deps.nix is up to date
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::deps.nix is out of date. Run 'mix deps.nix' in each app and commit the result."
+            exit 1
+          fi

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -45,7 +45,25 @@ beamPackages.mixRelease rec {
     ];
   };
 
-  mixNixDeps = callPackages ../apps/expert/deps.nix { inherit lib beamPackages; };
+  mixNixDeps = callPackages ../apps/expert/deps.nix {
+    inherit lib beamPackages;
+    # exqlite bundles the SQLite amalgamation and compiles a NIF through elixir_make.
+    # elixir_make first populates a precompiled-artefact cache under $HOME/.cache
+    # (or ~/Library/Caches on darwin). In the Nix build sandbox HOME is
+    # /homeless-shelter, so that mkdir fails and the build aborts. Point the cache at
+    # a writable location; the sandboxed download then fails and elixir_make falls
+    # back to compiling the bundled C source, which is what we want.
+    #
+    # This lives here, in deps.nix's `overrides` hook, rather than in deps.nix itself
+    # so it survives `mix deps.nix` regenerating that file.
+    overrides = _final: prev: {
+      exqlite = prev.exqlite.overrideAttrs (old: {
+        preConfigure = (old.preConfigure or "") + ''
+          export ELIXIR_MAKE_CACHE_DIR="$TMPDIR/elixir_make"
+        '';
+      });
+    };
+  };
 
   mixReleaseName = "plain";
 

--- a/nix/expert.nix
+++ b/nix/expert.nix
@@ -45,25 +45,7 @@ beamPackages.mixRelease rec {
     ];
   };
 
-  mixNixDeps = callPackages ../apps/expert/deps.nix {
-    inherit lib beamPackages;
-    # exqlite bundles the SQLite amalgamation and compiles a NIF through elixir_make.
-    # elixir_make first populates a precompiled-artefact cache under $HOME/.cache
-    # (or ~/Library/Caches on darwin). In the Nix build sandbox HOME is
-    # /homeless-shelter, so that mkdir fails and the build aborts. Point the cache at
-    # a writable location; the sandboxed download then fails and elixir_make falls
-    # back to compiling the bundled C source, which is what we want.
-    #
-    # This lives here, in deps.nix's `overrides` hook, rather than in deps.nix itself
-    # so it survives `mix deps.nix` regenerating that file.
-    overrides = _final: prev: {
-      exqlite = prev.exqlite.overrideAttrs (old: {
-        preConfigure = (old.preConfigure or "") + ''
-          export ELIXIR_MAKE_CACHE_DIR="$TMPDIR/elixir_make"
-        '';
-      });
-    };
-  };
+  mixNixDeps = callPackages ../apps/expert/deps.nix { inherit lib beamPackages; };
 
   mixReleaseName = "plain";
 


### PR DESCRIPTION
Happened to me more than once that I forgot to run `mix deps.nix` (recently on #759), so I figured we might want to have a CI check for that.