### PR TITLE
fix: report progress after a file is indexed

### DIFF
--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -40,12 +40,16 @@ defmodule Engine.Search.Indexer.Beams do
       results =
         beams
         |> beam_chunks()
-        |> Task.async_stream(&index_beam_chunk(&1, report),
+        |> Task.async_stream(&index_beam_chunk/1,
           max_concurrency: @beam_index_concurrency,
           ordered: false,
           timeout: :infinity
         )
-        |> Enum.flat_map(&task_result!/1)
+        |> Enum.flat_map(fn task_result ->
+          {chunk_bytes, chunk_results} = task_result!(task_result)
+          report.(message: "Indexing dependencies", add: chunk_bytes)
+          chunk_results
+        end)
 
       elapsed = System.monotonic_time(:millisecond) - start_time
       {:done, results, "Completed in #{format_duration(elapsed)}"}
@@ -73,9 +77,8 @@ defmodule Engine.Search.Indexer.Beams do
 
   defp beam_size({_path, %File.Stat{size: size}}), do: size
 
-  defp index_beam_chunk({chunk_bytes, beams}, report) do
-    report.(message: "Indexing dependencies", add: chunk_bytes)
-    Enum.flat_map(beams, &metadata_from_beam/1)
+  defp index_beam_chunk({chunk_bytes, beams}) do
+    {chunk_bytes, Enum.flat_map(beams, &metadata_from_beam/1)}
   end
 
   defp entries_and_manifest_entries(results) do

--- a/apps/engine/lib/engine/search/indexer/sources.ex
+++ b/apps/engine/lib/engine/search/indexer/sources.ex
@@ -40,13 +40,14 @@ defmodule Engine.Search.Indexer.Sources do
       results =
         paths
         |> Task.async_stream(
-          fn path ->
-            report.(message: message, add: 1)
-            processor.(path)
-          end,
+          fn path -> processor.(path) end,
           timeout: :infinity
         )
-        |> Enum.flat_map(&task_result!/1)
+        |> Enum.flat_map(fn task_result ->
+          results = task_result!(task_result)
+          report.(message: message, add: 1)
+          results
+        end)
 
       elapsed = System.monotonic_time(:millisecond) - start_time
       {:done, results, "Completed in #{format_duration(elapsed)}"}

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -2,6 +2,7 @@ defmodule Engine.Search.IndexerTest do
   use ExUnit.Case
   use Patch
 
+  import Engine.Test.Entry.Builder
   import Forge.Test.Fixtures
 
   alias Engine.Dispatch
@@ -10,6 +11,8 @@ defmodule Engine.Search.IndexerTest do
   alias Engine.Search.Indexer.Manifest
   alias Engine.Search.Indexer.Manifest.Entry, as: ManifestEntry
   alias Engine.Search.Indexer.ManifestStore
+  alias Engine.Search.Indexer.Source
+  alias Engine.Search.Indexer.Sources
   alias Forge.Project
   alias Forge.Search.Indexer.Entry
 
@@ -100,6 +103,42 @@ defmodule Engine.Search.IndexerTest do
     [build_root | List.wrap(relative_path)]
     |> Path.join()
     |> Forge.Path.native()
+  end
+
+  describe "Sources.index/1" do
+    @tag :tmp_dir
+    test "reports progress after source indexing finishes", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "progress.ex")
+      source = "defmodule Progress do end"
+      File.write!(path, source)
+      test_pid = self()
+
+      patch(Dispatch, :erpc_call, fn
+        Expert.Progress, :begin, [_title, _opts] ->
+          {:ok, System.unique_integer([:positive])}
+
+        Expert.Progress, :report, [_token, opts] ->
+          send(test_pid, {:progress_report, opts})
+          :ok
+      end)
+
+      patch(Source, :index, fn ^path, ^source ->
+        send(test_pid, {:source_index_started, self()})
+        assert_receive :finish_source_index
+
+        {:ok, [structure(path: path), definition(path: path)]}
+      end)
+
+      task = Task.async(fn -> Sources.index([path]) end)
+
+      assert_receive {:source_index_started, worker_pid}
+      refute_receive {:progress_report, _opts}, 100
+
+      send(worker_pid, :finish_source_index)
+
+      assert {[_structure, _definition], [_manifest_entry]} = Task.await(task)
+      assert_receive {:progress_report, [message: "Indexing", percentage: 100]}
+    end
   end
 
   describe "create_index/1" do


### PR DESCRIPTION
We were reporting progress when we *started* indexing a file, not afterwards. This would sometimes result in progress getting stuck at 100% for a while if a file was particularly slow to index.