### PR TITLE
chore(sqlite): improve subtype indexing

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -11,7 +11,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   require Entry
   require Logger
 
-  @schema_version 2
+  @schema_version 3
   @database_file "source.index.sqlite3"
   @slow_query_threshold_ms 500
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params
@@ -619,9 +619,11 @@ defmodule Expert.Search.Store.Backends.Sqlite do
              state,
              "CREATE INDEX IF NOT EXISTS entries_type_subtype_idx ON entries (type, subtype)"
            ) do
+      # We only ever use subtype column by filtering it to definitions, so partial index makes it smaller (without references),
+      # while also making inserting references faster and being able to query for fuzzy definitions using index only
       exec(
         state,
-        "CREATE INDEX IF NOT EXISTS entries_subtype_subject_idx ON entries (subtype, subject)"
+        "CREATE INDEX IF NOT EXISTS entries_definitions_idx ON entries (subject, id, path, type) WHERE subtype = 'definition'"
       )
     end
   end

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -619,8 +619,9 @@ defmodule Expert.Search.Store.Backends.Sqlite do
              state,
              "CREATE INDEX IF NOT EXISTS entries_type_subtype_idx ON entries (type, subtype)"
            ) do
-      # We only ever use subtype column by filtering it to definitions, so partial index makes it smaller (without references),
-      # while also making inserting references faster and being able to query for fuzzy definitions using index only
+      # We only ever use subtype column by filtering it to definitions, so partial index makes it smaller
+      # (without references), while also making inserting references faster and being able to query
+      # for fuzzy definitions using index only.
       exec(
         state,
         "CREATE INDEX IF NOT EXISTS entries_definitions_idx ON entries (subject, id, path, type) WHERE subtype = 'definition'"

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -134,7 +134,7 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
 
       {:ok, conn} = Exqlite.Basic.open(database_path)
       result = Exqlite.Basic.exec(conn, "SELECT version FROM schema")
-      assert {:ok, [[2]], ["version"]} = Exqlite.Basic.rows(result)
+      assert {:ok, [[3]], ["version"]} = Exqlite.Basic.rows(result)
       assert :ok = Exqlite.Basic.close(conn)
     end
   end


### PR DESCRIPTION
This improves the indexing situation by replacing the generic `entries_subtype_idx` index with a partial one only on subtype definition.

In my tests on a large codase, the definitions constitutes less than 10% of the `entries` tables, and as a result, `entries_subtype_idx`. However, we only ever query by subtype by filtering `subtype = 'definition'`, so 90+% of the index was never used.

Replacing it with a partial index gives a small disk size saving (60M), but also should make:
- querying faster, because the index to scan is smaller
- inserting references faster, because we bypass one index completely
- by adding additional fields to the index we should be able to query for fuzzy definitions using index only - making it faster too