### PR TITLE
chore(sqlite): fix indexer crash on defmodule without a block

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -1035,6 +1035,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp subtype_key(subtype), do: Atom.to_string(subtype)
 
   defp block_id_key(:root), do: 0
+  defp block_id_key(nil), do: 0
   defp block_id_key(block_id) when is_integer(block_id), do: block_id
 
   defp blob(term), do: {:blob, encode_term(term)}

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -171,6 +171,25 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
     end
   end
 
+  describe "replace_all/2 with indexed source entries" do
+    test "handles modules defined with keyword do syntax", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      start_supervised!(Engine.ApplicationCache)
+      {:ok, entries} = Engine.Search.Indexer.Source.index("/foo.ex", "defmodule Foo, do: :ok")
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert :ok = Sqlite.replace_all(project, entries)
+    end
+  end
+
   describe "insert/2" do
     test "persists entries", %{project: project, runtime_versions: runtime_versions} do
       entry = %Entry{


### PR DESCRIPTION
This fixes one found case which results in the error reported in #790. ~~This feels very contrived, but~~ it's a valid code, so I guess we should be able to handle that.