### PR TITLE
chore(sqlite): compress entry_blobs

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -1040,7 +1040,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
   defp blob(term), do: {:blob, encode_term(term)}
 
-  defp encode_term(term), do: :erlang.term_to_binary(term)
+  defp encode_term(term), do: :erlang.term_to_binary(term, [:compressed])
   defp decode_term(binary), do: :erlang.binary_to_term(binary)
 
   defp same_block_type?(left_entry, right_entry),


### PR DESCRIPTION
Doing that saves about 55% disk space on Jump project (1.6G -> 720M). Decoding via `binary_to_term` handles the compression automatically, so this is backwards compatible.

There's probably more to win here, as there is duplicated data encoded as blob, but this alone is pretty big.
