### PR TITLE
fix: prevent formatter cache from forgetting the formatter for a path

### DIFF
--- a/apps/engine/lib/engine/code_mod/format/cache.ex
+++ b/apps/engine/lib/engine/code_mod/format/cache.ex
@@ -35,15 +35,14 @@ defmodule Engine.CodeMod.Format.Cache do
   defmodule Entry do
     @moduledoc false
 
-    defstruct [:id, :formatter, :opts, :extension, :path]
+    defstruct [:id, :formatter, :opts, :extension]
     @type id :: non_neg_integer()
 
     @type t :: %__MODULE__{
             id: id(),
             formatter: Engine.CodeMod.Format.formatter_function(),
             opts: keyword(),
-            extension: String.t(),
-            path: Path.t()
+            extension: String.t()
           }
 
     @spec new(Format.formatter_function(), keyword(), Path.t()) :: t()
@@ -54,8 +53,7 @@ defmodule Engine.CodeMod.Format.Cache do
         id: :erlang.unique_integer([:positive]),
         formatter: formatter,
         opts: opts,
-        extension: extension,
-        path: file_path
+        extension: extension
       }
     end
 
@@ -330,18 +328,25 @@ defmodule Engine.CodeMod.Format.Cache do
   end
 
   defp clean_closed_entries do
-    closed_entries =
-      @entries_table
-      |> :ets.tab2list()
-      |> Enum.reject(fn entry_row(entry: %Entry{} = entry) ->
-        entry.path
-        |> Document.Path.to_uri()
-        |> Document.Store.open?()
-      end)
+    @paths_table
+    |> :ets.tab2list()
+    |> Enum.each(fn path_row(path: path) ->
+      if not (path |> Document.Path.to_uri() |> Document.Store.open?()) do
+        true = :ets.delete(@paths_table, path)
+      end
+    end)
 
-    Enum.each(closed_entries, fn entry_row(entry: %Entry{} = entry) ->
-      true = :ets.delete(@entries_table, entry.id)
-      true = :ets.delete(@paths_table, entry.path)
+    referenced_entry_ids =
+      @paths_table
+      |> :ets.tab2list()
+      |> MapSet.new(fn path_row(entry_id: entry_id) -> entry_id end)
+
+    @entries_table
+    |> :ets.tab2list()
+    |> Enum.each(fn entry_row(id: entry_id) ->
+      if !MapSet.member?(referenced_entry_ids, entry_id) do
+        true = :ets.delete(@entries_table, entry_id)
+      end
     end)
   end
 end

--- a/apps/engine/test/engine/code_mod/format/cache_test.exs
+++ b/apps/engine/test/engine/code_mod/format/cache_test.exs
@@ -82,6 +82,28 @@ defmodule Engine.CodeMod.Format.CacheTest do
     refute_called(Cache.State.put_dot_formatters(_, _))
   end
 
+  test "refresh retains a shared formatter until every path is closed", ctx do
+    patch_resolver()
+
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.ex_path)
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
+    assert_called(Resolver.resolve(_, _), 1)
+
+    :ok = ctx.ex_path |> Document.Path.to_uri() |> Document.Store.close()
+    refresh()
+
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
+    assert_called(Resolver.resolve(_, _), 1)
+
+    other_ex_uri = Document.Path.to_uri(ctx.other_ex_path)
+    :ok = Document.Store.close(other_ex_uri)
+    refresh()
+    :ok = Document.Store.open(other_ex_uri, "", 2)
+
+    assert {:ok, _, _} = Cache.fetch_formatter(ctx.project, ctx.other_ex_path)
+    assert_called(Resolver.resolve(_, _), 2)
+  end
+
   test "a changed .formatter.exs clears the cache on refresh", ctx do
     patch_resolver()
     assert {:ok, _, opts} = Cache.fetch_formatter(ctx.project, ctx.ex_path)


### PR DESCRIPTION
Fix #830 

The formatter cache stored a single file to match against a formatter. Closing that file would clear the cache and cause formatting to fail for any other file.