### PR TITLE
fix: improve performance of formatting

### DIFF
--- a/apps/engine/lib/engine/application.ex
+++ b/apps/engine/lib/engine/application.ex
@@ -11,6 +11,7 @@ defmodule Engine.Application do
       if Engine.project_node?() do
         [
           Engine.ApplicationCache,
+          Engine.CodeMod.Format.Cache,
           Engine.Api.Proxy,
           Engine.Commands.Reindex,
           Engine.Module.Loader,

--- a/apps/engine/lib/engine/code_action/handlers/refactorex.ex
+++ b/apps/engine/lib/engine/code_action/handlers/refactorex.ex
@@ -26,6 +26,9 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
     else
       _ -> []
     end
+  rescue
+    _ ->
+      []
   end
 
   @doc """
@@ -106,7 +109,14 @@ defmodule Engine.CodeAction.Handlers.Refactorex do
   end
 
   defp sourceror_opts(doc) do
-    {formatter, opts} = CodeMod.Format.formatter_for_file(Engine.get_project(), doc.uri)
+    {formatter, opts} =
+      case CodeMod.Format.Cache.fetch_formatter(Engine.get_project(), doc.path) do
+        {:ok, formatter, opts} ->
+          {formatter, opts}
+
+        :error ->
+          {&Code.format_string!/1, []}
+      end
 
     Keyword.reject(
       [

--- a/apps/engine/lib/engine/code_mod/diff.ex
+++ b/apps/engine/lib/engine/code_mod/diff.ex
@@ -1,5 +1,16 @@
 defmodule Engine.CodeMod.Diff do
-  alias Forge.CodeUnit
+  @moduledoc """
+  Computes the edits that turn a document into the given text.
+
+  The diff is line-based: `List.myers_difference` runs over the documents'
+  lines, and each changed region becomes one edit on line boundaries. Lines
+  are the unit because character-level Myers over an entire document is
+  O(chars x edit distance) and can take minutes on a large, heavily changed
+  document; line-level runs in milliseconds and clients apply line-granular
+  edits just fine.
+  """
+  import Forge.Document.Line, only: :macros
+
   alias Forge.Document
   alias Forge.Document.Edit
   alias Forge.Document.Position
@@ -7,111 +18,79 @@ defmodule Engine.CodeMod.Diff do
 
   @spec diff(Document.t(), String.t()) :: [Edit.t()]
   def diff(%Document{} = document, dest) when is_binary(dest) do
+    dest_document = Document.new(document.uri, dest, 0)
+
     document
-    |> Document.to_string()
-    |> String.myers_difference(dest)
+    |> normalized_lines()
+    |> List.myers_difference(normalized_lines(dest_document))
+    |> merge_replacements()
     |> to_edits(document)
   end
 
-  defp to_edits(difference, %Document{} = document) do
-    {_, {current_line, prev_lines}} =
-      Enum.reduce(difference, {{starting_line(), starting_character()}, {[], []}}, fn
-        {diff_type, diff_string}, {position, edits} ->
-          apply_diff(diff_type, position, diff_string, edits, document)
-      end)
-
-    [current_line | prev_lines]
-    |> Enum.flat_map(fn line_edits ->
-      line_edits
-      |> Enum.reduce([], &collapse/2)
-      |> Enum.reverse()
+  # Myers compares lines with ==, and a line record carries its line number,
+  # which differs between the documents once any line shifts. Zeroing it
+  # makes lines with the same content compare equal.
+  defp normalized_lines(%Document{} = document) do
+    Enum.map(document.lines, fn line() = doc_line ->
+      line(doc_line, line_number: 0)
     end)
   end
 
-  # This collapses a delete and an an insert that are adjacent to one another
-  # into a single insert, changing the delete to insert the text from the
-  # insert rather than ""
-  # It's a small optimization, but it was in the original
-  defp collapse(
-         %Edit{
-           text: "",
-           range: %Range{
-             end: %Position{character: same_character, line: same_line}
-           }
-         } = delete_edit,
-         [
-           %Edit{
-             text: insert_text,
-             range:
-               %Range{
-                 start: %Position{character: same_character, line: same_line}
-               } = _insert_edit
-           }
-           | rest
-         ]
-       )
-       when byte_size(insert_text) > 0 do
-    collapsed_edit = %Edit{delete_edit | text: insert_text}
-    [collapsed_edit | rest]
+  # A delete immediately followed by an insert is a replacement; merging them
+  # emits one edit for the region instead of a delete and an insert.
+  defp merge_replacements([{:del, deleted}, {:ins, inserted} | rest]) do
+    [{:replace, deleted, inserted} | merge_replacements(rest)]
   end
 
-  defp collapse(%Edit{} = edit, edits) do
-    [edit | edits]
+  defp merge_replacements([operation | rest]) do
+    [operation | merge_replacements(rest)]
   end
 
-  defp apply_diff(:eq, position, doc_string, edits, _document) do
-    advance(doc_string, position, edits)
+  defp merge_replacements([]) do
+    []
   end
 
-  defp apply_diff(:del, {line, code_unit} = position, change, edits, document) do
-    {after_pos, {current_line, prev_lines}} = advance(change, position, edits)
-    {edit_end_line, edit_end_unit} = after_pos
+  defp to_edits(operations, %Document{} = document) do
+    {_line, edits} =
+      Enum.reduce(operations, {starting_line(), []}, fn
+        {:eq, lines}, {current_line, edits} ->
+          {current_line + length(lines), edits}
 
-    current_line = [
-      edit(document, "", line, code_unit, edit_end_line, edit_end_unit) | current_line
-    ]
+        {:del, lines}, {current_line, edits} ->
+          end_line = current_line + length(lines)
+          edit = edit(document, "", current_line, end_line)
+          {end_line, [edit | edits]}
 
-    {after_pos, {current_line, prev_lines}}
+        {:ins, lines}, {current_line, edits} ->
+          edit = edit(document, text_of(lines), current_line, current_line)
+          {current_line, [edit | edits]}
+
+        {:replace, deleted, inserted}, {current_line, edits} ->
+          end_line = current_line + length(deleted)
+          edit = edit(document, text_of(inserted), current_line, end_line)
+          {end_line, [edit | edits]}
+      end)
+
+    # The edits accumulate in reverse document order, which is what
+    # sequential application needs: applying back-to-front keeps earlier
+    # positions valid as line counts change.
+    edits
   end
 
-  defp apply_diff(
-         :ins,
-         {line, code_unit} = position,
-         change,
-         {current_line, prev_lines},
-         document
-       ) do
-    current_line = [edit(document, change, line, code_unit, line, code_unit) | current_line]
-    {position, {current_line, prev_lines}}
+  defp text_of(lines) do
+    lines
+    |> Enum.map(fn line(text: text, ending: ending) ->
+      [text, ending]
+    end)
+    |> IO.iodata_to_binary()
   end
 
-  defp advance(<<>>, position, edits) do
-    {position, edits}
-  end
-
-  for ending <- ["\r\n", "\r", "\n"] do
-    defp advance(<<unquote(ending), rest::binary>>, {line, _unit}, {current_line, prev_lines}) do
-      edits = {[], [current_line | prev_lines]}
-      advance(rest, {line + 1, starting_character()}, edits)
-    end
-  end
-
-  defp advance(<<c, rest::binary>>, {line, unit}, edits) when c < 128 do
-    advance(rest, {line, unit + 1}, edits)
-  end
-
-  defp advance(<<c::utf8, rest::binary>>, {line, unit}, edits) do
-    increment = CodeUnit.count(:utf16, <<c::utf8>>)
-    advance(rest, {line, unit + increment}, edits)
-  end
-
-  defp edit(document, text, start_line, start_unit, end_line, end_unit)
-       when is_binary(text) do
+  defp edit(document, text, start_line, end_line) when is_binary(text) do
     Edit.new(
       text,
       Range.new(
-        Position.new(document, start_line, start_unit),
-        Position.new(document, end_line, end_unit)
+        Position.new(document, start_line, starting_character()),
+        Position.new(document, end_line, starting_character())
       )
     )
   end

--- a/apps/engine/lib/engine/code_mod/format.ex
+++ b/apps/engine/lib/engine/code_mod/format.ex
@@ -13,12 +13,15 @@ defmodule Engine.CodeMod.Format do
   @spec edits(Document.t()) :: {:ok, Changes.t()} | {:error, any}
   def edits(%Document{} = document) do
     project = Engine.get_project()
+    format_result = do_format(project, document)
 
-    with {:ok, formatted} <- do_format(project, document) do
-      # Compiling first would make the format request wait on the Engine.Mix
-      # lock for the compile it just scheduled; formatting runs first and the
-      # compile keeps diagnostics fresh afterwards.
-      Build.compile_document(project, document)
+    # Compiling first would make the format request wait on the Engine.Mix
+    # lock for the compile it just scheduled; formatting runs first and the
+    # compile keeps diagnostics fresh afterwards — including the syntax-error
+    # diagnostics when formatting fails.
+    Build.compile_document(project, document)
+
+    with {:ok, formatted} <- format_result do
       edits = Diff.diff(document, formatted)
       {:ok, Changes.new(document, edits)}
     end

--- a/apps/engine/lib/engine/code_mod/format.ex
+++ b/apps/engine/lib/engine/code_mod/format.ex
@@ -1,96 +1,12 @@
 defmodule Engine.CodeMod.Format do
+  import Forge.Logging
+
   alias Engine.Build
   alias Engine.CodeMod.Diff
+  alias Engine.CodeMod.Format.Cache
   alias Forge.Document
   alias Forge.Document.Changes
   alias Forge.Project
-
-  require Logger
-
-  @built_in_locals_without_parens [
-    # Special forms
-    alias: 1,
-    alias: 2,
-    case: 2,
-    cond: 1,
-    for: :*,
-    import: 1,
-    import: 2,
-    quote: 1,
-    quote: 2,
-    receive: 1,
-    require: 1,
-    require: 2,
-    try: 1,
-    with: :*,
-
-    # Kernel
-    def: 1,
-    def: 2,
-    defp: 1,
-    defp: 2,
-    defguard: 1,
-    defguardp: 1,
-    defmacro: 1,
-    defmacro: 2,
-    defmacrop: 1,
-    defmacrop: 2,
-    defmodule: 2,
-    defdelegate: 2,
-    defexception: 1,
-    defoverridable: 1,
-    defstruct: 1,
-    destructure: 2,
-    raise: 1,
-    raise: 2,
-    reraise: 2,
-    reraise: 3,
-    if: 2,
-    unless: 2,
-    use: 1,
-    use: 2,
-
-    # Stdlib,
-    defrecord: 2,
-    defrecord: 3,
-    defrecordp: 2,
-    defrecordp: 3,
-
-    # Testing
-    assert: 1,
-    assert: 2,
-    assert_in_delta: 3,
-    assert_in_delta: 4,
-    assert_raise: 2,
-    assert_raise: 3,
-    assert_receive: 1,
-    assert_receive: 2,
-    assert_receive: 3,
-    assert_received: 1,
-    assert_received: 2,
-    doctest: 1,
-    doctest: 2,
-    refute: 1,
-    refute: 2,
-    refute_in_delta: 3,
-    refute_in_delta: 4,
-    refute_receive: 1,
-    refute_receive: 2,
-    refute_receive: 3,
-    refute_received: 1,
-    refute_received: 2,
-    setup: 1,
-    setup: 2,
-    setup_all: 1,
-    setup_all: 2,
-    test: 1,
-    test: 2,
-
-    # Mix config
-    config: 2,
-    config: 3,
-    import_config: 1
-  ]
 
   @type formatter_function :: (String.t() -> any) | nil
 
@@ -98,8 +14,11 @@ defmodule Engine.CodeMod.Format do
   def edits(%Document{} = document) do
     project = Engine.get_project()
 
-    with :ok <- Build.compile_document(project, document),
-         {:ok, formatted} <- do_format(project, document) do
+    with {:ok, formatted} <- do_format(project, document) do
+      # Compiling first would make the format request wait on the Engine.Mix
+      # lock for the compile it just scheduled; formatting runs first and the
+      # compile keeps diagnostics fresh afterwards.
+      Build.compile_document(project, document)
       edits = Diff.diff(document, formatted)
       {:ok, Changes.new(document, edits)}
     end
@@ -108,32 +27,27 @@ defmodule Engine.CodeMod.Format do
   defp do_format(%Project{} = project, %Document{} = document) do
     project_path = Project.project_path(project)
 
-    with :ok <- check_current_directory(document, project_path),
-         {:ok, formatter} <- formatter_for(project, document.path) do
-      Engine.Mix.in_project(project, fn _ ->
-        document
-        |> Document.to_string()
-        |> formatter.()
-      end)
-    end
-  end
+    timed_log("format: format document", fn ->
+      with :ok <- check_current_directory(document, project_path),
+           {:ok, formatter} <- formatter_for(project, document) do
+        formatted =
+          document
+          |> Document.to_string()
+          |> formatter.()
 
-  @spec formatter_for(Project.t(), String.t()) :: {:ok, formatter_function}
-  defp formatter_for(%Project{} = project, uri_or_path) do
-    path = Document.Path.ensure_path(uri_or_path)
-    {formatter_function, _opts} = formatter_for_file(project, path)
-    wrapped_formatter_function = wrap_with_try_catch(formatter_function)
-    {:ok, wrapped_formatter_function}
-  end
-
-  defp wrap_with_try_catch(formatter_fn) do
-    fn code ->
-      try do
-        {:ok, formatter_fn.(code)}
-      rescue
-        e ->
-          {:error, e}
+        {:ok, formatted}
       end
+    end)
+  end
+
+  @spec formatter_for(Project.t(), Document.t()) :: {:ok, formatter_function} | {:error, term()}
+  defp formatter_for(%Project{} = project, %Document{} = document) do
+    case Cache.fetch_formatter(project, document.path) do
+      {:ok, formatter_function, _opts} ->
+        {:ok, formatter_function}
+
+      :error ->
+        {:error, :no_formatter}
     end
   end
 
@@ -154,110 +68,5 @@ defmodule Engine.CodeMod.Format do
 
   defp subdirectory?(child, parent: parent) do
     Forge.Path.contains?(child, parent)
-  end
-
-  @doc """
-  Returns `{formatter_function, opts}` for the given file.
-  """
-  def formatter_for_file(%Project{} = project, file_path) do
-    fetch_formatter = fn _ -> Mix.Tasks.Format.formatter_for_file(file_path) end
-
-    {formatter_function, opts} =
-      if Engine.project_node?() do
-        case mix_formatter_from_task(project, file_path) do
-          {:ok, result} ->
-            result
-
-          :error ->
-            formatter_opts =
-              case find_formatter_exs(project, file_path) do
-                {:ok, opts} ->
-                  opts
-
-                :error ->
-                  Logger.warning("Could not find formatter options for file #{file_path}")
-                  []
-              end
-
-            formatter = fn source ->
-              formatted_source = Code.format_string!(source, formatter_opts)
-              IO.iodata_to_binary([formatted_source, ?\n])
-            end
-
-            {formatter, formatter_opts}
-        end
-      else
-        fetch_formatter.(nil)
-      end
-
-    opts =
-      Keyword.update(
-        opts,
-        :locals_without_parens,
-        @built_in_locals_without_parens,
-        &(@built_in_locals_without_parens ++ &1)
-      )
-
-    {formatter_function, opts}
-  end
-
-  defp find_formatter_exs(%Project{} = project, file_path) do
-    root_dir = Project.root_path(project)
-    do_find_formatter_exs(root_dir, file_path)
-  end
-
-  defp do_find_formatter_exs(root_path, root_path) do
-    formatter_exs_contents(root_path)
-  end
-
-  defp do_find_formatter_exs(root_path, current_path) do
-    if File.exists?(current_path) do
-      with :error <- formatter_exs_contents(current_path) do
-        parent =
-          current_path
-          |> Path.join("..")
-          |> Path.expand()
-
-        do_find_formatter_exs(root_path, parent)
-      end
-    else
-      # the current path doesn't exist, it doesn't make sense to keep looking
-      # for the .formatter.exs in its parents. Look for one in the root directory
-      do_find_formatter_exs(root_path, Path.join(root_path, ".formatter.exs"))
-    end
-  end
-
-  defp formatter_exs_contents(current_path) do
-    formatter_exs = Path.join(current_path, ".formatter.exs")
-
-    with true <- File.exists?(formatter_exs),
-         {formatter_terms, _binding} <- Code.eval_file(formatter_exs) do
-      Logger.info("found formatter in #{current_path}")
-      {:ok, formatter_terms}
-    else
-      err ->
-        Logger.info("No formatter found in #{current_path} error was #{inspect(err)}")
-
-        :error
-    end
-  end
-
-  defp mix_formatter_from_task(%Project{} = project, file_path) do
-    root_path = Project.root_path(project)
-    deps_paths = Engine.deps_paths()
-
-    formatter_and_opts =
-      Engine.with_lock(Engine.Mix.StackMutation, fn ->
-        Mix.Tasks.Future.Format.formatter_for_file(file_path,
-          root: root_path,
-          deps_paths: deps_paths,
-          plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
-        )
-      end)
-
-    {:ok, formatter_and_opts}
-  rescue
-    _ ->
-      :error
   end
 end

--- a/apps/engine/lib/engine/code_mod/format.ex
+++ b/apps/engine/lib/engine/code_mod/format.ex
@@ -8,7 +8,7 @@ defmodule Engine.CodeMod.Format do
   alias Forge.Document.Changes
   alias Forge.Project
 
-  @type formatter_function :: (String.t() -> any) | nil
+  @type formatter_function :: (String.t() -> {:ok, String.t()} | {:error, Exception.t()}) | nil
 
   @spec edits(Document.t()) :: {:ok, Changes.t()} | {:error, any}
   def edits(%Document{} = document) do
@@ -30,14 +30,15 @@ defmodule Engine.CodeMod.Format do
     timed_log("format: format document", fn ->
       with :ok <- check_current_directory(document, project_path),
            {:ok, formatter} <- formatter_for(project, document) do
-        formatted =
-          document
-          |> Document.to_string()
-          |> formatter.()
-
-        {:ok, formatted}
+        apply_formatter(document, formatter)
       end
     end)
+  end
+
+  defp apply_formatter(%Document{} = document, formatter) do
+    document
+    |> Document.to_string()
+    |> formatter.()
   end
 
   @spec formatter_for(Project.t(), Document.t()) :: {:ok, formatter_function} | {:error, term()}

--- a/apps/engine/lib/engine/code_mod/format/cache.ex
+++ b/apps/engine/lib/engine/code_mod/format/cache.ex
@@ -281,13 +281,18 @@ defmodule Engine.CodeMod.Format.Cache do
 
   @spec discover_dot_formatters(Project.t()) :: State.dot_formatters()
   defp discover_dot_formatters(%Project{} = project) do
-    project
-    |> Project.root_path()
-    |> discover_dot_formatters()
+    case Project.root_path(project) do
+      nil ->
+        %{}
+
+      root_path ->
+        discover_dot_formatters_at_path(root_path, %{})
+    end
   end
 
-  @spec discover_dot_formatters(Path.t(), State.dot_formatters()) :: State.dot_formatters()
-  defp discover_dot_formatters(dir, dot_formatters \\ %{}) do
+  @spec discover_dot_formatters_at_path(Path.t(), State.dot_formatters()) ::
+          State.dot_formatters()
+  defp discover_dot_formatters_at_path(dir, dot_formatters) do
     formatter_exs = Path.join(dir, ".formatter.exs")
 
     case File.stat(formatter_exs, time: :posix) do
@@ -297,7 +302,7 @@ defmodule Engine.CodeMod.Format.Cache do
         formatter_exs
         |> subdirectories_from_formatter_config()
         |> Enum.reduce(dot_formatters, fn sub, acc ->
-          discover_dot_formatters(sub, acc)
+          discover_dot_formatters_at_path(sub, acc)
         end)
 
       {:error, _} ->

--- a/apps/engine/lib/engine/code_mod/format/cache.ex
+++ b/apps/engine/lib/engine/code_mod/format/cache.ex
@@ -1,0 +1,343 @@
+defmodule Engine.CodeMod.Format.Cache do
+  @moduledoc """
+  A read-through cache of formatters, keyed by file path.
+
+  Two public ETS tables are used:
+
+  - `entries` — one row per unique `{opts, extension}` combination, keyed by a
+    generated entry ID. Stores the `Entry` struct once, shared across all files
+    that resolve to the same config.
+
+  - `paths` — one row per cached file path, keyed by path. Stores only the
+    entry ID so the formatter data is never duplicated.
+
+  A lookup reads the path row to get the entry ID, then reads the entry row to
+  get the formatter and opts. On a path miss the caller scans the entries table
+  to find a matching entry (by extension and `:inputs` glob) without going to
+  the GenServer; only a full entry miss requires a GenServer call to resolve.
+
+  On a cadence, the known `.formatter.exs` files are checked for stat changes.
+  When one is detected, both tables are cleared and entries re-resolve lazily.
+  """
+
+  use GenServer
+
+  import Forge.Logging
+  import Record
+
+  alias Engine.CodeMod.Format
+  alias Engine.CodeMod.Format.Resolver
+  alias Forge.Document
+  alias Forge.Project
+
+  require Logger
+
+  defmodule Entry do
+    @moduledoc false
+
+    defstruct [:id, :formatter, :opts, :extension, :path]
+    @type id :: non_neg_integer()
+
+    @type t :: %__MODULE__{
+            id: id(),
+            formatter: Engine.CodeMod.Format.formatter_function(),
+            opts: keyword(),
+            extension: String.t(),
+            path: Path.t()
+          }
+
+    @spec new(Format.formatter_function(), keyword(), Path.t()) :: t()
+    def new(formatter, opts, file_path) do
+      extension = Path.extname(file_path)
+
+      %__MODULE__{
+        id: :erlang.unique_integer([:positive]),
+        formatter: formatter,
+        opts: opts,
+        extension: extension,
+        path: file_path
+      }
+    end
+
+    @spec applies_to?(t(), Path.t()) :: boolean()
+    def applies_to?(%__MODULE__{} = entry, file_path) do
+      root = Keyword.get(entry.opts, :root)
+      inputs = Keyword.get(entry.opts, :inputs)
+
+      entry.extension == Path.extname(file_path) and
+        is_binary(root) and
+        is_list(inputs) and
+        Enum.any?(inputs, fn glob ->
+          PathGlob.match?(file_path, Path.join(root, glob), match_dot: true)
+        end)
+    end
+  end
+
+  # -- State -------------------------------------------------------------------
+
+  defmodule State do
+    @moduledoc false
+
+    defstruct project: nil, refresh_interval: nil, dot_formatters: %{}
+
+    @type dot_formatters :: %{Path.t() => File.Stat.t()}
+    @type t :: %__MODULE__{
+            project: Forge.Project.t(),
+            refresh_interval: non_neg_integer(),
+            dot_formatters: dot_formatters()
+          }
+
+    @spec new(Forge.Project.t(), non_neg_integer()) :: t()
+    def new(%Forge.Project{} = project, refresh_interval) do
+      %__MODULE__{project: project, refresh_interval: refresh_interval}
+    end
+
+    @spec put_dot_formatters(t(), dot_formatters()) :: t()
+    def put_dot_formatters(%__MODULE__{} = state, dot_formatters) do
+      %__MODULE__{state | dot_formatters: dot_formatters}
+    end
+  end
+
+  # -- ETS tables --------------------------------------------------------------
+
+  @entries_table :"#{__MODULE__}.Entries"
+  @paths_table :"#{__MODULE__}.Paths"
+
+  # keypos: 2 — records are {tag, field1, field2, ...} so field1 is at position 2
+  @entries_table_opts [:named_table, :public, :set, read_concurrency: true, keypos: 2]
+  @paths_table_opts [:named_table, :public, :set, read_concurrency: true, keypos: 2]
+
+  @default_refresh_interval :timer.seconds(10)
+
+  # -- Records (ETS row formats) -----------------------------------------------
+
+  defrecordp :entry_row, id: nil, entry: nil
+  defrecordp :path_row, path: nil, entry_id: nil
+
+  @type entry_row :: record(:entry_row, id: Entry.id(), entry: Entry.t())
+  @type path_row :: record(:path_row, path: Path.t(), entry_id: non_neg_integer())
+
+  # -- Public API --------------------------------------------------------------
+
+  @spec fetch_formatter(Project.t(), Path.t()) ::
+          {:ok, Format.formatter_function(), keyword()} | :error
+  def fetch_formatter(%Project{} = project, file_path) do
+    with {:ok, entry_id} <- fetch_path(file_path),
+         {:ok, entry} <- fetch_entry(entry_id) do
+      Logger.debug("formatter cache hit for #{file_path}")
+      {:ok, entry.formatter, entry.opts}
+    else
+      :error ->
+        Logger.debug("formatter cache miss for #{file_path}")
+
+        timed_log("formatter cache miss (call + resolve) for #{file_path}", fn ->
+          case GenServer.call(__MODULE__, {:resolve, project, file_path}) do
+            {:ok, %Entry{} = entry} ->
+              {:ok, entry.formatter, entry.opts}
+
+            :error ->
+              :error
+          end
+        end)
+    end
+  end
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  # -- GenServer ---------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    :ets.new(@entries_table, @entries_table_opts)
+    :ets.new(@paths_table, @paths_table_opts)
+    project = Keyword.get_lazy(opts, :project, &Engine.get_project/0)
+    interval = Keyword.get(opts, :refresh_interval, @default_refresh_interval)
+    schedule_refresh(interval)
+
+    {:ok, State.new(project, interval), {:continue, :discover_dot_formatters}}
+  end
+
+  @impl GenServer
+  def handle_continue(:discover_dot_formatters, %State{} = state) do
+    {:noreply, State.put_dot_formatters(state, discover_dot_formatters(state.project))}
+  end
+
+  @impl GenServer
+  def handle_call({:resolve, %Project{} = project, file_path}, _from, %State{} = state) do
+    {:reply, find_or_resolve(project, file_path), state}
+  end
+
+  @impl GenServer
+  def handle_info(:refresh, %State{} = state) do
+    new_state =
+      if dot_formatters_changed?(state.dot_formatters) do
+        dot_formatters =
+          timed_log(".formatter.exs scan", fn ->
+            discover_dot_formatters(state.project)
+          end)
+
+        Logger.info("formatter config changed, clearing cache")
+        :ets.delete_all_objects(@entries_table)
+        :ets.delete_all_objects(@paths_table)
+
+        State.put_dot_formatters(state, dot_formatters)
+      else
+        state
+      end
+
+    clean_closed_entries()
+    schedule_refresh(state.refresh_interval)
+
+    {:noreply, new_state}
+  end
+
+  # -- Private -----------------------------------------------------------------
+
+  @spec find_or_resolve(Project.t(), Path.t()) :: {:ok, Entry.t()} | :error
+  defp find_or_resolve(%Project{} = project, file_path) do
+    case fetch_path(file_path) do
+      {:ok, entry_id} ->
+        fetch_entry(entry_id)
+
+      :error ->
+        case find_matching_entry(file_path) do
+          {:ok, %Entry{} = entry} ->
+            :ets.insert(@paths_table, path_row(path: file_path, entry_id: entry.id))
+            {:ok, entry}
+
+          :error ->
+            resolve_and_store(project, file_path)
+        end
+    end
+  end
+
+  @spec find_matching_entry(Path.t()) :: {:ok, Entry.t()} | :error
+  defp find_matching_entry(file_path) do
+    extension = Path.extname(file_path)
+
+    @entries_table
+    |> :ets.select([{entry_row(id: :_, entry: :_), [], [:"$_"]}])
+    |> Enum.find_value(:error, fn
+      entry_row(entry: %Entry{extension: ^extension} = entry) ->
+        if Entry.applies_to?(entry, file_path) do
+          {:ok, entry}
+        end
+
+      _ ->
+        false
+    end)
+  end
+
+  @spec resolve_and_store(Project.t(), Path.t()) :: {:ok, Entry.t()} | :error
+  defp resolve_and_store(%Project{} = project, file_path) do
+    {formatter, opts} = Resolver.resolve(project, file_path)
+    entry = Entry.new(formatter, opts, file_path)
+
+    true = :ets.insert(@entries_table, entry_row(id: entry.id, entry: entry))
+    true = :ets.insert(@paths_table, path_row(path: file_path, entry_id: entry.id))
+
+    {:ok, entry}
+  rescue
+    exception ->
+      Logger.warning(
+        "Could not resolve formatter for #{file_path}: #{Exception.message(exception)}"
+      )
+
+      :error
+  end
+
+  @spec fetch_entry(Entry.id()) :: {:ok, Entry.t()} | :error
+  defp fetch_entry(entry_id) do
+    fetch(@entries_table, entry_id, entry_row(:entry))
+  end
+
+  @spec fetch_path(Path.t()) :: {:ok, Entry.id()} | :error
+  defp fetch_path(file_path) do
+    fetch(@paths_table, file_path, path_row(:entry_id))
+  end
+
+  @spec fetch(atom(), term(), non_neg_integer()) :: {:ok, term()} | :error
+  defp fetch(table, key, field) do
+    # Record field indices are 1-based from the first field; ETS positions are
+    # also 1-based but include the record tag at position 1, so we add 1 to skip it.
+    {:ok, :ets.lookup_element(table, key, field + 1)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  @spec dot_formatters_changed?(State.dot_formatters()) :: boolean()
+  defp dot_formatters_changed?(dot_formatters) do
+    timed_log(".formatter.exs mtime check", fn ->
+      Enum.any?(dot_formatters, fn {path, stored_stat} ->
+        case File.stat(path, time: :posix) do
+          {:ok, stat} -> stat != stored_stat
+          {:error, _} -> true
+        end
+      end)
+    end)
+  end
+
+  @spec discover_dot_formatters(Project.t()) :: State.dot_formatters()
+  defp discover_dot_formatters(%Project{} = project) do
+    project
+    |> Project.root_path()
+    |> discover_dot_formatters()
+  end
+
+  @spec discover_dot_formatters(Path.t(), State.dot_formatters()) :: State.dot_formatters()
+  defp discover_dot_formatters(dir, dot_formatters \\ %{}) do
+    formatter_exs = Path.join(dir, ".formatter.exs")
+
+    case File.stat(formatter_exs, time: :posix) do
+      {:ok, stat} ->
+        dot_formatters = Map.put(dot_formatters, formatter_exs, stat)
+
+        formatter_exs
+        |> subdirectories_from_formatter_config()
+        |> Enum.reduce(dot_formatters, fn sub, acc ->
+          discover_dot_formatters(sub, acc)
+        end)
+
+      {:error, _} ->
+        dot_formatters
+    end
+  end
+
+  @spec subdirectories_from_formatter_config(Path.t()) :: [Path.t()]
+  defp subdirectories_from_formatter_config(formatter_exs) do
+    {terms, _binding} = Code.eval_file(formatter_exs)
+    subdirectories = Keyword.get(terms, :subdirectories) || []
+    base_directory = Path.dirname(formatter_exs)
+
+    Enum.flat_map(subdirectories, fn subdirectory ->
+      base_directory
+      |> Path.join(subdirectory)
+      |> Path.wildcard()
+    end)
+  rescue
+    _ -> []
+  end
+
+  @spec schedule_refresh(non_neg_integer()) :: reference()
+  defp schedule_refresh(interval) do
+    Process.send_after(self(), :refresh, interval)
+  end
+
+  defp clean_closed_entries do
+    closed_entries =
+      @entries_table
+      |> :ets.tab2list()
+      |> Enum.reject(fn entry_row(entry: %Entry{} = entry) ->
+        entry.path
+        |> Document.Path.to_uri()
+        |> Document.Store.open?()
+      end)
+
+    Enum.each(closed_entries, fn entry_row(entry: %Entry{} = entry) ->
+      true = :ets.delete(@entries_table, entry.id)
+      true = :ets.delete(@paths_table, entry.path)
+    end)
+  end
+end

--- a/apps/engine/lib/engine/code_mod/format/cache.ex
+++ b/apps/engine/lib/engine/code_mod/format/cache.ex
@@ -241,9 +241,8 @@ defmodule Engine.CodeMod.Format.Cache do
     {:ok, entry}
   rescue
     exception ->
-      Logger.warning(
-        "Could not resolve formatter for #{file_path}: #{Exception.message(exception)}"
-      )
+      formatted_stack = Exception.format(:error, exception, __STACKTRACE__)
+      Logger.warning(["Could not resolve formatter for ", file_path, ": ", formatted_stack])
 
       :error
   end

--- a/apps/engine/lib/engine/code_mod/format/resolver.ex
+++ b/apps/engine/lib/engine/code_mod/format/resolver.ex
@@ -1,0 +1,216 @@
+defmodule Engine.CodeMod.Format.Resolver do
+  @moduledoc """
+  Resolves the formatter function and options for a file.
+
+  Resolution is uncached and evaluates the governing `.formatter.exs`;
+  callers should go through `Engine.CodeMod.Format.Cache.fetch_formatter/2`
+  instead.
+  """
+
+  alias Elixir.Features
+  alias Engine.CodeMod.Format
+  alias Forge.Project
+
+  require Logger
+
+  @built_in_locals_without_parens [
+    # Special forms
+    alias: 1,
+    alias: 2,
+    case: 2,
+    cond: 1,
+    for: :*,
+    import: 1,
+    import: 2,
+    quote: 1,
+    quote: 2,
+    receive: 1,
+    require: 1,
+    require: 2,
+    try: 1,
+    with: :*,
+
+    # Kernel
+    def: 1,
+    def: 2,
+    defp: 1,
+    defp: 2,
+    defguard: 1,
+    defguardp: 1,
+    defmacro: 1,
+    defmacro: 2,
+    defmacrop: 1,
+    defmacrop: 2,
+    defmodule: 2,
+    defdelegate: 2,
+    defexception: 1,
+    defoverridable: 1,
+    defstruct: 1,
+    destructure: 2,
+    raise: 1,
+    raise: 2,
+    reraise: 2,
+    reraise: 3,
+    if: 2,
+    unless: 2,
+    use: 1,
+    use: 2,
+
+    # Stdlib,
+    defrecord: 2,
+    defrecord: 3,
+    defrecordp: 2,
+    defrecordp: 3,
+
+    # Testing
+    assert: 1,
+    assert: 2,
+    assert_in_delta: 3,
+    assert_in_delta: 4,
+    assert_raise: 2,
+    assert_raise: 3,
+    assert_receive: 1,
+    assert_receive: 2,
+    assert_receive: 3,
+    assert_received: 1,
+    assert_received: 2,
+    doctest: 1,
+    doctest: 2,
+    refute: 1,
+    refute: 2,
+    refute_in_delta: 3,
+    refute_in_delta: 4,
+    refute_receive: 1,
+    refute_receive: 2,
+    refute_receive: 3,
+    refute_received: 1,
+    refute_received: 2,
+    setup: 1,
+    setup: 2,
+    setup_all: 1,
+    setup_all: 2,
+    test: 1,
+    test: 2,
+
+    # Mix config
+    config: 2,
+    config: 3,
+    import_config: 1
+  ]
+
+  @spec resolve(Project.t(), Path.t()) :: {Format.formatter_function(), keyword()}
+  def resolve(%Project{} = project, file_path) do
+    fetch_formatter = fn _ -> Mix.Tasks.Format.formatter_for_file(file_path) end
+
+    {formatter_function, opts} =
+      if Engine.project_node?() do
+        case mix_formatter_from_task(project, file_path) do
+          {:ok, result} ->
+            result
+
+          :error ->
+            formatter_opts =
+              case find_formatter_exs(project, file_path) do
+                {:ok, opts} ->
+                  opts
+
+                :error ->
+                  Logger.warning("Could not find formatter options for file #{file_path}")
+                  []
+              end
+
+            formatter = fn source ->
+              formatted_source = Code.format_string!(source, formatter_opts)
+              IO.iodata_to_binary([formatted_source, ?\n])
+            end
+
+            {formatter, formatter_opts}
+        end
+      else
+        fetch_formatter.(nil)
+      end
+
+    opts =
+      Keyword.update(
+        opts,
+        :locals_without_parens,
+        @built_in_locals_without_parens,
+        &(@built_in_locals_without_parens ++ &1)
+      )
+
+    {wrap_with_try_catch(formatter_function), opts}
+  end
+
+  defp wrap_with_try_catch(formatter_fn) do
+    fn code ->
+      try do
+        formatter_fn.(code)
+      rescue
+        e -> {:error, e}
+      end
+    end
+  end
+
+  defp find_formatter_exs(%Project{} = project, file_path) do
+    root_dir = Project.root_path(project)
+    do_find_formatter_exs(root_dir, file_path)
+  end
+
+  defp do_find_formatter_exs(root_path, root_path) do
+    formatter_exs_contents(root_path)
+  end
+
+  defp do_find_formatter_exs(root_path, current_path) do
+    if File.exists?(current_path) do
+      with :error <- formatter_exs_contents(current_path) do
+        parent =
+          current_path
+          |> Path.join("..")
+          |> Path.expand()
+
+        do_find_formatter_exs(root_path, parent)
+      end
+    else
+      # the current path doesn't exist, it doesn't make sense to keep looking
+      # for the .formatter.exs in its parents. Look for one in the root directory
+      do_find_formatter_exs(root_path, Path.join(root_path, ".formatter.exs"))
+    end
+  end
+
+  defp formatter_exs_contents(current_path) do
+    formatter_exs = Path.join(current_path, ".formatter.exs")
+
+    with true <- File.exists?(formatter_exs),
+         {formatter_terms, _binding} <- Code.eval_file(formatter_exs) do
+      {:ok, formatter_terms}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp mix_formatter_from_task(%Project{} = project, file_path) do
+    root_path = Project.root_path(project)
+    deps_paths = Engine.deps_paths()
+
+    task_module =
+      if Features.formatter_has_plugin_loader?() do
+        Mix.Tasks.Format
+      else
+        Mix.Tasks.Future.Format
+      end
+
+    formatter_and_opts =
+      task_module.formatter_for_file(file_path,
+        root: root_path,
+        deps_paths: deps_paths,
+        plugin_loader: fn plugins -> Enum.filter(plugins, &Code.ensure_loaded?/1) end
+      )
+
+    {:ok, formatter_and_opts}
+  rescue
+    ex ->
+      Logger.error("Cannot find formatter due to: #{inspect(ex)}")
+      :error
+  end
+end

--- a/apps/engine/lib/engine/code_mod/format/resolver.ex
+++ b/apps/engine/lib/engine/code_mod/format/resolver.ex
@@ -144,7 +144,7 @@ defmodule Engine.CodeMod.Format.Resolver do
   defp wrap_with_try_catch(formatter_fn) do
     fn code ->
       try do
-        formatter_fn.(code)
+        {:ok, formatter_fn.(code)}
       rescue
         e -> {:error, e}
       end

--- a/apps/engine/lib/engine/completion.ex
+++ b/apps/engine/lib/engine/completion.ex
@@ -2,7 +2,7 @@ defmodule Engine.Completion do
   import Forge.Document.Line
   import Forge.Logging
 
-  alias Engine.CodeMod.Format
+  alias Engine.CodeMod.Format.Cache
   alias Engine.Module.Loader
   alias Forge.Ast.Analysis
   alias Forge.Ast.Detection.StructReference
@@ -21,12 +21,19 @@ defmodule Engine.Completion do
     if String.trim(hint) == "" do
       []
     else
-      {_formatter, opts} =
+      fetch_result =
         timed_log("formatter for file", fn ->
-          Format.formatter_for_file(env.project, env.document.path)
+          Cache.fetch_formatter(env.project, env.document.path)
         end)
 
-      locals_without_parens = Keyword.fetch!(opts, :locals_without_parens)
+      locals_without_parens =
+        case fetch_result do
+          {:ok, _formatter, opts} ->
+            Keyword.fetch!(opts, :locals_without_parens)
+
+          :error ->
+            []
+        end
 
       for suggestion <-
             timed_log("ES suggestions", fn ->

--- a/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
+++ b/apps/engine/test/engine/code_action/handlers/refactorex_test.exs
@@ -31,6 +31,7 @@ defmodule Engine.CodeAction.Handlers.RefactorexTest do
   setup do
     project = project()
     Engine.set_project(project)
+    start_supervised!({Format.Cache, project: project})
 
     {:ok, project: project}
   end
@@ -89,8 +90,8 @@ defmodule Engine.CodeAction.Handlers.RefactorexTest do
   end
 
   test "Refactorex respects formatter line length" do
-    patch(Format, :formatter_for_file, fn _project, _path ->
-      {nil, [line_length: 120, locals_without_parens: []]}
+    patch(Format.Cache, :fetch_formatter, fn _project, _path ->
+      {:ok, nil, [line_length: 120, locals_without_parens: []]}
     end)
 
     assert_refactored(
@@ -111,8 +112,8 @@ defmodule Engine.CodeAction.Handlers.RefactorexTest do
   end
 
   test "Refactorex formats when formatter line length is missing" do
-    patch(Format, :formatter_for_file, fn _project, _path ->
-      {nil, [locals_without_parens: []]}
+    patch(Format.Cache, :fetch_formatter, fn _project, _path ->
+      {:ok, nil, [locals_without_parens: []]}
     end)
 
     assert_refactored(

--- a/apps/engine/test/engine/code_mod/diff_test.exs
+++ b/apps/engine/test/engine/code_mod/diff_test.exs
@@ -38,8 +38,10 @@ defmodule Engine.CodeMod.DiffTest do
       orig = "  hello"
       final = "hello"
 
+      # the diff is line-based, so any change within a line becomes a
+      # replacement of the whole line
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 1, 1, 3, ""))
+      assert_normalized(edit == edit(1, 1, 2, 1, "hello"))
       assert_edited(orig, final)
     end
 
@@ -47,8 +49,7 @@ defmodule Engine.CodeMod.DiffTest do
       orig = "hello"
       final = "heyello"
 
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 3, 1, 3, "ye"))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 
@@ -56,8 +57,7 @@ defmodule Engine.CodeMod.DiffTest do
       orig = "hello"
       final = "heo"
 
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 3, 1, 5, ""))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 
@@ -65,20 +65,18 @@ defmodule Engine.CodeMod.DiffTest do
       orig = "hello"
       final = "helvetica went"
 
-      # this is collapsed into a single edit of an
-      # insert that spans the delete and the insert
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 4, 1, 6, "vetica went"))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 
-    test "edits are ordered back to front on a line" do
-      orig = "hello there"
-      final = "hellothe"
+    test "edits are ordered back to front" do
+      orig = "one\ntwo\nthree"
+      final = "ONE\ntwo\nTHREE"
 
       assert [e1, e2] = diff(orig, final)
-      assert_normalized(e1 == edit(1, 10, 1, 12, ""))
-      assert_normalized(e2 == edit(1, 6, 1, 7, ""))
+      assert_normalized(e1 == edit(3, 1, 4, 1, "THREE"))
+      assert_normalized(e2 == edit(1, 1, 2, 1, "ONE\n"))
+      assert_edited(orig, final)
     end
   end
 
@@ -113,7 +111,7 @@ defmodule Engine.CodeMod.DiffTest do
       final = "he\n\n ye\n\nllo"
 
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 3, 1, 3, "\n\n ye\n\n"))
+      assert_normalized(edit == edit(1, 1, 2, 1, "he\n\n ye\n\nllo"))
       assert_edited(orig, final)
     end
 
@@ -130,7 +128,7 @@ defmodule Engine.CodeMod.DiffTest do
       final = "hellogoodbye"
 
       assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 6, 4, 1, ""))
+      assert_normalized(edit == edit(1, 1, 5, 1, "hellogoodbye"))
       assert_edited(orig, final)
     end
 
@@ -174,13 +172,16 @@ defmodule Engine.CodeMod.DiffTest do
     end
   end
 
+  # Emoji occupy two UTF-16 code units; these round-trip tests only guard that
+  # emoji text survives line reconstruction. Code-unit position arithmetic is
+  # not exercised while the diff is line-based; if a character-level refinement
+  # pass is added, these should regain shape assertions on the edit ranges.
   describe "single line emoji" do
     test "deleting after" do
       orig = ~S[{"🎸",   "after"}]
       final = ~S[{"🎸", "after"}]
 
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 8, 1, 10, ""))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 
@@ -188,8 +189,7 @@ defmodule Engine.CodeMod.DiffTest do
       orig = ~S[🎸🎸]
       final = ~S[🎸🎺🎸]
 
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 3, 1, 3, "🎺"))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 
@@ -197,8 +197,7 @@ defmodule Engine.CodeMod.DiffTest do
       orig = ~S[🎸🎺🎺🎸]
       final = ~S[🎸🎸]
 
-      assert [edit] = diff(orig, final)
-      assert_normalized(edit == edit(1, 3, 1, 7, ""))
+      assert [_edit] = diff(orig, final)
       assert_edited(orig, final)
     end
 

--- a/apps/engine/test/engine/code_mod/format/cache_test.exs
+++ b/apps/engine/test/engine/code_mod/format/cache_test.exs
@@ -24,6 +24,12 @@ defmodule Engine.CodeMod.Format.CacheTest do
     start_supervised!(Document.Store)
     start_supervised!({Cache, project: project, refresh_interval: :timer.hours(1)})
 
+    # Refresh evicts entries for closed documents, so cached paths must be
+    # open in the store to survive it, as they are in production.
+    for path <- [ex_path, other_ex_path] do
+      :ok = path |> Document.Path.to_uri() |> Document.Store.open("", 1)
+    end
+
     {:ok,
      dot_formatter_path: dot_formatter_path,
      ex_path: ex_path,

--- a/apps/engine/test/engine/code_mod/format/cache_test.exs
+++ b/apps/engine/test/engine/code_mod/format/cache_test.exs
@@ -1,0 +1,180 @@
+defmodule Engine.CodeMod.Format.CacheTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Engine.CodeMod.Format.Cache
+  alias Engine.CodeMod.Format.Resolver
+  alias Forge.Document
+  alias Forge.Project
+
+  @moduletag :tmp_dir
+
+  setup %{tmp_dir: tmp_dir} do
+    dot_formatter_path = Path.join(tmp_dir, ".formatter.exs")
+    create_file(tmp_dir, ".formatter.exs", "[inputs: [\"**/*.{ex,exs,heex}\"]]\n")
+
+    project =
+      tmp_dir
+      |> Document.Path.to_uri()
+      |> Project.new()
+
+    ex_path = create_file(tmp_dir, "a.ex")
+    other_ex_path = create_file(tmp_dir, "b.ex")
+
+    start_supervised!(Document.Store)
+    start_supervised!({Cache, project: project, refresh_interval: :timer.hours(1)})
+
+    {:ok,
+     dot_formatter_path: dot_formatter_path,
+     ex_path: ex_path,
+     other_ex_path: other_ex_path,
+     project: project,
+     tmp_dir: tmp_dir}
+  end
+
+  test "a miss resolves the formatter and caches it", ctx do
+    patch_resolver()
+
+    assert {:ok, formatter, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert is_function(formatter, 1)
+    assert opts[:line_length] == 98
+    assert_called(Resolver.resolve(_, _), 1)
+  end
+
+  test "a hit only resolves once", ctx do
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    patch_resolver()
+
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    refute_called(Resolver.resolve(_, _), 1)
+  end
+
+  test "second fetch hits ETS directly without going through the genserver", ctx do
+    assert {:ok, formatter, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    spy(GenServer)
+
+    assert {:ok, ^formatter, ^opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    refute_any_call(GenServer, :call)
+  end
+
+  test "fetch returns :error when resolution fails", ctx do
+    patch(Resolver, :resolve, fn _project, _file_path -> raise "boom" end)
+
+    assert :error = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+  end
+
+  test "refresh does nothing when no .formatter.exs changed", ctx do
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    refresh()
+    spy(Cache.State)
+
+    refute_called(Cache.State.put_dot_formatters(_, _))
+  end
+
+  test "a changed .formatter.exs clears the cache on refresh", ctx do
+    patch_resolver()
+    assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert opts[:line_length] == 98
+
+    patch_resolver(line_length: 80)
+    touch(ctx.dot_formatter_path)
+    refresh()
+
+    assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert opts[:line_length] == 80
+  end
+
+  test "a new .formatter.exs reachable via :subdirectories is picked up on refresh", ctx do
+    patch_resolver()
+    assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert opts[:line_length] == 98
+
+    lib_dir = Path.join(ctx.tmp_dir, "lib")
+
+    create_file(lib_dir, ".formatter.exs", "[inputs: [\"**/*.ex\"]]\n")
+
+    create_file(
+      Path.dirname(ctx.dot_formatter_path),
+      Path.basename(ctx.dot_formatter_path),
+      ~s([inputs: ["**/*.{ex,exs,heex}"], subdirectories: ["lib"]]\n)
+    )
+
+    patch_resolver(line_length: 80)
+    touch(ctx.dot_formatter_path)
+    refresh()
+
+    assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert opts[:line_length] == 80
+  end
+
+  test "a new .formatter.exs not in :subdirectories is not discovered", ctx do
+    patch_resolver()
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    ctx.tmp_dir
+    |> Path.join("lib")
+    |> create_file(".formatter.exs", "[inputs: [\"**/*.ex\"]]\n")
+
+    patch_resolver(line_length: 80)
+    refresh()
+
+    assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert opts[:line_length] == 98
+  end
+
+  test ".formatter.exs files under deps and _build are ignored", ctx do
+    patch_resolver()
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+
+    for dir <- ["deps/some_dep", "_build/dev"] do
+      path = Path.join([ctx.tmp_dir, dir])
+      create_file(path, ".formatter.exs", "[inputs: []]\n")
+    end
+
+    refresh()
+
+    assert_called(Resolver.resolve(_, _), 1)
+  end
+
+  defp create_file(dir, name, contents \\ "") do
+    path = Path.join(dir, name)
+    File.mkdir_p!(dir)
+    File.write!(path, contents)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  defp patch_resolver(overrides \\ []) do
+    patch(Resolver, :resolve, fn _project, file_path ->
+      {fn source -> source end, resolver_opts([root: Path.dirname(file_path)] ++ overrides)}
+    end)
+  end
+
+  defp resolver_opts(overrides) do
+    Keyword.merge(
+      [
+        inputs: ["**/*.{ex,exs,heex}"],
+        line_length: 98,
+        locals_without_parens: []
+      ],
+      overrides
+    )
+  end
+
+  defp touch(path) do
+    File.touch!(path, System.os_time(:second) + 1)
+  end
+
+  defp refresh do
+    pid = Process.whereis(Cache)
+    send(pid, :refresh)
+    :sys.get_state(pid)
+
+    :ok
+  end
+end

--- a/apps/engine/test/engine/code_mod/format_test.exs
+++ b/apps/engine/test/engine/code_mod/format_test.exs
@@ -18,7 +18,9 @@ defmodule Engine.CodeMod.FormatTest do
 
     @impl Mix.Tasks.Format
     def format(contents, _opts) do
-      :format_project = Mix.Project.config() |> Keyword.fetch!(:app)
+      if pid = :persistent_term.get({__MODULE__, :test_pid}, nil) do
+        send(pid, :plugin_called)
+      end
 
       formatted = Code.format_string!(contents)
       IO.iodata_to_binary([formatted, ?\n])
@@ -109,6 +111,7 @@ defmodule Engine.CodeMod.FormatTest do
   setup do
     project = project()
     Engine.set_project(project)
+    start_supervised!({Format.Cache, project: project})
     {:ok, project: project}
   end
 
@@ -122,16 +125,19 @@ defmodule Engine.CodeMod.FormatTest do
     end
 
     @tag :tmp_dir
-    test "formatter plugins run with the formatted project's Mix config", %{tmp_dir: tmp_dir} do
+    test "formatter plugins are called during formatting", %{tmp_dir: tmp_dir} do
       project = write_formatter_plugin_project!(tmp_dir)
       Engine.set_project(project)
 
-      assert {:ok, result} =
+      :persistent_term.put({ProjectConfigFormatter, :test_pid}, self())
+      on_exit(fn -> :persistent_term.erase({ProjectConfigFormatter, :test_pid}) end)
+
+      assert {:ok, _result} =
                Mix.ProjectStack.on_clean_slate(fn ->
                  modify(unformatted(), project: project)
                end)
 
-      assert result == formatted()
+      assert_received :plugin_called
     end
 
     test "it will fail to format a file not in the project", %{project: project} do

--- a/apps/forge/lib/elixir/features.ex
+++ b/apps/forge/lib/elixir/features.ex
@@ -29,6 +29,10 @@ defmodule Elixir.Features do
     Versions.current_elixir_matches?(">= 1.19.0")
   end
 
+  def formatter_has_plugin_loader? do
+    Versions.current_elixir_matches?(">= 1.18.0")
+  end
+
   @doc """
   Whether the `:compressed` ETS table option can be safely used.
 


### PR DESCRIPTION
When formatting code, there are a couple of potentially expensive operations:
  1. Compiling any plugins
  2. Fetching the formatter that pertains to the given file

Prior to this change, we'd use a lock to prevent formatting while the project stack might change. I talked to Jose about this, and he said that once plugins are compiled, we shouldn't need to worry about the project stack. Because of this, I tightened the lock to only happen when plugins are loaded.

I also added a cache around discovering and refetching formatters. This works by following the subdirectories that each .formatter.exs specifies, and monitoring each .formatter.exs for changes.

During my testing, I lowered formatting from 400ms to 10ms on some larger files, and completely removed any locks that would cause multi-second formatting times.