### PR TITLE
chore(sqlite): more performant way to check if table is empty

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -523,8 +523,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
          :ok <- create_entry_blobs_table(state),
          :ok <- create_structures_table(state),
          :ok <- create_indexes(state),
-         {:ok, [[count]]} <- query(state, "SELECT COUNT(*) FROM entries") do
-      if count == 0, do: {:ok, :empty}, else: {:ok, :stale}
+         {:ok, result} <- query(state, "SELECT 1 FROM entries LIMIT 1") do
+      case result do
+        [] -> {:ok, :empty}
+        [[1]] -> {:ok, :stale}
+      end
     end
   end
 


### PR DESCRIPTION
Current core uses `SELECT COUNT(*)` on `entries` table and then comparison against `0`. On large `entries` tables is take quite some time, for example at Jump:

```
10:38:32.533 instance_id=19F5AA06545 [warning] [SQL SLOW] 4146ms | SELECT COUNT(*) FROM entries
EXPLAIN QUERY PLAN:
  4 | 0 | 0 | SCAN entries USING COVERING INDEX entries_path_id_idx
```

Replacing this with `SELECT 1 LIMIT 1` should be orders of magnitude faster.

(chore, because SQLite backend is not released and we just want one entry in the changelog)