### PR TITLE
fix: make sure to return only Diagnostic.Result struct as diagnostics

### DIFF
--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -5,6 +5,7 @@ defmodule Engine.Build.State do
   alias Engine.Build
   alias Engine.Plugin
   alias Forge.Document
+  alias Forge.Plugin.V1.Diagnostic
   alias Forge.Project
   alias Forge.VM.Versions
 
@@ -140,12 +141,22 @@ defmodule Engine.Build.State do
           {:ok, diagnostics} ->
             message = project_compiled(status: :success, project: project, elapsed_ms: elapsed_ms)
 
-            {message, List.wrap(diagnostics)}
+            diagnostics =
+              diagnostics
+              |> List.wrap()
+              |> Enum.filter(&match?(%Diagnostic.Result{}, &1))
+
+            {message, diagnostics}
 
           {:error, diagnostics} ->
             message = project_compiled(status: :error, project: project, elapsed_ms: elapsed_ms)
 
-            {message, List.wrap(diagnostics)}
+            diagnostics =
+              diagnostics
+              |> List.wrap()
+              |> Enum.filter(&match?(%Diagnostic.Result{}, &1))
+
+            {message, diagnostics}
         end
 
       diagnostics_message =

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -186,6 +186,27 @@ defmodule Engine.Build.StateTest do
     end
   end
 
+  describe "project compilation with exception" do
+    setup [:with_metadata_project]
+
+    test "broadcasts exception as invalid diagnostic when compile returns {:error, {:exception, ...}}",
+         %{state: state} do
+      exception = %Mix.Error{message: "Hex dependency resolution failed"}
+      stacktrace = [{Mix, :raise, 2, [file: ~c"lib/mix.ex", line: 647]}]
+      blamed = {exception, stacktrace}
+
+      patch(Build.Project, :compile, {:error, {:exception, blamed, stacktrace}})
+
+      state
+      |> State.on_project_compile(true)
+      |> State.on_timeout()
+
+      assert_receive {:project_diagnostics, _, _, diagnostics}
+
+      assert Enum.all?(diagnostics, &match?(%Forge.Plugin.V1.Diagnostic.Result{}, &1))
+    end
+  end
+
   describe "fetching deps" do
     test "stores :ok when deps fetch succeeds" do
       {:ok, state} = with_project_state(:project_metadata)


### PR DESCRIPTION
Results from `Build.Project.compile` might contains different things than diagnostics, specifically if the `mix deps.get` fails as shown in #781. We should make sure to only treat `Diagnostic.Result` as diagnostics.

The test is kind of _meh_, but reproduces the exact error from #781.