### PR TITLE
fix: incorrect undefined protocol function diagnostic

### DIFF
--- a/apps/engine/lib/engine/compilation/tracer.ex
+++ b/apps/engine/lib/engine/compilation/tracer.ex
@@ -18,12 +18,7 @@ defmodule Engine.Compilation.Tracer do
 
   def extract_module_updated(module, module_binary, filename) do
     if !Loader.ensure_loaded?(module) do
-      erlang_filename =
-        filename
-        |> ensure_filename()
-        |> String.to_charlist()
-
-      :code.load_binary(module, erlang_filename, module_binary)
+      :code.load_binary(module, [], module_binary)
     end
 
     functions = module.__info__(:functions)
@@ -45,15 +40,6 @@ defmodule Engine.Compilation.Tracer do
       name: module,
       struct: struct
     )
-  end
-
-  defp ensure_filename(:none) do
-    unique = System.unique_integer([:positive, :monotonic])
-    Path.join(System.tmp_dir(), "file-#{unique}.ex")
-  end
-
-  defp ensure_filename(filename) when is_binary(filename) do
-    filename
   end
 
   defp maybe_report_progress(file) do

--- a/apps/expert/test/engine/build_test.exs
+++ b/apps/expert/test/engine/build_test.exs
@@ -178,6 +178,14 @@ defmodule Engine.BuildTest do
     end
   end
 
+  test "does not report defined protocol functions as undefined" do
+    {:ok, project} = with_project(:protocol_diagnostics)
+    EngineApi.schedule_compile(project, true)
+
+    assert_receive project_compiled(status: :success), @project_compile_timeout
+    assert_receive project_diagnostics(diagnostics: [])
+  end
+
   def with_patched_state_timeout(_) do
     patch(Engine.Build.State, :should_compile?, true)
     patch(Engine.Build.State, :edit_window_millis, 50)

--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -80,9 +80,8 @@ defmodule Expert.Provider.Handlers.HoverTest do
         fun.()
       after
         for module <- modules do
-          path = EngineApi.call(project, :code, :which, [module])
           EngineApi.call(project, :code, :delete, [module])
-          File.rm!(path)
+          File.rm!(Path.join(compile_path, Atom.to_string(module) <> ".beam"))
         end
       end
     end)
@@ -969,10 +968,8 @@ defmodule Expert.Provider.Handlers.HoverTest do
         fun.()
       after
         for module <- modules do
-          path = EngineApi.call(project, :code, :which, [module])
           EngineApi.call(project, :code, :delete, [module])
-          # only delete the .beam file, not the source file (which with_tmp_file handles)
-          if is_binary(path), do: File.rm(path)
+          File.rm!(Path.join(compile_path, Atom.to_string(module) <> ".beam"))
         end
       end
     end)

--- a/apps/forge/test/fixtures/protocol_diagnostics/lib/caller.ex
+++ b/apps/forge/test/fixtures/protocol_diagnostics/lib/caller.ex
@@ -1,0 +1,3 @@
+defmodule ProtocolDiagnostics.Caller do
+  def call(value), do: ProtocolDiagnostics.Protocol.call(value)
+end

--- a/apps/forge/test/fixtures/protocol_diagnostics/lib/protocol.ex
+++ b/apps/forge/test/fixtures/protocol_diagnostics/lib/protocol.ex
@@ -1,0 +1,7 @@
+defprotocol ProtocolDiagnostics.Protocol do
+  def call(value)
+end
+
+defimpl ProtocolDiagnostics.Protocol, for: Atom do
+  def call(value), do: value
+end

--- a/apps/forge/test/fixtures/protocol_diagnostics/mix.exs
+++ b/apps/forge/test/fixtures/protocol_diagnostics/mix.exs
@@ -1,0 +1,7 @@
+defmodule ProtocolDiagnostics.MixProject do
+  use Mix.Project
+
+  def project do
+    [app: :protocol_diagnostics, version: "0.1.0"]
+  end
+end


### PR DESCRIPTION
Fix #296 

I spent several weeks trying to reproduce this thinking that it was an issue with Elixir's 1.19 parallel compilation, but it turned out to be something way simpler.  The docs for `:code.load_binary` say this:

> `Filename` is only used by the code server to keep a record of from which file the object code for `Module` originates

We interpreted `Filename` to mean the source file, but it must be a .beam file: "from which file the object code from `Module` originates". Due to this confusion we were passing the .ex file path to the code server, then Elixir introduced [this commit](https://github.com/elixir-lang/elixir/commit/5f50a1f9075ccfadd0ccdc37f2328e146660b4e8#diff-5fc27e300aa733026cf10db92ae6a9a753a73e2466fa7569a28755e87443c1a8R78) in 1.19 which calls `:code.which` on that path. Elixir would then try to read the beam bytecode from that path, get nothing useful back and return `{:not_found, nil}` for that module in the parallel checker, the compiler thought the module/functions did not exist, and produced the spurious diagnostics from linked issue.

The fix is to just not pass any path there and just provide `[]`, that is a safe value for the code server meaning the bytecode does not come from a file, and the parallel checker already considers this a legal scenario and handles it appropriately.