### PR TITLE
chore: log slow SQL queries

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -9,9 +9,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   alias Forge.Search.Indexer.Entry
 
   require Entry
+  require Logger
 
   @schema_version 2
   @database_file "source.index.sqlite3"
+  @slow_query_threshold_ms 500
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params
   # per entry. 4000 entries per batch is 28000 params per batch, below SQLite's
   # limit.
@@ -870,16 +872,58 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp recoverable_database_error?(_reason), do: false
 
   defp exec(%State{} = state, statement, args \\ []) do
-    case Exqlite.Basic.exec(state.conn, statement, args) do
-      {:error, reason, _details} -> {:error, reason}
-      result -> rows_to_ok(result)
-    end
+    timed(state, statement, args, fn ->
+      case Exqlite.Basic.exec(state.conn, statement, args) do
+        {:error, reason, _details} -> {:error, reason}
+        result -> rows_to_ok(result)
+      end
+    end)
   end
 
   defp query(%State{} = state, statement, args \\ []) do
-    case Exqlite.Basic.exec(state.conn, statement, args) do
-      {:error, reason, _details} -> {:error, reason}
-      result -> rows(result)
+    timed(state, statement, args, fn ->
+      case Exqlite.Basic.exec(state.conn, statement, args) do
+        {:error, reason, _details} -> {:error, reason}
+        result -> rows(result)
+      end
+    end)
+  end
+
+  defp timed(%State{} = state, statement, args, fun) do
+    started_at = System.monotonic_time(:millisecond)
+    result = fun.()
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+
+    if elapsed_ms > @slow_query_threshold_ms do
+      log_slow_query(state, statement, args, elapsed_ms)
+    end
+
+    result
+  end
+
+  defp log_slow_query(%State{} = state, statement, args, elapsed_ms) do
+    query = String.trim(statement)
+
+    case Exqlite.Basic.exec(state.conn, "EXPLAIN QUERY PLAN #{statement}", args) do
+      {:error, _reason, _details} ->
+        Logger.warning("[SQL SLOW] #{elapsed_ms}ms | #{query}")
+
+      result ->
+        case Exqlite.Basic.rows(result) do
+          {:ok, [], _columns} ->
+            Logger.warning("[SQL SLOW] #{elapsed_ms}ms | #{query}")
+
+          {:ok, rows, _columns} ->
+            plan =
+              Enum.map_join(rows, "\n", fn row ->
+                "  " <> Enum.map_join(row, " | ", &to_string/1)
+              end)
+
+            Logger.warning("[SQL SLOW] #{elapsed_ms}ms | #{query}\nEXPLAIN QUERY PLAN:\n#{plan}")
+
+          {:error, _reason} ->
+            Logger.warning("[SQL SLOW] #{elapsed_ms}ms | #{query}")
+        end
     end
   end
 


### PR DESCRIPTION
Improved version of the code I used to track #752 - I think it would be useful to have slow queries logged for debugging. This includes logging the query plan for it too. The threshold is set to 500ms, maybe it's too low.

Chore, because it's an unreleased feature, so we don't need duplicated changelog entries for it.