### PR TITLE
fix(engine): analyzer gets confused with overlapping aliases

### DIFF
--- a/apps/engine/lib/engine/analyzer.ex
+++ b/apps/engine/lib/engine/analyzer.ex
@@ -201,8 +201,31 @@ defmodule Engine.Analyzer do
     # in one go, like Foo.{First, Second.Third, Fourth}
     # Our alias mapping will have Third mapped to Foo.Second.Third, so we need to look
     # for Third, whereas the leading alias will look for Second in the mappings.
-    with {:ok, resolved} <- Map.fetch(aliases_mapping, [List.last(segments)]) do
+    # The resolved module must end with all the segments being resolved; otherwise an
+    # unrelated alias sharing the last segment (e.g. alias A.B.User while resolving
+    # Foo.User) would shadow the literal module.
+    with {:ok, resolved} <- Map.fetch(aliases_mapping, [List.last(segments)]),
+         true <- ends_with_segments?(resolved, segments) do
       {:ok, List.wrap(resolved)}
+    else
+      _ ->
+        :error
     end
+  end
+
+  defp ends_with_segments?(resolved, segments) when is_atom(resolved) do
+    case Ast.Module.safe_split(resolved, as: :atoms) do
+      {:elixir, resolved_segments} ->
+        resolved_segments
+        |> Enum.reverse()
+        |> List.starts_with?(Enum.reverse(segments))
+
+      _ ->
+        false
+    end
+  end
+
+  defp ends_with_segments?(_resolved, _segments) do
+    false
   end
 end

--- a/apps/engine/test/engine/analyzer_test.exs
+++ b/apps/engine/test/engine/analyzer_test.exs
@@ -104,6 +104,38 @@ defmodule Engine.AnalyzerTest do
                Analyzer.expand_alias([:Something, :Baz], analysis, position)
     end
 
+    test "does not apply an unrelated alias to the trailing segment of a literal module" do
+      {position, document} =
+        ~q[
+          defmodule Parent do
+            alias MyApp.User
+            |
+          end
+        ]
+        |> pop_cursor(as: :document)
+
+      analysis = Ast.analyze(document)
+
+      assert {:ok, Dependency.User} =
+               Analyzer.expand_alias([:Dependency, :User], analysis, position)
+    end
+
+    test "works with trailing aliases from the multi-alias curly syntax" do
+      {position, document} =
+        ~q[
+          defmodule Parent do
+            alias Foo.{First, Second.Third}
+            |
+          end
+        ]
+        |> pop_cursor(as: :document)
+
+      analysis = Ast.analyze(document)
+
+      assert {:ok, Foo.Second.Third} =
+               Analyzer.expand_alias([:Second, :Third], analysis, position)
+    end
+
     test "works with protocol definitions nested in a module" do
       {position, document} =
         ~q[


### PR DESCRIPTION
If someone has aliased MyApp.User, and then, in the same module, hovers over %OtherCompany.User{}, and select go-to-definition, then expert returns the definition of MyApp.User.

This is because the analyzer only took the last segment of the alias into account, and it needs to look at the entire alias.