### PR TITLE
chore(sqlite): add PRAGMA optimize as suggested in the docs

### DIFF
--- a/apps/expert/lib/expert/search/store.ex
+++ b/apps/expert/lib/expert/search/store.ex
@@ -85,7 +85,11 @@ defmodule Expert.Search.Store do
     do: GenServer.call(name(project), {:update, path, entries}, :infinity)
 
   def destroy(%Project{} = project), do: GenServer.call(name(project), :destroy)
-  def enable(%Project{} = project), do: GenServer.call(name(project), :enable)
+
+  # we need higher timeout for this, as it performs optimization via PRAGMA optimize
+  # on existing database
+  def enable(%Project{} = project),
+    do: GenServer.call(name(project), :enable, :timer.seconds(30))
 
   @spec start_link(Project.t()) :: GenServer.on_start()
   def start_link(%Project{} = project), do: start_link(project, backend())

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -286,13 +286,16 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   def do_replace_all(%State{} = state, entries) when is_list(entries) do
-    transaction(state, fn ->
-      with :ok <- exec(state, "DELETE FROM entry_blobs"),
-           :ok <- exec(state, "DELETE FROM entries"),
-           :ok <- exec(state, "DELETE FROM structures") do
-        insert_entries(state, entries)
-      end
-    end)
+    with :ok <-
+           transaction(state, fn ->
+             with :ok <- exec(state, "DELETE FROM entry_blobs"),
+                  :ok <- exec(state, "DELETE FROM entries"),
+                  :ok <- exec(state, "DELETE FROM structures") do
+               insert_entries(state, entries)
+             end
+           end) do
+      exec(state, "PRAGMA optimize = 0x10002")
+    end
   end
 
   def do_apply_index_update(%State{} = state, updated_entries, paths_to_clear)
@@ -461,8 +464,10 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp initialize_schema(%State{} = state) do
     with :ok <- configure_database(state),
          :ok <- create_schema_table(state),
-         {:ok, current_version} <- current_schema_version(state) do
-      load_or_reset_schema(state, current_version)
+         {:ok, current_version} <- current_schema_version(state),
+         {:ok, status} <- load_or_reset_schema(state, current_version),
+         :ok <- exec(state, "PRAGMA optimize = 0x10002") do
+      {:ok, status}
     end
   end
 


### PR DESCRIPTION
Adds `PRAGMA optimize` according to the docs for long-living connections - so after connecting and then after large operations and schema changes. `PRAGMA optimize` attempts to optimize the database. I bumped the timeout for store enabling too, because I've seen it timeout with default 5 seconds after this change.