### PR TITLE
fix(engine): improve progress notifications

### DIFF
--- a/apps/engine/lib/engine/commands/reindex.ex
+++ b/apps/engine/lib/engine/commands/reindex.ex
@@ -8,6 +8,7 @@ defmodule Engine.Commands.Reindex do
   import Forge.EngineApi.Messages
 
   alias Engine.ManagerApi
+  alias Engine.Progress
   alias Engine.Search.Indexer
   alias Forge.Document
   alias Forge.Project
@@ -203,9 +204,8 @@ defmodule Engine.Commands.Reindex do
 
     {elapsed_us, result} =
       :timer.tc(fn ->
-        with {:ok, entries, manifest} <- Indexer.create_index(project),
-             :ok <- replace_search_store(project, entries) do
-          Indexer.commit_manifest(project, manifest)
+        with {:ok, entries, manifest} <- Indexer.create_index(project) do
+          persist_index(project, entries, manifest)
         end
       end)
 
@@ -227,6 +227,17 @@ defmodule Engine.Commands.Reindex do
 
   defp schedule_gc do
     Process.send_after(self(), :gc, :timer.seconds(5))
+  end
+
+  defp persist_index(%Project{} = project, entries, manifest) do
+    Progress.with_progress("Persisting index", fn _token ->
+      result =
+        with :ok <- replace_search_store(project, entries) do
+          Indexer.commit_manifest(project, manifest)
+        end
+
+      {:done, result}
+    end)
   end
 
   defp replace_search_store(%Project{} = project, entries) do

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -74,8 +74,9 @@ defmodule Engine.Search.Indexer.Beams do
   defp beam_size({_path, %File.Stat{size: size}}), do: size
 
   defp index_beam_chunk({chunk_bytes, beams}, report) do
+    results = Enum.flat_map(beams, &metadata_from_beam/1)
     report.(message: "Indexing dependencies", add: chunk_bytes)
-    Enum.flat_map(beams, &metadata_from_beam/1)
+    results
   end
 
   defp entries_and_manifest_entries(results) do

--- a/apps/engine/lib/engine/search/indexer/sources.ex
+++ b/apps/engine/lib/engine/search/indexer/sources.ex
@@ -34,15 +34,18 @@ defmodule Engine.Search.Indexer.Sources do
   defp map_paths([], _title, _message, _processor), do: []
 
   defp map_paths(paths, title, message, processor) do
-    Progress.with_tracked_progress(title, length(paths), fn report ->
+    {sized_paths, total_bytes} = stat_paths(paths)
+
+    Progress.with_tracked_progress(title, total_bytes, fn report ->
       start_time = System.monotonic_time(:millisecond)
 
       results =
-        paths
+        sized_paths
         |> Task.async_stream(
-          fn path ->
-            report.(message: message, add: 1)
-            processor.(path)
+          fn {path, size} ->
+            result = processor.(path)
+            report.(message: message, add: size)
+            result
           end,
           timeout: :infinity
         )
@@ -51,6 +54,20 @@ defmodule Engine.Search.Indexer.Sources do
       elapsed = System.monotonic_time(:millisecond) - start_time
       {:done, results, "Completed in #{format_duration(elapsed)}"}
     end)
+  end
+
+  defp stat_paths(paths) do
+    sized_paths = Enum.map(paths, fn path -> {path, file_size(path)} end)
+    total_bytes = sized_paths |> Enum.map(fn {_path, size} -> size end) |> Enum.sum()
+
+    {sized_paths, total_bytes}
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} -> size
+      _ -> 0
+    end
   end
 
   defp task_result!({:ok, items}), do: items

--- a/apps/engine/test/engine/commands/reindex_test.exs
+++ b/apps/engine/test/engine/commands/reindex_test.exs
@@ -8,6 +8,7 @@ defmodule Engine.Commands.ReindexTest do
   import Forge.Test.Fixtures
 
   alias Engine.Commands.Reindex
+  alias Engine.Dispatch
   alias Engine.Search.Indexer
   alias Forge.Document
 
@@ -15,6 +16,16 @@ defmodule Engine.Commands.ReindexTest do
     debounce_interval_millis = Map.get(context, :debounce_interval_millis, 0)
     project = project()
     Engine.set_project(project)
+
+    patch(Dispatch, :erpc_call, fn
+      Expert.Progress, :begin, [_title, _opts] ->
+        {:ok, System.unique_integer([:positive])}
+
+      Expert.Progress, :report, _args ->
+        :ok
+    end)
+
+    patch(Dispatch, :erpc_cast, fn Expert.Progress, _function, _args -> true end)
 
     case Map.get(context, :reindex_fun, :sleep) do
       :default ->

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -8,6 +8,7 @@ defmodule Expert.Project.Indexer do
   import Forge.EngineApi.Messages
 
   alias Expert.EngineApi
+  alias Expert.Progress
   alias Expert.Project.Node
   alias Expert.Search
   alias Forge.Project
@@ -140,14 +141,24 @@ defmodule Expert.Project.Indexer do
   end
 
   defp persist_index(%Project{} = project, :empty, create_index, _update_index) do
-    with {:ok, entries, after_apply} <- create_index.(project),
-         :ok <- Search.Store.replace(project, entries) do
-      after_apply.()
+    with {:ok, entries, after_apply} <- create_index.(project) do
+      persist_full_index(project, entries, after_apply)
     end
   end
 
   defp persist_index(%Project{} = project, _status, create_index, update_index) do
     persist_incremental_index(project, create_index, update_index)
+  end
+
+  defp persist_full_index(%Project{} = project, entries, after_apply) do
+    Progress.with_progress("Persisting index", fn _token ->
+      result =
+        with :ok <- Search.Store.replace(project, entries) do
+          after_apply.()
+        end
+
+      {:done, result}
+    end)
   end
 
   defp persist_incremental_index(%Project{} = project, create_index, update_index) do


### PR DESCRIPTION
Progress for a chunk of the indexer's work was being sent at the start of the indexer's task and not after it had completed. On our project, this would result in Indexing: 100% being displayed for a while while the last large task was being completed. This was confusing.

This change also adds a progress notification for writing the index, to better communicate what's going on after the source level indexer is complete.