### PR TITLE
chore(expert): chunk index blob deletes

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -17,8 +17,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params
   # per entry. 4000 entries per batch is 28000 params per batch, below SQLite's
   # limit.
-  # If the schema changes and we need a different number of params per entry,
-  # this number needs to be updated.
+  @sqlite_variable_limit 32_766
   @insert_batch_size 4_000
   @busy_timeout_ms Application.compile_env(:expert, :search_store_sqlite_busy_timeout_ms, 5_000)
 
@@ -714,13 +713,20 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp delete_entry_blobs_for_rows(%State{}, []), do: :ok
 
   defp delete_entry_blobs_for_rows(%State{} = state, rows) do
-    entry_keys = Enum.map(rows, fn [entry_key, _id] -> entry_key end)
+    rows
+    |> Stream.chunk_every(@sqlite_variable_limit)
+    |> Enum.reduce_while(:ok, fn rows, :ok ->
+      entry_keys = Enum.map(rows, fn [entry_key, _id] -> entry_key end)
 
-    exec(
-      state,
-      "DELETE FROM entry_blobs WHERE entry_key IN (#{placeholders(entry_keys)})",
-      entry_keys
-    )
+      case exec(
+             state,
+             "DELETE FROM entry_blobs WHERE entry_key IN (#{placeholders(entry_keys)})",
+             entry_keys
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
   end
 
   defp delete_structures_for_paths(%State{}, []), do: :ok

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -248,6 +248,58 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
       assert {:ok, [[1, 1]], _columns} = Exqlite.Basic.rows(result)
       assert :ok = Exqlite.Basic.close(conn)
     end
+
+    test "chunks blob deletes that exceed SQLite's variable limit", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      path = "/large_generated.ex"
+
+      old_entries =
+        Enum.map(1..32_767, fn id ->
+          %Entry{
+            id: id,
+            subject: "Old",
+            path: path,
+            type: :module,
+            subtype: :definition,
+            block_id: :root
+          }
+        end)
+
+      new_entry = %Entry{
+        id: 32_768,
+        subject: "New",
+        path: path,
+        type: :module,
+        subtype: :definition,
+        block_id: :root
+      }
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert :ok = Sqlite.replace_all(project, old_entries)
+      assert {:ok, deleted_ids} = Sqlite.apply_index_update(project, [new_entry], [])
+      assert length(deleted_ids) == 32_767
+      assert [] = Sqlite.find_by_subject(project, "Old", :_, :_)
+      assert [^new_entry] = Sqlite.find_by_subject(project, "New", :_, :_)
+
+      database_path = Sqlite.database_path(project, runtime_versions)
+      {:ok, conn} = Exqlite.Basic.open(database_path)
+
+      result =
+        Exqlite.Basic.exec(conn, """
+        SELECT (SELECT COUNT(*) FROM entries), (SELECT COUNT(*) FROM entry_blobs)
+        """)
+
+      assert {:ok, [[1, 1]], _columns} = Exqlite.Basic.rows(result)
+      assert :ok = Exqlite.Basic.close(conn)
+    end
   end
 
   describe "parent/2" do


### PR DESCRIPTION
We were not chunking blob deletes in the sqlite backend, resulting in errors if we tried to delete more entries than what sqlite supports