### PR TITLE
chore(sqlite): use recursive CTE to get path ids

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -259,7 +259,38 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   def do_path_to_ids(%State{} = state) do
-    case query(state, "SELECT path, MAX(id) FROM entries WHERE id IS NOT NULL GROUP BY path") do
+    # Used to be:
+    #   SELECT path, MAX(id) FROM entries WHERE id IS NOT NULL GROUP BY path
+    #
+    # However, even though it had high index coverage, it turned out to be inefficient,
+    # as GROUP BY forced it to scan the whole index.
+    sql = """
+    WITH RECURSIVE paths(path) AS (
+      SELECT MIN(path)
+      FROM entries
+
+      UNION ALL
+
+      SELECT (
+        SELECT MIN(path)
+        FROM entries
+        WHERE path > paths.path
+      )
+      FROM paths
+      WHERE path IS NOT NULL
+    )
+    SELECT
+      path,
+      (
+        SELECT MAX(id)
+        FROM entries
+        WHERE entries.path = paths.path
+      )
+    FROM paths
+    WHERE path IS NOT NULL
+    """
+
+    case query(state, sql) do
       {:ok, rows} -> Map.new(rows, fn [path, id] -> {path, id} end)
       {:error, _} = error -> error
     end


### PR DESCRIPTION
Despite the index coverage, the query to get path ids was slow. On Jump codebase it could exceed 5 seconds:

```
12:30:46.317 instance_id=19F5B06E4DF [warning] [SQL SLOW] 5068ms | SELECT path, MAX(id) FROM entries WHERE id IS NOT NULL GROUP BY path
EXPLAIN QUERY PLAN:
  7 | 0 | 217 | SCAN entries USING COVERING INDEX entries_path_id_idx
```

This was because the whole index had to be scanned for GROUP BY. This PR adds a bit tricky recursive CTE, to first iterate over paths and then join max id.

```
15:36:27.984 instance_id=19F5BB0F594 [warning] [SQL SLOW] 910ms | WITH RECURSIVE paths(path) AS (
  SELECT MIN(path)
  FROM entries

  UNION ALL

  SELECT (
    SELECT MIN(path)
    FROM entries
    WHERE path > paths.path
  )
  FROM paths
  WHERE path IS NOT NULL
)
SELECT
  path,
  (
    SELECT MAX(id)
    FROM entries
    WHERE entries.path = paths.path
  )
FROM paths
WHERE path IS NOT NULL
EXPLAIN QUERY PLAN:
  2 | 0 | 0 | CO-ROUTINE paths
  5 | 2 | 0 | SETUP
  8 | 5 | 217 | SEARCH entries USING COVERING INDEX entries_path_id_idx
  26 | 2 | 0 | RECURSIVE STEP
  27 | 26 | 216 | SCAN paths
  31 | 26 | 0 | CORRELATED SCALAR SUBQUERY 2
  36 | 31 | 197 | SEARCH entries USING COVERING INDEX entries_path_id_idx (path>?)
  56 | 0 | 215 | SCAN paths
  63 | 0 | 0 | CORRELATED SCALAR SUBQUERY 4
  68 | 63 | 82 | SEARCH entries USING COVERING INDEX entries_path_id_idx (path=?)
```

The alternative to this high-complexity query would be to create a separate `path_ids` table, keeping only path <-> max(id), but it has some downsides I'm afraid (even though the LLM seems to strongly push in that direction):
- we have to remember to update the cache every time we touch `entries` for `path` or `id`, and this is easy to overlook, leading to stale cache and subtle error
- quite big data duplication on `path`

But the query would be super simple in that case.