### PR TITLE
chore(sqlite): only store what's needed in entry_blobs table

### DIFF
--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -11,7 +11,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   require Entry
   require Logger
 
-  @schema_version 3
+  @schema_version 4
   @database_file "source.index.sqlite3"
   @slow_query_threshold_ms 500
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params
@@ -397,7 +397,14 @@ defmodule Expert.Search.Store.Backends.Sqlite do
                query(
                  state,
                  """
-                 SELECT entries.id, entry_blobs.entry
+                 SELECT
+                   entries.id,
+                   entries.path,
+                   entries.subject,
+                   entries.type,
+                   entries.subtype,
+                   entries.block_id,
+                   entry_blobs.entry
                  FROM entries
                  JOIN entry_blobs ON entry_blobs.entry_key = entries.entry_key
                  #{where_clause(where)}
@@ -408,8 +415,8 @@ defmodule Expert.Search.Store.Backends.Sqlite do
           entries_by_id =
             Enum.group_by(
               rows,
-              fn [id, _entry_blob] -> id end,
-              fn [_id, entry_blob] -> decode_term(entry_blob) end
+              fn [id | _rest] -> id end,
+              &decode_entry/1
             )
 
           Enum.flat_map(ids, fn id -> Map.get(entries_by_id, id, []) end)
@@ -449,7 +456,14 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     case query(
            state,
            """
-           SELECT entry_blobs.entry
+           SELECT
+             entries.id,
+             entries.path,
+             entries.subject,
+             entries.type,
+             entries.subtype,
+             entries.block_id,
+             entry_blobs.entry
            FROM entries
             JOIN entry_blobs ON entry_blobs.entry_key = entries.entry_key
            WHERE block_id = ? AND path = ?
@@ -459,7 +473,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
          ) do
       {:ok, rows} ->
         rows
-        |> Enum.map(fn [entry_blob] -> decode_term(entry_blob) end)
+        |> Enum.map(&decode_entry/1)
         |> Enum.filter(&same_block_type?(entry, &1))
         |> Enum.uniq()
         |> then(&{:ok, &1})
@@ -712,7 +726,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
 
     args =
       Enum.flat_map(rows, fn {entry, entry_key} ->
-        [entry_key, blob(entry)]
+        [entry_key, build_entry_blob(entry)]
       end)
 
     exec(state, sql, args)
@@ -809,7 +823,14 @@ defmodule Expert.Search.Store.Backends.Sqlite do
     query(
       state,
       """
-      SELECT entry_blobs.entry
+      SELECT
+        entries.id,
+        entries.path,
+        entries.subject,
+        entries.type,
+        entries.subtype,
+        entries.block_id,
+        entry_blobs.entry
       FROM entries
       JOIN entry_blobs ON entry_blobs.entry_key = entries.entry_key
       #{where}
@@ -832,7 +853,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   end
 
   defp entries_result({:ok, rows}) do
-    Enum.map(rows, fn [entry_blob] -> decode_term(entry_blob) end)
+    Enum.map(rows, &decode_entry/1)
   end
 
   defp entries_result({:error, _} = error), do: error
@@ -1081,6 +1102,38 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   defp block_id_key(:root), do: 0
   defp block_id_key(nil), do: 0
   defp block_id_key(block_id) when is_integer(block_id), do: block_id
+
+  defp block_id(0), do: :root
+  defp block_id(block_id) when is_integer(block_id), do: block_id
+
+  defp build_entry_blob(%Entry{} = entry) do
+    subject_override = if !is_binary(entry.subject), do: entry.subject
+
+    blob({subject_override, entry.application, entry.block_range, entry.range, entry.metadata})
+  end
+
+  defp decode_entry([id, path, subject_key, type_blob, subtype, block_id, entry_blob]) do
+    {subject_override, application, block_range, range, metadata} = decode_term(entry_blob)
+
+    subject =
+      case subject_override do
+        nil -> subject_key
+        subject -> subject
+      end
+
+    %Entry{
+      application: application,
+      id: id,
+      block_id: block_id(block_id),
+      block_range: block_range,
+      path: path,
+      range: range,
+      subject: subject,
+      subtype: String.to_existing_atom(subtype),
+      type: decode_term(type_blob),
+      metadata: metadata
+    }
+  end
 
   defp blob(term), do: {:blob, encode_term(term)}
 

--- a/apps/expert/test/expert/search/store/backends/sqlite_test.exs
+++ b/apps/expert/test/expert/search/store/backends/sqlite_test.exs
@@ -58,7 +58,7 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
              end)
     end
 
-    test "stores full entry blobs outside the entries metadata table", %{
+    test "stores only entry data that is not available in the entries table", %{
       project: project,
       runtime_versions: runtime_versions
     } do
@@ -99,6 +99,45 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
              end)
     end
 
+    test "stores lean entry blobs and reconstructs entries from both tables", %{
+      project: project,
+      runtime_versions: runtime_versions
+    } do
+      database_path = Sqlite.database_path(project, runtime_versions)
+
+      entry = %Entry{
+        application: :sample,
+        id: 1,
+        block_id: :root,
+        block_range: %{start: 1, end: 2},
+        path: "/a/path/that/must/not/be/duplicated.ex",
+        range: %{start: 3, end: 4},
+        subject: "Lean.Module.function/0",
+        subtype: :definition,
+        type: :module,
+        metadata: %{detail: :kept}
+      }
+
+      pid =
+        start_supervised!(%{
+          id: :sqlite,
+          start: {Sqlite, :start_link, [project, [runtime_versions: runtime_versions]]}
+        })
+
+      assert {:ok, :empty} = Sqlite.prepare(pid)
+      assert :ok = Sqlite.replace_all(project, [entry])
+
+      {:ok, conn} = Exqlite.Basic.open(database_path)
+      result = Exqlite.Basic.exec(conn, "SELECT entry FROM entry_blobs")
+      assert {:ok, [[entry_blob]], _columns} = Exqlite.Basic.rows(result)
+      assert :ok = Exqlite.Basic.close(conn)
+
+      assert {nil, :sample, %{start: 1, end: 2}, %{start: 3, end: 4}, %{detail: :kept}} =
+               :erlang.binary_to_term(entry_blob)
+
+      assert [^entry] = Sqlite.find_by_subject(project, "Lean.Module.function/0", :_, :_)
+    end
+
     test "recreates a database with a different schema version", %{
       project: project,
       runtime_versions: runtime_versions
@@ -134,7 +173,7 @@ defmodule Expert.Search.Store.Backends.SqliteTest do
 
       {:ok, conn} = Exqlite.Basic.open(database_path)
       result = Exqlite.Basic.exec(conn, "SELECT version FROM schema")
-      assert {:ok, [[3]], ["version"]} = Exqlite.Basic.rows(result)
+      assert {:ok, [[4]], ["version"]} = Exqlite.Basic.rows(result)
       assert :ok = Exqlite.Basic.close(conn)
     end
   end


### PR DESCRIPTION
One more proposal to improve SQLite indexer a bit. Currently `entry_blobs` contains just a serialized `Entry` struct, which means a lot of duplication and table taking a lot more space than necessary. This introduces serialization to specialized entry blob shape and deserializing `Entry` from it.

On our work project:

**Before:**

```
*** Table ENTRY_BLOBS *********************************************************

Percentage of total database......................  43.6%    
Number of entries................................. 1753557   
Bytes of storage consumed......................... 805842944 
Bytes of payload.................................. 749056083   93.0% 
Bytes of metadata................................. 15598615     1.9% 
```

**After:**

```
*** Table ENTRY_BLOBS *********************************************************

Percentage of total database......................  30.7%    
Number of entries................................. 1753557   
Bytes of storage consumed......................... 461762560 
Bytes of payload.................................. 433125631   93.8% 
Bytes of metadata................................. 14172401     3.1% 
```

This is more than 40% down for `entry_blobs`, saving about 300M of disk space in the database file.

Thoughts?