### PR TITLE
feat: use compiler tracers to index definitions

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -15,6 +15,7 @@ defmodule Engine.Application do
           Engine.Api.Proxy,
           Engine.Commands.Reindex,
           Engine.Module.Loader,
+          Engine.Compilation.TraceBuffer,
           Engine.Dispatch,
           Engine.ModuleMappings,
           Engine.Build,

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -128,6 +128,7 @@ defmodule Engine.Build.State do
         project_compile_requested(project: project, build_number: state.build_number)
 
       Engine.broadcast(compile_requested_message)
+      Engine.Compilation.TraceBuffer.discard()
       {elapsed_us, result} = :timer.tc(fn -> Build.Project.compile(project, initial?) end)
       elapsed_ms = to_ms(elapsed_us)
 
@@ -149,6 +150,7 @@ defmodule Engine.Build.State do
             {message, diagnostics}
 
           {:error, diagnostics} ->
+            Engine.Compilation.TraceBuffer.discard()
             message = project_compiled(status: :error, project: project, elapsed_ms: elapsed_ms)
 
             diagnostics =

--- a/apps/engine/lib/engine/compilation/trace_buffer.ex
+++ b/apps/engine/lib/engine/compilation/trace_buffer.ex
@@ -1,0 +1,66 @@
+defmodule Engine.Compilation.TraceBuffer do
+  use GenServer
+
+  alias Engine.Search.Indexer.Beams
+
+  @table __MODULE__
+
+  defstruct []
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %__MODULE__{}, name: __MODULE__)
+  end
+
+  def discard, do: call(:discard)
+
+  def drain_definitions, do: call(:drain_definitions, :infinity)
+
+  def record_module(path, binary) when is_binary(path) and is_binary(binary) do
+    true = :ets.insert(@table, {Forge.Path.native(path), binary})
+    :ok
+  end
+
+  def record_module(_path, _binary), do: :ok
+
+  @impl GenServer
+  def init(%__MODULE__{} = state) do
+    _ = :ets.new(@table, [:named_table, :public, :duplicate_bag, write_concurrency: true])
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:discard, _from, %__MODULE__{} = state) do
+    clear_live()
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:drain_definitions, _from, %__MODULE__{} = state) do
+    definitions = definitions_by_path(live_events())
+    clear_live()
+    {:reply, {:ok, definitions}, state}
+  end
+
+  defp call(message, timeout \\ 5_000), do: GenServer.call(__MODULE__, message, timeout)
+
+  defp live_events do
+    :ets.tab2list(@table)
+  end
+
+  defp clear_live do
+    :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  defp definitions_by_path(events) do
+    events
+    |> Enum.flat_map(&definitions_from_event/1)
+    |> Enum.group_by(& &1.path)
+  end
+
+  defp definitions_from_event({path, binary}) do
+    case Beams.extract_definitions_from_binary(binary, path) do
+      {:ok, entries} -> entries
+      :error -> []
+    end
+  end
+end

--- a/apps/engine/lib/engine/compilation/tracer.ex
+++ b/apps/engine/lib/engine/compilation/tracer.ex
@@ -2,10 +2,12 @@ defmodule Engine.Compilation.Tracer do
   import Forge.EngineApi.Messages
 
   alias Engine.Build
+  alias Engine.Compilation.TraceBuffer
   alias Engine.Module.Loader
   alias Engine.Progress
 
   def trace({:on_module, module_binary, _filename}, %Macro.Env{} = env) do
+    maybe_record_module(env.file, module_binary)
     message = extract_module_updated(env.module, module_binary, env.file)
     maybe_report_progress(env.file)
     Engine.broadcast(message)
@@ -48,6 +50,13 @@ defmodule Engine.Compilation.Tracer do
       Progress.report(token, message: progress_message(file))
     end
   end
+
+  defp maybe_record_module(file, module_binary)
+       when is_binary(file) and is_binary(module_binary) do
+    TraceBuffer.record_module(file, module_binary)
+  end
+
+  defp maybe_record_module(_file, _module_binary), do: :ok
 
   defp progress_message(file) do
     relative_path_elements =

--- a/apps/engine/lib/engine/manager_api.ex
+++ b/apps/engine/lib/engine/manager_api.ex
@@ -57,7 +57,7 @@ defmodule Engine.ManagerApi do
     )
   end
 
-  @spec search_store_all(Project.t(), Entry.constraints()) ::
+  @spec search_store_all(Project.t(), [Entry.constraint() | {:paths, [Path.t()]}]) ::
           {:ok, [Entry.t()]} | {:error, term()} | []
   def search_store_all(%Project{} = project, constraints \\ []) do
     Dispatch.erpc_call(Expert.Search.Store, :all, [project, constraints], @search_timeout)

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -736,9 +736,9 @@ defmodule Engine.Search.Indexer.Beams do
   end
 
   defp position(line, column, context_line) do
-    # NOTE(doorgan): We need to populate the `document_line_count` otherwise the
-    # will end up pointing to the top of the file. We are faking it here instead
-    # of actually reading the file for performance, and it seems to work
+    # NOTE(doorgan): We need to populate `document_line_count` otherwise the LSP
+    # range will end up pointing to the top of the file. We are faking it here
+    # instead of actually reading the file for performance, and it seems to work
     # well despite being a hack.
     %Position{
       line: line,

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -1,4 +1,6 @@
 defmodule Engine.Search.Indexer.Beams do
+  import Forge.Document.Line
+
   alias Engine.ApplicationCache
   alias Engine.Progress
   alias Engine.Search.Indexer.Manifest
@@ -17,6 +19,22 @@ defmodule Engine.Search.Indexer.Beams do
     beams
     |> index_beam_chunks(total_bytes)
     |> entries_and_manifest_entries()
+  end
+
+  def extract_definitions_from_binary(beam, source_path)
+      when is_binary(beam) and is_binary(source_path) do
+    with {:ok, metadata} <- debug_metadata_from_binary(beam) do
+      metadata = Map.put(metadata, :file, Forge.Path.native(source_path))
+
+      entries =
+        metadata
+        |> entries_from_metadata(
+          source_lines(source_path, [metadata |> metadata_position() |> elem(0)])
+        )
+        |> Enum.filter(&definition?/1)
+
+      {:ok, entries}
+    end
   end
 
   defp stat_beams(paths) do
@@ -171,6 +189,18 @@ defmodule Engine.Search.Indexer.Beams do
   defp debug_metadata(beam_path) do
     with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
            :beam_lib.chunks(String.to_charlist(beam_path), [:debug_info]),
+         {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
+      {:ok, metadata}
+    else
+      _ -> :error
+    end
+  catch
+    _kind, _reason -> :error
+  end
+
+  defp debug_metadata_from_binary(beam) do
+    with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
+           :beam_lib.chunks(beam, [:debug_info]),
          {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
       {:ok, metadata}
     else
@@ -684,6 +714,9 @@ defmodule Engine.Search.Indexer.Beams do
 
   defp valid_line?(line), do: is_integer(line) and line > 0
 
+  defp definition?(%Entry{subtype: :definition}), do: true
+  defp definition?(_entry), do: false
+
   defp metadata_position(metadata) do
     case Map.get(metadata, :anno) || Map.get(metadata, :line) do
       {line, column} -> {line, column}
@@ -693,10 +726,32 @@ defmodule Engine.Search.Indexer.Beams do
   end
 
   defp range(line, column, length) do
+    end_column = column + max(length, 1)
+    context_line = synthetic_line(line, end_column)
+
     Range.new(
-      %Position{line: line, character: column, starting_index: 1},
-      %Position{line: line, character: column + max(length, 1), starting_index: 1}
+      position(line, column, context_line),
+      position(line, end_column, context_line)
     )
+  end
+
+  defp position(line, column, context_line) do
+    # NOTE(doorgan): We need to populate the `document_line_count` otherwise the
+    # will end up pointing to the top of the file. We are faking it here instead
+    # of actually reading the file for performance, and it seems to work
+    # well despite being a hack.
+    %Position{
+      line: line,
+      character: column,
+      context_line: context_line,
+      document_line_count: line,
+      starting_index: 1,
+      valid?: true
+    }
+  end
+
+  defp synthetic_line(line_number, column) do
+    line(text: String.duplicate(" ", max(column - 1, 0)), ending: "", line_number: line_number)
   end
 
   defp task_result!({:ok, items}), do: items

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -14,6 +14,7 @@ defmodule Engine.Build.StateTest do
     start_supervised!(Engine.Dispatch)
     start_supervised!(Engine.Api.Proxy)
     start_supervised!(Build.CaptureServer)
+    start_supervised!(Engine.Compilation.TraceBuffer)
     start_supervised!(Engine.ModuleMappings)
     start_supervised!(Plugin.Runner.Coordinator)
     start_supervised!(Plugin.Runner.Supervisor)

--- a/apps/engine/test/engine/search/indexer/beams_test.exs
+++ b/apps/engine/test/engine/search/indexer/beams_test.exs
@@ -93,6 +93,100 @@ defmodule Engine.Search.Indexer.BeamsTest do
       refute Enum.any?(entries, &(&1.subject == private_fun and &1.subtype == :definition))
     end
 
+    test "indexes definitions from module binaries", %{
+      tmp_dir: tmp_dir
+    } do
+      module = unique_module("BinaryDefinitions")
+
+      %{beam_paths_by_module: beam_paths_by_module} =
+        compile_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(module)} do
+            def public_fun, do: :ok
+          end
+          """,
+          expected_modules: [module],
+          rewrite_source?: false
+        )
+
+      {entries, _manifest_entries} = Beams.index([Map.fetch!(beam_paths_by_module, module)])
+
+      for {subject, type} <- [
+            {module, :module},
+            {Formats.mfa(module, :public_fun, 0), {:function, :public}}
+          ] do
+        assert Enum.any?(
+                 entries,
+                 &(&1.subject == subject and &1.type == type and &1.subtype == :definition)
+               )
+      end
+
+      assert %Entry{range: %{start: start_pos}} =
+               Enum.find(entries, &(&1.subject == Formats.mfa(module, :public_fun, 0)))
+
+      assert start_pos.line == 2
+      assert start_pos.valid?
+      assert start_pos.document_line_count >= start_pos.line
+      assert start_pos.context_line != nil
+    end
+
+    test "synthesizes contextual ranges for macro-generated definitions from beam metadata", %{
+      tmp_dir: tmp_dir
+    } do
+      macro_module = unique_module("GeneratedFunctionMacro")
+      target_module = unique_module("GeneratedFunctionTarget")
+
+      source = """
+      defmodule #{inspect(macro_module)} do
+        defmacro fun(name) do
+          quote do
+            def unquote(name), do: :ok
+          end
+        end
+      end
+
+      defmodule #{inspect(target_module)} do
+        require #{inspect(macro_module)}
+        #{inspect(macro_module)}.fun(gen)
+      end
+      """
+
+      %{beam_paths_by_module: beam_paths_by_module} =
+        compile_source!(tmp_dir, source,
+          expected_modules: [macro_module, target_module],
+          rewrite_source?: false
+        )
+
+      {entries, _manifest_entries} =
+        Beams.index([Map.fetch!(beam_paths_by_module, target_module)])
+
+      generated_fun = Formats.mfa(target_module, :gen, 0)
+
+      macro_call_line =
+        source |> String.split("\n") |> Enum.find_index(&String.contains?(&1, ".fun(gen)"))
+
+      macro_call_line = macro_call_line + 1
+      macro_call_text = source |> String.split("\n") |> Enum.at(macro_call_line - 1)
+      {gen_byte, _length} = :binary.match(macro_call_text, "gen)")
+      gen_column = macro_call_text |> binary_part(0, gen_byte) |> String.length() |> Kernel.+(1)
+
+      assert %Entry{range: range} =
+               Enum.find(
+                 entries,
+                 &(&1.subject == generated_fun and &1.type == {:function, :public} and
+                     &1.subtype == :definition)
+               )
+
+      assert range.start.line == macro_call_line
+      assert range.start.character == gen_column
+      assert range.end.line == macro_call_line
+      assert range.end.character == gen_column + String.length("gen")
+      assert range.start.valid?
+      assert range.start.document_line_count == range.start.line
+      assert range.start.context_line != nil
+    end
+
     test "does not run the source indexer for BEAM-backed entries", %{tmp_dir: tmp_dir} do
       patch(Engine.Search.Indexer.Source, :index, fn _path, _source, _extractors ->
         flunk("BEAM indexing must not call the source indexer")

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -173,8 +173,7 @@ defmodule Expert.Project.Indexer do
   defp apply_trace_definitions(_project, trace_batch) when map_size(trace_batch) == 0, do: :ok
 
   defp apply_trace_definitions(%Project{} = project, trace_batch) when is_map(trace_batch) do
-    with {:ok, all_entries} <- Search.Store.all(project, []) do
-      current_entries = Enum.filter(all_entries, &Map.has_key?(trace_batch, &1.path))
+    with {:ok, current_entries} <- Search.Store.all(project, paths: Map.keys(trace_batch)) do
       trace_entries = missing_trace_entries(current_entries, trace_batch)
 
       case trace_entries do

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -22,6 +22,7 @@ defmodule Expert.Project.Indexer do
       :task_supervisor,
       :create_index,
       :update_index,
+      :trace_batch,
       :initial_compile?,
       pending?: false
     ]
@@ -93,6 +94,8 @@ defmodule Expert.Project.Indexer do
   @impl GenServer
   def handle_info(project_compiled(status: status), %State{} = state)
       when status in [:success, :successful, :error] do
+    trace_batch = if status == :error, do: %{}, else: drain_trace_definitions(state)
+    state = %State{state | trace_batch: trace_batch}
     {:noreply, start_or_queue_index(state)}
   end
 
@@ -100,15 +103,16 @@ defmodule Expert.Project.Indexer do
     Process.demonitor(ref, [:flush])
     log_index_result(result)
 
-    state = %State{state | task: nil}
-    {:noreply, maybe_run_pending(state)}
+    {:noreply, complete_index(state, result)}
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, reason}, %State{task: %Task{ref: ref}} = state) do
+  def handle_info(
+        {:DOWN, ref, :process, _pid, reason},
+        %State{task: %Task{ref: ref}} = state
+      ) do
     Logger.error("Search indexing failed: #{Exception.format_exit(reason)}")
 
-    state = %State{state | task: nil}
-    {:noreply, maybe_run_pending(state)}
+    {:noreply, complete_index(state, {:error, reason})}
   end
 
   def handle_info(_message, %State{} = state), do: {:noreply, state}
@@ -124,20 +128,90 @@ defmodule Expert.Project.Indexer do
     %State{state | task: task, pending?: false}
   end
 
-  defp maybe_run_pending(%State{pending?: true} = state) do
-    state
-    |> Map.put(:pending?, false)
-    |> start_or_queue_index()
+  defp complete_index(%State{pending?: true} = state, _result),
+    do: start_or_queue_index(%State{state | task: nil, pending?: false})
+
+  defp complete_index(%State{} = state, :ok) do
+    state = %State{state | task: nil}
+
+    case apply_trace_definitions(state.project, state.trace_batch) do
+      :ok ->
+        broadcast_index_ready(state)
+
+      {:error, reason} ->
+        Logger.warning("Could not apply compiler trace index supplement: #{inspect(reason)}")
+        broadcast_index_ready(state)
+    end
   end
 
-  defp maybe_run_pending(%State{} = state), do: state
+  defp complete_index(%State{} = state, _result) do
+    %State{state | task: nil, trace_batch: nil}
+  end
 
   defp run_index(%Project{} = project, create_index, update_index) do
-    with :ok <- Search.Store.enable(project),
-         :ok <-
-           persist_index(project, Search.Store.load_status(project), create_index, update_index) do
-      EngineApi.broadcast(project, project_index_ready(project: project))
+    with :ok <- Search.Store.enable(project) do
+      persist_index(project, Search.Store.load_status(project), create_index, update_index)
     end
+  end
+
+  defp broadcast_index_ready(%State{} = state) do
+    EngineApi.broadcast(state.project, project_index_ready(project: state.project))
+    %State{state | trace_batch: nil}
+  end
+
+  defp drain_trace_definitions(%State{project: project}) do
+    case EngineApi.call(project, Engine.Compilation.TraceBuffer, :drain_definitions, []) do
+      {:ok, entries_by_path} when is_map(entries_by_path) ->
+        entries_by_path
+
+      {:error, reason} ->
+        Logger.warning("Could not drain compiler trace index supplement: #{inspect(reason)}")
+        %{}
+    end
+  end
+
+  defp apply_trace_definitions(_project, trace_batch) when map_size(trace_batch) == 0, do: :ok
+
+  defp apply_trace_definitions(%Project{} = project, trace_batch) when is_map(trace_batch) do
+    with {:ok, all_entries} <- Search.Store.all(project, []) do
+      current_entries = Enum.filter(all_entries, &Map.has_key?(trace_batch, &1.path))
+      trace_entries = missing_trace_entries(current_entries, trace_batch)
+
+      case trace_entries do
+        [] -> :ok
+        [_ | _] -> Search.Store.apply_index_update(project, current_entries ++ trace_entries, [])
+      end
+    end
+  end
+
+  defp missing_trace_entries(current_entries, trace_batch) do
+    current_keys =
+      current_entries
+      |> Enum.filter(&definition?/1)
+      |> MapSet.new(&definition_identity/1)
+
+    trace_entries =
+      trace_batch
+      |> Enum.flat_map(fn {_path, entries} -> entries end)
+      |> Enum.filter(&definition?/1)
+
+    {_keys, missing_entries} =
+      Enum.reduce(trace_entries, {current_keys, []}, fn entry, {keys, entries} ->
+        key = definition_identity(entry)
+
+        if MapSet.member?(keys, key),
+          do: {keys, entries},
+          else: {MapSet.put(keys, key), [entry | entries]}
+      end)
+
+    Enum.reverse(missing_entries)
+  end
+
+  defp definition?(%{subtype: :definition}), do: true
+  defp definition?(_entry), do: false
+
+  defp definition_identity(%{path: path, subject: subject, subtype: :definition, type: type}) do
+    {path, subject, :definition, type}
   end
 
   defp persist_index(%Project{} = project, :empty, create_index, _update_index) do
@@ -181,9 +255,11 @@ defmodule Expert.Project.Indexer do
 
   defp log_index_result(:ok), do: :ok
 
-  defp log_index_result({:error, reason}),
-    do: Logger.warning("Could not refresh index: #{inspect(reason)}")
+  defp log_index_result({:error, reason}) do
+    Logger.warning("Could not refresh index: #{inspect(reason)}")
+  end
 
-  defp log_index_result(other),
-    do: Logger.warning("Unexpected index refresh result: #{inspect(other)}")
+  defp log_index_result(other) do
+    Logger.warning("Unexpected index refresh result: #{inspect(other)}")
+  end
 end

--- a/apps/expert/lib/expert/search/store.ex
+++ b/apps/expert/lib/expert/search/store.ex
@@ -58,7 +58,8 @@ defmodule Expert.Search.Store do
     call_or_default(project, {:fuzzy, subject, constraints}, [])
   end
 
-  @spec all(Project.t(), Entry.constraints()) :: {:ok, [Entry.t()]} | {:error, term()} | []
+  @spec all(Project.t(), [Entry.constraint() | {:paths, [Path.t()]}]) ::
+          {:ok, [Entry.t()]} | {:error, term()} | []
   def all(%Project{} = project, constraints \\ []) do
     call_or_default(project, {:all, constraints}, [])
   end

--- a/apps/expert/lib/expert/search/store/backend.ex
+++ b/apps/expert/lib/expert/search/store/backend.ex
@@ -45,6 +45,8 @@ defmodule Expert.Search.Store.Backend do
                 Entry.t()
               ]
               | {:error, any()}
+  @callback find_by_paths(Project.t(), [Path.t()], type_query(), subtype_query()) ::
+              [Entry.t()] | {:error, any()}
   @callback siblings(Project.t(), Entry.t()) ::
               [Entry.t()] | :error | {:ok, [Entry.t()]} | {:error, any()}
   @callback parent(Project.t(), Entry.t()) :: {:ok, Entry.t()} | :error | {:error, any()}

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -111,6 +111,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   @impl Backend
+  def find_by_paths(%Project{} = project, paths, type, subtype) when is_list(paths) do
+    GenServer.call(name(project), {:find_by_paths, paths, type, subtype}, :infinity)
+  end
+
+  @impl Backend
   def structure_for_path(%Project{} = project, path) do
     GenServer.call(name(project), {:structure_for_path, path}, :infinity)
   end
@@ -227,6 +232,9 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   def handle_call({:find_by_ids, ids, type, subtype}, _from, %State{} = state),
     do: reply(do_find_by_ids(state, ids, type, subtype), state)
+
+  def handle_call({:find_by_paths, paths, type, subtype}, _from, %State{} = state),
+    do: reply(do_find_by_paths(state, paths, type, subtype), state)
 
   def handle_call({:structure_for_path, path}, _from, %State{} = state),
     do: reply(do_structure_for_path(state, path), state)
@@ -406,6 +414,26 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
           Enum.flat_map(ids, fn id -> Map.get(entries_by_id, id, []) end)
         end
+    end
+  end
+
+  def do_find_by_paths(%State{}, [], _type, _subtype), do: []
+
+  def do_find_by_paths(%State{} = state, paths, type, subtype) when is_list(paths) do
+    result =
+      paths
+      |> Enum.uniq()
+      |> Stream.chunk_every(path_chunk_size(type, subtype))
+      |> Enum.reduce_while([], fn paths, batches ->
+        case find_by_path_chunk(state, paths, type, subtype) do
+          entries when is_list(entries) -> {:cont, [entries | batches]}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:error, _} = error -> error
+      batches -> batches |> Enum.reverse() |> List.flatten()
     end
   end
 
@@ -788,6 +816,19 @@ defmodule Expert.Search.Store.Backends.Sqlite do
       """,
       args
     )
+  end
+
+  defp find_by_path_chunk(%State{} = state, paths, type, subtype) do
+    {where, args} =
+      constraints(["entries.path IN (#{placeholders(paths)})"], paths, type, subtype)
+
+    state
+    |> query_entries(where_clause(where), args)
+    |> entries_result()
+  end
+
+  defp path_chunk_size(type, subtype) do
+    @sqlite_variable_limit - Enum.count([type, subtype], &(&1 != :_))
   end
 
   defp entries_result({:ok, rows}) do

--- a/apps/expert/lib/expert/search/store/state.ex
+++ b/apps/expert/lib/expert/search/store/state.ex
@@ -130,11 +130,20 @@ defmodule Expert.Search.Store.State do
   def all(%__MODULE__{} = state, constraints) do
     type = Keyword.get(constraints, :type, :_)
     subtype = Keyword.get(constraints, :subtype, :_)
+    paths = Keyword.get(constraints, :paths, :_)
 
-    case state.backend.find_by_subject(state.project, :_, type, subtype) do
+    case all_entries(state, paths, type, subtype) do
       {:error, _} = error -> error
       entries -> {:ok, entries}
     end
+  end
+
+  defp all_entries(state, :_, type, subtype) do
+    state.backend.find_by_subject(state.project, :_, type, subtype)
+  end
+
+  defp all_entries(state, paths, type, subtype) when is_list(paths) do
+    state.backend.find_by_paths(state.project, paths, type, subtype)
   end
 
   def path_to_ids(%__MODULE__{} = state) do

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -40,6 +40,10 @@ defmodule Expert.Project.IndexerTest do
     test_pid = self()
     entry = definition(id: 1, subject: ProjectIndexer.Initial, path: "/initial.ex")
 
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:ok, %{}}
+    end)
+
     start_supervised!(
       {Indexer,
        [
@@ -62,9 +66,9 @@ defmodule Expert.Project.IndexerTest do
     )
 
     EngineApi.broadcast(project, project_compiled(project: project, status: :success))
-
     assert_receive :create_index
     refute_receive :update_index
+
     assert_receive {:after_apply, {:ok, [^entry]}}
     assert_receive project_index_ready(project: ^project)
     assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.Initial, [])
@@ -117,6 +121,10 @@ defmodule Expert.Project.IndexerTest do
 
     test_pid = self()
 
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:ok, %{}}
+    end)
+
     start_supervised!(
       {Indexer,
        [
@@ -139,13 +147,154 @@ defmodule Expert.Project.IndexerTest do
     )
 
     EngineApi.broadcast(project, project_compiled(project: project, status: :success))
-
     assert_receive {:update_index, %{^path => 1}}
     refute_receive :create_index
+
     assert_receive {:after_apply, {:ok, [^new_entry]}}
     assert_receive project_index_ready(project: ^project)
     assert {:ok, []} = Store.exact(project, ProjectIndexer.Stale, [])
     assert {:ok, [^new_entry]} = Store.exact(project, ProjectIndexer.Fresh, [])
+  end
+
+  test "applies compiler trace definitions after the normal index write", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    test_pid = self()
+    structure_entry = Entry.block_structure("/generated.ex", %{root: %{}})
+    source_entry = definition(id: 1, subject: ProjectIndexer.Source, path: "/generated.ex")
+    trace_entry = definition(id: 2, subject: ProjectIndexer.Generated, path: "/generated.ex")
+
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:ok, %{trace_entry.path => [trace_entry]}}
+    end)
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project ->
+           send(test_pid, {:create_started, self()})
+
+           receive do
+             :finish_index -> {:ok, [structure_entry, source_entry], fn -> :ok end}
+           end
+         end,
+         update_index: fn ^project, _path_to_ids -> {:ok, [], [], fn -> :ok end} end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+    assert_receive {:create_started, index_task}
+    refute_receive project_index_ready(project: ^project), 100
+
+    send(index_task, :finish_index)
+
+    assert_receive project_index_ready(project: ^project)
+
+    assert {:ok, [%Entry{subject: ProjectIndexer.Generated}]} =
+             Store.exact(project, ProjectIndexer.Generated, [])
+
+    assert {:ok, [^source_entry]} = Store.exact(project, ProjectIndexer.Source, [])
+  end
+
+  test "uses the latest trace batch when successful compiles overlap indexing", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    test_pid = self()
+    first_entry = definition(id: 1, subject: ProjectIndexer.First, path: "/stale_trace.ex")
+    second_entry = definition(id: 2, subject: ProjectIndexer.Second, path: "/stale_trace.ex")
+    old_trace = definition(id: 3, subject: ProjectIndexer.OldTrace, path: "/stale_trace.ex")
+    new_trace = definition(id: 4, subject: ProjectIndexer.NewTrace, path: "/stale_trace.ex")
+
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      send(test_pid, {:drain_trace, self()})
+
+      receive do
+        {:trace_batch, batch} -> {:ok, batch}
+      end
+    end)
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project ->
+           send(test_pid, {:index_started, self(), :first})
+
+           receive do
+             :finish_index -> {:ok, [first_entry], fn -> :ok end}
+           end
+         end,
+         update_index: fn ^project, _path_to_ids ->
+           send(test_pid, {:index_started, self(), :second})
+
+           receive do
+             :finish_index -> {:ok, [second_entry], [], fn -> :ok end}
+           end
+         end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+    assert_receive {:drain_trace, drain_task}
+    send(drain_task, {:trace_batch, %{old_trace.path => [old_trace]}})
+    assert_receive {:index_started, first_task, :first}
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+    assert_receive {:drain_trace, drain_task}
+    send(drain_task, {:trace_batch, %{new_trace.path => [new_trace]}})
+
+    send(first_task, :finish_index)
+    assert_receive {:index_started, second_task, :second}
+
+    send(second_task, :finish_index)
+    assert_receive project_index_ready(project: ^project)
+
+    assert {:ok, []} = Store.exact(project, ProjectIndexer.OldTrace, [])
+    assert {:ok, []} = Store.exact(project, ProjectIndexer.First, [])
+
+    assert {:ok, [%Entry{subject: ProjectIndexer.NewTrace}]} =
+             Store.exact(project, ProjectIndexer.NewTrace, [])
+
+    assert {:ok, [%Entry{subject: ProjectIndexer.Second}]} =
+             Store.exact(project, ProjectIndexer.Second, [])
+  end
+
+  test "source entries win over duplicate compiler trace definitions", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    path = "/duplicate.ex"
+    source_entry = definition(id: 1, subject: ProjectIndexer.Duplicate, path: path)
+    trace_entry = definition(id: 2, subject: ProjectIndexer.Duplicate, path: path)
+    unique_trace_entry = definition(id: 3, subject: ProjectIndexer.TraceOnly, path: path)
+    duplicate_trace_entry = definition(id: 4, subject: ProjectIndexer.TraceOnly, path: path)
+
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:ok, %{path => [trace_entry, unique_trace_entry, duplicate_trace_entry]}}
+    end)
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project -> {:ok, [source_entry], fn -> :ok end} end,
+         update_index: fn ^project, _path_to_ids -> {:ok, [], [], fn -> :ok end} end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+
+    assert_receive project_index_ready(project: ^project)
+    assert {:ok, [^source_entry]} = Store.exact(project, ProjectIndexer.Duplicate, [])
+
+    assert {:ok, [%Entry{subject: ProjectIndexer.TraceOnly}]} =
+             Store.exact(project, ProjectIndexer.TraceOnly, [])
   end
 
   defp definition(opts) do

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -417,4 +417,22 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
       assert [^three, ^one, ^three] = Sqlite.find_by_ids(project, [3, 1, 3], :_, :definition)
     end
   end
+
+  describe "find_by_paths/4" do
+    test "chunks path lists that exceed SQLite's variable limit", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      paths = Enum.map(1..32_767, &"/generated/#{&1}.ex")
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert [] = Sqlite.find_by_paths(project, paths, :module, :definition)
+    end
+  end
 end

--- a/apps/expert/test/expert/search/store/state_test.exs
+++ b/apps/expert/test/expert/search/store/state_test.exs
@@ -25,6 +25,8 @@ defmodule Expert.Search.Store.StateTest do
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, [2], :module, :definition), do: [entry(2)]
     def find_by_ids(_project, _ids, _type, _subtype), do: []
+    def find_by_paths(_project, ["/query_backend.ex"], :module, :definition), do: [entry(3)]
+    def find_by_paths(_project, _paths, _type, _subtype), do: []
     def path_to_ids(_project), do: %{}
     def definitions_for_fuzzy(_project), do: []
     def siblings(_project, _entry), do: []
@@ -60,6 +62,7 @@ defmodule Expert.Search.Store.StateTest do
     def find_by_subject(_project, _subject, _type, _subtype), do: []
     def find_by_prefix(_project, _prefix, _type, _subtype), do: []
     def find_by_ids(_project, _ids, _type, _subtype), do: []
+    def find_by_paths(_project, _paths, _type, _subtype), do: []
     def path_to_ids(_project), do: %{}
     def definitions_for_fuzzy(_project), do: []
     def siblings(_project, _entry), do: []
@@ -98,6 +101,9 @@ defmodule Expert.Search.Store.StateTest do
     }
 
     assert {:ok, [%Entry{id: 1}]} = State.all(state, type: :module, subtype: :definition)
+
+    assert {:ok, [%Entry{id: 3}]} =
+             State.all(state, paths: ["/query_backend.ex"], type: :module, subtype: :definition)
 
     assert {:ok, [%Entry{id: 2}]} =
              State.fuzzy(state, "Needle", type: :module, subtype: :definition)


### PR DESCRIPTION
Alternative to #764 in the hopes we'll get the same benefits from tracers without paying as high of a price on big projects with large files

The idea is rather simple:
- We are already able to index most things, including references, and indexing times are not *terrible*
- We are not able to index code generated by macros, so if module A has functions defined by macros and module B calls those functions from A, it is very likely that we won't be able to index references for the B functions, nor be able to find them with workspace symbols
- Compiler tracers see the module bytecode after compilation, so we are able to extract definitions from there
- If we use the compiler tracers to complete what we index by reading source files, we get a more complete index with relatively low effort

The way this is implemented is via a new function in the existing Tracer, and a TraceBuffer(same idea as #764) that receives and processes the tracer events to not slow down compilation. The results of this are then added to the index.


This PR does not remove the locks that serialize compilation and indexing, so right now they don't run in parallel, but changes here were made assuming that they can run in parallel. If they do, then we are open to race conditions where the tracer or the index may overwrite the results of one another. To prevent, we wait for the indexer to finish if it's still running before adding the extra results, that is we try to write the results in the order source indexer -> compiler tracer.

---

The previous PR is way larger and does a lot more work than this, but ultimately I think its benefits do not outweight the costs. One particular issue is references: compiler tracers make it trivial to retrieve function, struct and module references, but they come as one event per reference. Those events don't hold as much information as we need for out index, so we need to read the source file anyways to refine the entry ranges. If we go to disk once per reference, this is easily an n^2 problem and compilation runs slow as molasses for huge files. If we want to avoid this we need a lot of ceremony to buffer references so we can perform the range analysis, but at this point this is almost the same as the source indexer, so it's not really a benefit. That is the main reason we're exploring this alternative, simpler approach.