### PR TITLE
fix: index project sources even when compile reports error

### DIFF
--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -92,7 +92,7 @@ defmodule Expert.Project.Indexer do
 
   @impl GenServer
   def handle_info(project_compiled(status: status), %State{} = state)
-      when status in [:success, :successful] do
+      when status in [:success, :successful, :error] do
     {:noreply, start_or_queue_index(state)}
   end
 

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -70,6 +70,42 @@ defmodule Expert.Project.IndexerTest do
     assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.Initial, [])
   end
 
+  test "creates the initial index even when the project compile reports an error", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    test_pid = self()
+    entry = definition(id: 1, subject: ProjectIndexer.OnError, path: "/on_error.ex")
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project ->
+           send(test_pid, :create_index)
+
+           {:ok, [entry],
+            fn ->
+              send(test_pid, {:after_apply, Store.exact(project, ProjectIndexer.OnError, [])})
+              :ok
+            end}
+         end,
+         update_index: fn ^project, _path_to_ids ->
+           send(test_pid, :update_index)
+           {:ok, [], [], fn -> :ok end}
+         end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :error))
+
+    assert_receive :create_index
+    assert_receive {:after_apply, {:ok, [^entry]}}
+    assert_receive project_index_ready(project: ^project)
+    assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.OnError, [])
+  end
+
   test "updates an existing index after later successful project compiles", %{
     project: project,
     task_supervisor: task_supervisor


### PR DESCRIPTION
Previously Expert.Project.Indexer only ran on project_compiled status :success/:successful, so any failing compile left the search index empty and broke go-to-definition for every project symbol.

This was hit in practice when an Elixir 1.20.2 type-checker diagnostic crash (while formatting a warning for a dependency's Nx defn code) was promoted to a fatal compile error, suppressing all project-module indexing. Indexing on :error as well keeps go-to-definition working regardless of transient compile failures.
