### PR TITLE
feat: add Spark integration

### DIFF
--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -42,6 +42,8 @@ defmodule Engine do
 
   defdelegate complete(env), to: Engine.Completion, as: :elixir_sense_expand
 
+  defdelegate contextual_completion(env), to: Engine.Integrations, as: :complete
+
   defdelegate complete_struct_fields(analysis, position),
     to: Engine.Completion,
     as: :struct_fields

--- a/apps/engine/lib/engine.ex
+++ b/apps/engine/lib/engine.ex
@@ -44,6 +44,8 @@ defmodule Engine do
 
   defdelegate contextual_completion(env), to: Engine.Integrations, as: :complete
 
+  defdelegate contextual_hover(env), to: Engine.Integrations, as: :hover
+
   defdelegate complete_struct_fields(analysis, position),
     to: Engine.Completion,
     as: :struct_fields

--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -4,6 +4,7 @@ defmodule Engine.Build.Project do
   alias Engine.Module.Loader
   alias Engine.Plugin
   alias Engine.Progress
+  alias Engine.Search.Indexer.ManifestStore
   alias Forge.Internet
   alias Forge.Project
   alias Mix.Task.Compiler.Diagnostic
@@ -67,7 +68,7 @@ defmodule Engine.Build.Project do
     compile_fun = fn ->
       Mix.Task.clear()
       Progress.report(token, message: "Compiling #{Project.display_name(project)}")
-      result = compile_in_isolation()
+      result = compile_in_isolation(ManifestStore.integrations_changed?(project))
       maybe_load_modules()
       Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:loadpaths)
@@ -106,10 +107,10 @@ defmodule Engine.Build.Project do
     end
   end
 
-  defp compile_in_isolation do
+  defp compile_in_isolation(force?) do
     compile_fun = fn ->
       Engine.Mix.ensure_hex_and_rebar()
-      Mix.Task.run(:compile, mix_compile_opts())
+      Mix.Task.run(:compile, mix_compile_opts(force?))
     end
 
     case Isolation.invoke(compile_fun) do
@@ -155,12 +156,12 @@ defmodule Engine.Build.Project do
     Plugin.Discovery.run()
   end
 
-  defp mix_compile_opts do
+  defp mix_compile_opts(force?) do
     # --no-prune-code-paths keeps mix from deleting the engine's own code
     # paths during the project compile. It only applies to the top-level
     # compile; dependencies each compile in their own project frame with
     # pruning enabled, which is what isolates them from undeclared siblings.
-    ~w(
+    opts = ~w(
         --return-errors
         --ignore-module-conflict
         --all-warnings
@@ -169,5 +170,7 @@ defmodule Engine.Build.Project do
         --no-protocol-consolidation
         --no-prune-code-paths
     )
+
+    if force?, do: ["--force" | opts], else: opts
   end
 end

--- a/apps/engine/lib/engine/integrations.ex
+++ b/apps/engine/lib/engine/integrations.ex
@@ -7,6 +7,9 @@ defmodule Engine.Integrations do
 
   @beam_indexers [Engine.Integrations.Spark.Indexer]
   @completion_providers [Engine.Integrations.Spark.Completion]
+  @indexer_module_names @beam_indexers |> Enum.map(&Atom.to_string/1) |> Enum.sort()
+
+  def indexer_module_names, do: @indexer_module_names
 
   def index_beam(binary, metadata, source_path) do
     Enum.flat_map(@beam_indexers, & &1.index(binary, metadata, source_path))

--- a/apps/engine/lib/engine/integrations.ex
+++ b/apps/engine/lib/engine/integrations.ex
@@ -1,13 +1,26 @@
 defmodule Engine.Integrations do
   @moduledoc """
-  Registers dependency BEAM indexers and contextual completion providers.
+  Registers third party integrations.
   """
 
-  @callback index(binary(), map(), String.t()) :: [Forge.Search.Indexer.Entry.t()]
+  alias Forge.Ast.Env
+  alias Forge.Document.Range
+  alias Forge.Search.Indexer.Entry
+
+  @callback index(binary(), map(), String.t()) :: [Entry.t()]
+
+  @callback complete(Env.t()) ::
+              {:augment | :override, [{struct(), [atom()]}], boolean(), [atom()]} | :ignore
+
+  @callback hover(Env.t()) :: [{String.t(), Range.t()}]
+
+  @optional_callbacks index: 3, complete: 1, hover: 1
 
   @beam_indexers [Engine.Integrations.Spark.Indexer]
-  @completion_providers [Engine.Integrations.Spark.Completion]
   @indexer_module_names @beam_indexers |> Enum.map(&Atom.to_string/1) |> Enum.sort()
+
+  @completion_providers [Engine.Integrations.Spark.Completion]
+  @hover_providers [Engine.Integrations.Spark.Hover]
 
   def indexer_module_names, do: @indexer_module_names
 
@@ -22,5 +35,9 @@ defmodule Engine.Integrations do
         result -> result
       end
     end)
+  end
+
+  def hover(env) do
+    Enum.flat_map(@hover_providers, & &1.hover(env))
   end
 end

--- a/apps/engine/lib/engine/integrations.ex
+++ b/apps/engine/lib/engine/integrations.ex
@@ -1,0 +1,23 @@
+defmodule Engine.Integrations do
+  @moduledoc """
+  Registers dependency BEAM indexers and contextual completion providers.
+  """
+
+  @callback index(binary(), map(), String.t()) :: [Forge.Search.Indexer.Entry.t()]
+
+  @beam_indexers [Engine.Integrations.Spark.Indexer]
+  @completion_providers [Engine.Integrations.Spark.Completion]
+
+  def index_beam(binary, metadata, source_path) do
+    Enum.flat_map(@beam_indexers, & &1.index(binary, metadata, source_path))
+  end
+
+  def complete(env) do
+    Enum.find_value(@completion_providers, :ignore, fn provider ->
+      case provider.complete(env) do
+        :ignore -> nil
+        result -> result
+      end
+    end)
+  end
+end

--- a/apps/engine/lib/engine/integrations/spark/common.ex
+++ b/apps/engine/lib/engine/integrations/spark/common.ex
@@ -1,0 +1,221 @@
+defmodule Engine.Integrations.Spark.Common do
+  alias Engine.Analyzer
+  alias Engine.Analyzer.Uses
+  alias Engine.ManagerApi
+  alias Forge.Ast
+  alias Forge.Ast.Analysis.Use
+  alias Forge.Ast.Env
+  alias Forge.Search.Indexer.Entry
+
+  def use_context(cursor_path, env) do
+    Enum.find_value(cursor_path, :error, fn
+      {:use, _, [module_ast | arguments]} ->
+        with {:ok, module} <- expand_module(module_ast, env),
+             do: {:ok, module, List.last(arguments)}
+
+      _ ->
+        nil
+    end)
+  end
+
+  def function_context(cursor_path, env) do
+    with {:ok, module_ast, name, arity, argument_index, argument} <-
+           Ast.remote_call_at_cursor(cursor_path),
+         {:ok, module} <- expand_module(module_ast, env) do
+      {:ok, module, name, arity, argument_index, argument}
+    end
+  end
+
+  def dsl_context(project, %Env{} = env) do
+    env.analysis
+    |> Uses.at(env.position)
+    |> Enum.find_value(:error, &dsl_for_use(project, &1, env))
+  end
+
+  def active_extensions(project, dsl, %Use{} = use, env) do
+    extensions = fetch_extensions(project)
+    configured = configured_extensions(use, dsl, env)
+
+    defaults =
+      Enum.reduce(dsl.single_extension_kinds, dsl.default_extensions, fn kind, defaults ->
+        if Map.get(configured, kind, []) == [],
+          do: defaults,
+          else: defaults -- Map.get(dsl.default_extension_kinds, kind, [])
+      end)
+
+    (defaults ++ Enum.flat_map(configured, fn {_kind, modules} -> modules end))
+    |> Enum.uniq()
+    |> expand_extensions(extensions, %{})
+    |> apply_patches()
+  end
+
+  def find_node(sections, names, current_call_name \\ nil) do
+    root = %{options: [], entities: [], sections: sections}
+    last_name = List.last(names)
+
+    Enum.reduce_while(names, {:ok, root}, fn name, {:ok, node} ->
+      case child(node, name) do
+        nil when name == last_name and name == current_call_name -> {:halt, {:ok, node}}
+        nil -> {:halt, :error}
+        child -> {:cont, {:ok, child}}
+      end
+    end)
+  end
+
+  def child(node, name) do
+    Enum.find(Map.get(node, :sections, []), &(&1.name == name)) ||
+      Enum.find(Map.get(node, :entities, []), &(&1.name == name)) ||
+      Enum.find(top_level_children(node), &(&1.name == name))
+  end
+
+  def top_level_children(node) do
+    node
+    |> Map.get(:sections, [])
+    |> Enum.filter(& &1.top_level?)
+    |> Enum.flat_map(fn section -> section.options ++ section.entities ++ section.sections end)
+  end
+
+  def selected_type_module({:__block__, _, [value]}, aliases, env),
+    do: selected_type_module(value, aliases, env)
+
+  def selected_type_module(value, aliases, _env) when is_atom(value),
+    do: Map.fetch(aliases, to_string(value))
+
+  def selected_type_module(value, _aliases, env) do
+    with {:ok, module} <- expand_module(value, env), do: {:ok, module_name(module)}
+  end
+
+  def fetch(project, kind, owner) do
+    subject = Entry.integration_subject("spark", kind, owner)
+
+    case ManagerApi.search_store_exact(project, subject,
+           type: :metadata,
+           subtype: :integration
+         ) do
+      {:ok, [%Entry{metadata: %{payload: payload}} | _]} -> {:ok, payload}
+      _ -> :error
+    end
+  end
+
+  def option_key(key) when is_atom(key), do: key
+  def option_key({:__block__, _, [key]}) when is_atom(key), do: key
+  def option_key(_), do: nil
+
+  defp dsl_for_use(project, %Use{} = use, %Env{} = env) do
+    env = %Env{env | position: use.range.start}
+
+    with {:ok, module} <- Analyzer.expand_alias(use.module, env.analysis, env.position),
+         {:ok, dsl} <- fetch(project, :dsl, module) do
+      {:ok, dsl, use}
+    else
+      _ -> nil
+    end
+  end
+
+  defp configured_extensions(%Use{opts: opts} = use, dsl, %Env{} = env) do
+    env = %Env{env | position: use.range.start}
+    extension_keys = ["extensions" | dsl.extension_kinds]
+
+    Enum.reduce(List.flatten(opts), %{}, fn
+      {key_ast, value}, acc ->
+        case option_key(key_ast) do
+          key when not is_nil(key) ->
+            key = to_string(key)
+
+            if key in extension_keys do
+              modules = modules_from_ast(value, env)
+              Map.update(acc, key, modules, &(&1 ++ modules))
+            else
+              acc
+            end
+
+          nil ->
+            acc
+        end
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp expand_extensions([], _extensions, _seen), do: []
+
+  defp expand_extensions([module | rest], extensions, seen) do
+    if Map.has_key?(seen, module) do
+      expand_extensions(rest, extensions, seen)
+    else
+      seen = Map.put(seen, module, true)
+
+      case Map.fetch(extensions, module) do
+        {:ok, extension} ->
+          [extension | expand_extensions(extension.added_extensions ++ rest, extensions, seen)]
+
+        :error ->
+          expand_extensions(rest, extensions, seen)
+      end
+    end
+  end
+
+  defp apply_patches(extensions) do
+    patches = Enum.flat_map(extensions, & &1.patches)
+
+    Enum.map(extensions, fn extension ->
+      %{extension | sections: patch_sections(extension.sections, patches, [])}
+    end)
+  end
+
+  defp patch_sections(sections, patches, path) do
+    Enum.map(sections, fn section ->
+      section_path = path ++ [section.name]
+      patched = for %{section_path: ^section_path, entity: entity} <- patches, do: entity
+
+      %{
+        section
+        | entities: section.entities ++ patched,
+          sections: patch_sections(section.sections, patches, section_path)
+      }
+    end)
+  end
+
+  defp modules_from_ast(list, env) when is_list(list),
+    do: Enum.flat_map(list, &modules_from_ast(&1, env))
+
+  defp modules_from_ast({:__block__, _, [value]}, env), do: modules_from_ast(value, env)
+
+  defp modules_from_ast(ast, env) do
+    case expand_module(ast, env) do
+      {:ok, module} -> [module_name(module)]
+      :error -> []
+    end
+  end
+
+  defp expand_module({:__aliases__, _, segments}, env),
+    do: Analyzer.expand_alias(segments, env.analysis, env.position)
+
+  defp expand_module({:__block__, _, [value]}, env), do: expand_module(value, env)
+
+  defp expand_module({:__MODULE__, _, _}, env),
+    do: Analyzer.current_module(env.analysis, env.position)
+
+  defp expand_module(module, _env) when is_atom(module), do: {:ok, module}
+  defp expand_module(_, _env), do: :error
+
+  defp fetch_extensions(project) do
+    case ManagerApi.search_store_prefix(
+           project,
+           Entry.integration_subject_prefix("spark", :extension),
+           type: :metadata,
+           subtype: :integration
+         ) do
+      {:ok, entries} ->
+        Map.new(entries, fn %Entry{metadata: %{owner_module: module, payload: payload}} ->
+          {module, payload}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp module_name(module) when is_atom(module), do: Atom.to_string(module)
+end

--- a/apps/engine/lib/engine/integrations/spark/completion.ex
+++ b/apps/engine/lib/engine/integrations/spark/completion.ex
@@ -1,0 +1,855 @@
+defmodule Engine.Integrations.Spark.Completion do
+  alias Engine.Integrations.Spark.Values
+  alias Engine.ManagerApi
+  alias Forge.Ast
+  alias Forge.Ast.Analysis
+  alias Forge.Ast.Analysis.Alias
+  alias Forge.Ast.Analysis.Scope
+  alias Forge.Ast.Analysis.Use
+  alias Forge.Ast.Env
+  alias Forge.Completion.Candidate
+  alias Forge.Search.Indexer.Entry
+
+  def complete(%Env{} = env) do
+    if Env.in_context?(env, :comment) or Env.in_context?(env, :string) do
+      :ignore
+    else
+      cursor_path = Ast.cursor_path(env.analysis, env.position)
+
+      case use_context(cursor_path, env) do
+        {:ok, module, argument} ->
+          case fetch(env.project, :dsl, module) do
+            {:ok, dsl} -> completion_result(schema_items(dsl.options, argument, env), :override)
+            :error -> :ignore
+          end
+
+        :error ->
+          with {:ok, module, name, arity, argument_index, argument} <-
+                 function_context(cursor_path, env),
+               key = "#{Forge.Formats.mfa(module, name, arity)}/#{argument_index}",
+               {:ok, options} <- fetch(env.project, :function, key) do
+            completion_result(schema_items(options, argument, env), :override)
+          else
+            _ -> complete_dsl(env.project, env, cursor_path)
+          end
+      end
+    end
+  end
+
+  defp completion_result({mode, candidates, transforms}, _mode),
+    do: {mode, candidates, true, transforms}
+
+  defp completion_result([], _mode), do: :ignore
+  defp completion_result(candidates, mode), do: {mode, candidates, true, []}
+
+  defp complete_dsl(project, env, cursor_path) do
+    if remote_call_context?(cursor_path, env) do
+      :ignore
+    else
+      case dsl_context(project, env) do
+        {:ok, dsl, use} ->
+          extensions = active_extensions(fetch_extensions(project), dsl, use, env)
+
+          case dsl_items(extensions, cursor_path, env) do
+            {:ok, items, mode} -> completion_result(items, mode)
+            :error -> :ignore
+          end
+
+        :error ->
+          :ignore
+      end
+    end
+  end
+
+  defp remote_call_context?(cursor_path, env) do
+    match?({:dot, _, _}, Code.Fragment.cursor_context(env.prefix)) or
+      Enum.any?(cursor_path, fn
+        {{:., _, _}, _, arguments} when is_list(arguments) -> true
+        _ -> false
+      end)
+  end
+
+  defp use_context(cursor_path, env) do
+    Enum.find_value(cursor_path, :error, fn
+      {:use, _, [module_ast | arguments]} ->
+        with {:ok, module} <- expand_module(module_ast, env) do
+          {:ok, module, List.last(arguments)}
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp schema_items(options, argument, env) do
+    case option_cursor(argument) do
+      {:key, existing} ->
+        option_items(options, env, :keyword, existing)
+
+      {:value, key, value_ast} ->
+        case Enum.find(options, &(&1.name == to_string(key))) do
+          nil -> []
+          option -> value_items_for_ast(option.type, value_ast, env)
+        end
+
+      :invalid ->
+        []
+    end
+  end
+
+  defp dsl_context(project, %Env{} = env) do
+    env.analysis
+    |> Analysis.scopes_at(env.position)
+    |> List.first()
+    |> case do
+      %Scope{} = scope ->
+        scope.uses
+        |> Enum.filter(&before_cursor?(&1, env))
+        |> Enum.find_value(:error, fn %Use{} = use ->
+          dsl_for_use(project, use, env)
+        end)
+
+      _ ->
+        :error
+    end
+  end
+
+  defp dsl_for_use(project, %Use{} = use, %Env{} = env) do
+    env = %Env{env | position: use.range.start}
+
+    case expand_segments(use.module, env) do
+      {:ok, module} ->
+        case fetch(project, :dsl, module) do
+          {:ok, dsl} -> {:ok, dsl, use}
+          :error -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp before_cursor?(%Use{range: range}, %Env{} = env) do
+    range.end.line < env.position.line or
+      (range.end.line == env.position.line and range.end.character <= env.position.character)
+  end
+
+  defp active_extensions(extensions, dsl, %Use{} = use, env) do
+    configured = configured_extensions(use, dsl, env)
+
+    defaults =
+      Enum.reduce(dsl.single_extension_kinds, dsl.default_extensions, fn kind, defaults ->
+        if Map.get(configured, kind, []) == [] do
+          defaults
+        else
+          defaults -- Map.get(dsl.default_extension_kinds, kind, [])
+        end
+      end)
+
+    (defaults ++ Enum.flat_map(configured, fn {_kind, extensions} -> extensions end))
+    |> Enum.uniq()
+    |> expand_extensions(extensions, %{})
+    |> apply_patches()
+  end
+
+  defp configured_extensions(%Use{opts: opts} = use, dsl, %Env{} = env) do
+    env = %Env{env | position: use.range.start}
+    extension_keys = ["extensions" | dsl.extension_kinds]
+
+    Enum.reduce(List.flatten(opts), %{}, fn
+      {key_ast, value}, acc ->
+        case option_key(key_ast) do
+          key when is_atom(key) and not is_nil(key) ->
+            key = to_string(key)
+
+            if key in extension_keys do
+              extensions = modules_from_ast(value, env)
+              Map.update(acc, key, extensions, &(&1 ++ extensions))
+            else
+              acc
+            end
+
+          nil ->
+            acc
+        end
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp option_key(key) when is_atom(key), do: key
+  defp option_key({:__block__, _, [key]}) when is_atom(key), do: key
+  defp option_key(_), do: nil
+
+  defp expand_extensions([], _extensions, _seen), do: []
+
+  defp expand_extensions([module | rest], extensions, seen) do
+    if Map.has_key?(seen, module) do
+      expand_extensions(rest, extensions, seen)
+    else
+      seen = Map.put(seen, module, true)
+
+      case Map.fetch(extensions, module) do
+        {:ok, extension} ->
+          [extension | expand_extensions(extension.added_extensions ++ rest, extensions, seen)]
+
+        :error ->
+          expand_extensions(rest, extensions, seen)
+      end
+    end
+  end
+
+  defp apply_patches(extensions) do
+    patches = Enum.flat_map(extensions, & &1.patches)
+
+    Enum.map(extensions, fn extension ->
+      %{extension | sections: patch_sections(extension.sections, patches, [])}
+    end)
+  end
+
+  defp patch_sections(sections, patches, path) do
+    Enum.map(sections, fn section ->
+      section_path = path ++ [section.name]
+
+      patched_entities =
+        for %{section_path: ^section_path, entity: entity} <- patches, do: entity
+
+      %{
+        section
+        | entities: section.entities ++ patched_entities,
+          sections: patch_sections(section.sections, patches, section_path)
+      }
+    end)
+  end
+
+  defp dsl_items(extensions, cursor_path, env) do
+    sections = Enum.flat_map(extensions, & &1.sections)
+    names = enclosing_call_names(cursor_path)
+    call_context = local_call_context(cursor_path)
+    names = drop_current_partial_call(names, call_context, hint(env))
+
+    current_call_name = if match?({:ok, _, _, _, _}, call_context), do: elem(call_context, 1)
+
+    with {:ok, node} <- find_node(sections, names, current_call_name) do
+      {candidates, mode} =
+        case call_context do
+          {:ok, name, index, argument, arguments} ->
+            {dsl_call_candidates(node, name, index, argument, arguments, env),
+             completion_mode(node, name)}
+
+          :error ->
+            {candidates_for_node(node), :augment}
+        end
+
+      completion_items(candidates, env, mode)
+    end
+  end
+
+  defp completion_items(:error, _env, _mode), do: :error
+
+  defp completion_items({state, candidates, transforms}, env, _mode) do
+    {:ok, {state, completion_items(candidates, env), transforms}, state}
+  end
+
+  defp completion_items(candidates, env, mode),
+    do: {:ok, completion_items(candidates, env), mode}
+
+  defp completion_items(candidates, env) do
+    candidates
+    |> Enum.filter(fn
+      {_candidate, transforms} when is_list(transforms) -> true
+      %_{} -> true
+      candidate -> matches?(candidate.name, hint(env))
+    end)
+    |> Enum.map(fn
+      {candidate, transforms} when is_list(transforms) -> {candidate, transforms}
+      %_{} = candidate -> {candidate, []}
+      candidate -> candidate_item(candidate, env)
+    end)
+    |> Enum.uniq()
+  end
+
+  defp completion_mode(%{name: name, arguments: _}, name), do: :override
+
+  defp completion_mode(node, name) do
+    if Enum.any?(Map.get(node, :options, []), &(&1.name == name)),
+      do: :override,
+      else: :augment
+  end
+
+  defp drop_current_partial_call(names, {:ok, name, _index, argument, _arguments}, hint)
+       when hint != "" do
+    if not cursor_in_do_block?(argument) and List.last(names) == name and matches?(name, hint),
+      do: Enum.drop(names, -1),
+      else: names
+  end
+
+  defp drop_current_partial_call(names, _call_context, _hint), do: names
+
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defp dsl_call_candidates(node, name, index, argument_ast, arguments, env) do
+    cond do
+      node[:name] == name and Map.has_key?(node, :arguments) ->
+        case Enum.at(node.arguments, index) do
+          nil ->
+            trailing_entity_candidates(node, argument_ast, arguments, env)
+
+          argument ->
+            values =
+              case Enum.find(node.options, &(&1.name == argument.name)) do
+                nil -> []
+                option -> value_items_for_ast(option.type, argument_ast, env)
+              end
+
+            if argument.optional?,
+              do:
+                merge_value_items([
+                  values,
+                  trailing_entity_candidates(node, argument_ast, arguments, env)
+                ]),
+              else: values
+        end
+
+      node[:name] == name ->
+        candidates_for_node(node)
+
+      option = Enum.find(node.options, &(&1.name == name)) ->
+        if index == 0, do: value_items_for_ast(option.type, argument_ast, env), else: []
+
+      hint(env) != "" and matches?(name, hint(env)) ->
+        candidates_for_node(node)
+
+      true ->
+        :error
+    end
+  end
+
+  defp trailing_entity_candidates(node, argument_ast, arguments, env) do
+    case option_cursor(argument_ast) do
+      {:key, existing} ->
+        required = for %{name: name, optional?: false} <- node.arguments, do: name
+
+        items =
+          node.options
+          |> Enum.reject(&(&1.name in required))
+          |> option_items(env, :keyword, existing)
+
+        {:override, items, []}
+
+      {:value, key, value_ast} ->
+        case Enum.find(node.options, &(&1.name == to_string(key))) do
+          nil -> {:override, candidates_for_node(node), []}
+          option -> option_value_items(option, node, arguments, value_ast, env)
+        end
+
+      _ ->
+        {:override, candidates_for_node(node), []}
+    end
+  end
+
+  defp enclosing_call_names(cursor_path) do
+    cursor_path
+    |> Enum.flat_map(fn
+      {name, _, args}
+      when is_atom(name) and is_list(args) and
+             name not in [:__cursor__, :__block__, :defmodule, :use] ->
+        [to_string(name)]
+
+      _ ->
+        []
+    end)
+    |> Enum.reverse()
+  end
+
+  defp find_node(sections, names, current_call_name) do
+    root = %{options: [], entities: [], sections: sections}
+    last_name = List.last(names)
+
+    Enum.reduce_while(names, {:ok, root}, fn name, {:ok, node} ->
+      case child(node, name) do
+        nil when name == last_name and name == current_call_name -> {:halt, {:ok, node}}
+        nil -> {:halt, :error}
+        child -> {:cont, {:ok, child}}
+      end
+    end)
+  end
+
+  defp child(node, name) do
+    Enum.find(Map.get(node, :sections, []), &(&1.name == name)) ||
+      Enum.find(Map.get(node, :entities, []), &(&1.name == name)) ||
+      Enum.find(top_level_children(node), &(&1.name == name))
+  end
+
+  defp candidates_for_node(node) do
+    Map.get(node, :options, []) ++
+      Map.get(node, :entities, []) ++
+      Enum.reject(Map.get(node, :sections, []), & &1.top_level?) ++ top_level_children(node)
+  end
+
+  defp top_level_children(node) do
+    node
+    |> Map.get(:sections, [])
+    |> Enum.filter(& &1.top_level?)
+    |> Enum.flat_map(fn section -> section.options ++ section.entities ++ section.sections end)
+  end
+
+  defp candidate_item(%{arguments: _} = entity, _env) do
+    snippet = entity.snippet || entity_snippet(entity)
+
+    {%Candidate.Snippet{
+       label: entity.name,
+       snippet: snippet,
+       detail: "DSL Entity",
+       documentation: entity.documentation,
+       priority: :contextual,
+       kind: :function
+     }, []}
+  end
+
+  defp candidate_item(%{top_level?: _} = section, _env) do
+    snippet = section.snippet || "#{section.name} do\n  $0\nend"
+
+    {%Candidate.Snippet{
+       label: section.name,
+       snippet: snippet,
+       detail: "DSL Section",
+       documentation: section.documentation,
+       priority: :contextual,
+       kind: :function
+     }, []}
+  end
+
+  defp candidate_item(option, env) do
+    option_item(option, env, :builder)
+  end
+
+  defp entity_snippet(entity) do
+    arguments =
+      entity.arguments
+      |> Enum.with_index(1)
+      |> Enum.map_join(", ", fn {argument, index} -> "${#{index}:#{argument.name}}" end)
+
+    if arguments == "", do: entity.name, else: "#{entity.name} #{arguments}"
+  end
+
+  defp option_items(options, env, syntax, existing) do
+    options
+    |> Enum.reject(&(&1.name in existing))
+    |> Enum.filter(&matches?(&1.name, hint(env)))
+    |> Enum.map(&option_item(&1, env, syntax))
+  end
+
+  defp option_value_items(
+         %{name: "constraints", type: fallback},
+         node,
+         arguments,
+         value_ast,
+         env
+       ) do
+    with %{type: %{kind: :spark_type, behaviour: behaviour, aliases: aliases}} <-
+           Enum.find(node.options, &(&1.name == "type")),
+         index when is_integer(index) <- Enum.find_index(node.arguments, &(&1.name == "type")),
+         type_ast when not is_nil(type_ast) <- Enum.at(arguments, index),
+         {:ok, module} <- selected_type_module(type_ast, aliases, env),
+         {:ok, %{constraints: options}} <-
+           fetch(env.project, :behaviour, "#{behaviour}/#{module}") do
+      schema_value_items(options, value_ast, env)
+    else
+      _ -> value_items_for_ast(fallback, value_ast, env)
+    end
+  end
+
+  defp option_value_items(option, _node, _arguments, value_ast, env),
+    do: value_items_for_ast(option.type, value_ast, env)
+
+  defp selected_type_module({:__block__, _, [value]}, aliases, env),
+    do: selected_type_module(value, aliases, env)
+
+  defp selected_type_module(value, aliases, _env) when is_atom(value),
+    do: Map.fetch(aliases, to_string(value))
+
+  defp selected_type_module(value, _aliases, env) do
+    with {:ok, module} <- expand_module(value, env), do: {:ok, module_name(module)}
+  end
+
+  defp value_items_for_ast(%{kind: :list, item: item}, value_ast, env) do
+    if list_literal?(value_ast) do
+      value_items(item, env)
+    else
+      item
+      |> value_items(env)
+      |> map_value_items(:wrap_list)
+    end
+  end
+
+  defp value_items_for_ast(%{kind: :wrap_list, item: item}, value_ast, env),
+    do: value_items_for_ast(item, value_ast, env)
+
+  defp value_items_for_ast(%{kind: :or, types: types}, value_ast, env),
+    do: types |> Enum.map(&value_items_for_ast(&1, value_ast, env)) |> merge_value_items()
+
+  defp value_items_for_ast(%{kind: :keyword_list, options: options}, value_ast, env),
+    do: schema_value_items(options, value_ast, env)
+
+  defp value_items_for_ast(type, _value_ast, env), do: value_items(type, env)
+
+  defp schema_value_items(options, value_ast, env) do
+    case schema_items(options, value_ast, env) do
+      {_, _, _} = result -> result
+      items -> {:override, items, []}
+    end
+  end
+
+  defp list_literal?(value) when is_list(value), do: true
+  defp list_literal?({:__block__, _, [value]}), do: list_literal?(value)
+  defp list_literal?(_value), do: false
+
+  defp value_items(%{kind: :choices, values: values}, env) do
+    candidates =
+      values
+      |> Enum.filter(&matches?(&1.label, hint(env)))
+      |> Enum.map(fn value ->
+        {%Candidate.Snippet{
+           label: value.label,
+           snippet: value.insert_text,
+           detail: "Value",
+           priority: :contextual,
+           kind: :enum_member
+         }, []}
+      end)
+
+    {:override, candidates, []}
+  end
+
+  defp value_items(%{kind: :boolean}, env) do
+    value_items(
+      %{
+        kind: :choices,
+        values: [
+          %{label: "true", insert_text: "true"},
+          %{label: "false", insert_text: "false"}
+        ]
+      },
+      env
+    )
+  end
+
+  defp value_items(%{kind: kind} = type, env)
+       when kind in [:behaviour, :spark, :spark_behaviour, :spark_function_behaviour] do
+    candidates = Enum.map(Values.candidates(env, type), &{&1, []})
+
+    candidates =
+      case type do
+        %{kind: :spark_function_behaviour, function: %{arity: arity}} ->
+          [function_item(arity) | candidates]
+
+        _ ->
+          candidates
+      end
+
+    {:override, candidates, []}
+  end
+
+  defp value_items(%{kind: :function, arity: arity}, _env) do
+    {:override, [function_item(arity)], []}
+  end
+
+  defp value_items(%{kind: kind, item: item}, env) when kind in [:list, :wrap_list],
+    do: value_items(item, env)
+
+  defp value_items(%{kind: :or, types: types}, env),
+    do: types |> Enum.map(&value_items(&1, env)) |> merge_value_items()
+
+  defp value_items(_type, _env), do: {:augment, [], []}
+
+  defp map_value_items({state, candidates, transforms}, transform) do
+    candidates =
+      Enum.map(candidates, fn {candidate, transforms} ->
+        {candidate, transforms ++ [transform]}
+      end)
+
+    transforms = if state == :augment, do: transforms ++ [transform], else: transforms
+    {state, candidates, transforms}
+  end
+
+  defp merge_value_items(results) do
+    candidates =
+      results
+      |> Enum.flat_map(&elem(&1, 1))
+      |> Enum.uniq()
+
+    state = if Enum.all?(results, &(elem(&1, 0) == :override)), do: :override, else: :augment
+
+    transforms =
+      Enum.find_value(results, fn
+        {:augment, _candidates, transforms} when transforms != [] -> transforms
+        _ -> nil
+      end) || []
+
+    {state, candidates, transforms}
+  end
+
+  defp function_item(arity) do
+    {%Candidate.Snippet{
+       label: "fn/#{arity || "?"}",
+       snippet: function_snippet(arity),
+       detail: "Anonymous function",
+       priority: :contextual,
+       kind: :function
+     }, []}
+  end
+
+  defp function_snippet(0), do: "fn ->\n  $0\nend"
+
+  defp function_snippet(arity) when is_integer(arity) do
+    arguments = Enum.map_join(1..arity, ", ", &"${#{&1}:arg#{&1}}")
+    "fn #{arguments} ->\n  $0\nend"
+  end
+
+  defp function_snippet(nil), do: "fn ${1:arg} ->\n  $0\nend"
+
+  defp option_item(option, _env, syntax) do
+    value = option.snippet || default_snippet(option.type, option.default)
+    separator = if syntax == :keyword, do: ": ", else: " "
+
+    {%Candidate.Snippet{
+       label: option.name,
+       snippet: option.name <> separator <> value,
+       detail: "Option",
+       documentation: option.documentation,
+       priority: :contextual,
+       kind: :field
+     }, []}
+  end
+
+  defp default_snippet(%{kind: :boolean}, default) when default in [true, false],
+    do: to_string(not default)
+
+  defp default_snippet(%{kind: :boolean}, _), do: "${1|true,false|}"
+  defp default_snippet(%{kind: :string}, _), do: "\"$0\""
+  defp default_snippet(%{kind: :atom}, _), do: ":$0"
+  defp default_snippet(%{kind: :map}, _), do: "%{${1:key} => ${2:value}}"
+  defp default_snippet(%{kind: :keyword_list}, _), do: "[${1:key}: ${2:value}]"
+  defp default_snippet(%{kind: :mfa}, _), do: "{${1:Module}, :${2:function}, [${3:args}]}"
+  defp default_snippet(%{kind: :function, arity: arity}, _), do: function_snippet(arity)
+
+  defp default_snippet(%{kind: :choices, values: values}, default) do
+    default = literal_snippet(default)
+    choice = Enum.find(values, &(&1.insert_text != default)) || List.first(values)
+    if choice, do: choice.insert_text, else: "$0"
+  end
+
+  defp default_snippet(%{kind: kind, item: item}, _) when kind in [:list, :wrap_list] do
+    if kind == :list, do: "[#{default_snippet(item, nil)}]", else: default_snippet(item, nil)
+  end
+
+  defp default_snippet(_type, _default), do: "$0"
+
+  defp local_call_context(cursor_path) do
+    Enum.find_value(cursor_path, :error, fn
+      {name, _, arguments}
+      when is_atom(name) and is_list(arguments) and
+             name not in [:__cursor__, :__block__, :defmodule, :use, :|>] ->
+        case cursor_argument(arguments) do
+          {:ok, index, argument} -> {:ok, to_string(name), index, argument, arguments}
+          :error -> nil
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp function_context(cursor_path, env) do
+    Enum.find_value(cursor_path, fn
+      {:|>, _, [_left, call]} ->
+        remote_function_context(call, env, 1)
+
+      _ ->
+        nil
+    end) || Enum.find_value(cursor_path, :error, &remote_function_context(&1, env, 0))
+  end
+
+  defp remote_function_context({{:., _, [module_ast, name]}, _, arguments}, env, offset)
+       when is_atom(name) and is_list(arguments) do
+    with {:ok, module} <- expand_module(module_ast, env),
+         {:ok, index, argument} <- cursor_argument(arguments) do
+      {:ok, module, name, length(arguments) + offset, index + offset, argument}
+    else
+      _ -> nil
+    end
+  end
+
+  defp remote_function_context(_ast, _env, _offset), do: nil
+
+  defp cursor_argument(arguments) do
+    arguments
+    |> Enum.with_index()
+    |> Enum.find_value(:error, fn {argument, index} ->
+      if contains_cursor?(argument), do: {:ok, index, argument}
+    end)
+  end
+
+  defp option_cursor({:__cursor__, _, _}), do: {:key, []}
+  defp option_cursor({:__block__, _, [value]}), do: option_cursor(value)
+
+  defp option_cursor(options) when is_list(options) do
+    without_cursor = Enum.reject(options, &match?({:__cursor__, _, _}, &1))
+
+    if Enum.all?(without_cursor, fn
+         {key, _value} -> not is_nil(option_key(key))
+         _ -> false
+       end) do
+      existing =
+        without_cursor
+        |> Enum.map(fn {key, _value} -> option_key(key) end)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.map(&to_string/1)
+
+      Enum.find_value(options, {:key, existing}, fn
+        {:__cursor__, _, _} -> {:key, existing}
+        {key, value} -> if contains_cursor?(value), do: {:value, option_key(key), value}
+        _ -> nil
+      end)
+    else
+      :invalid
+    end
+  end
+
+  defp option_cursor(_), do: :invalid
+
+  defp contains_cursor?(ast) do
+    {_ast, found?} =
+      Macro.prewalk(ast, false, fn
+        {:__cursor__, _, _} = node, _ -> {node, true}
+        node, found? -> {node, found?}
+      end)
+
+    found?
+  end
+
+  defp cursor_in_do_block?(arguments) when is_list(arguments) do
+    Enum.any?(arguments, fn
+      {key, value} -> option_key(key) == :do and contains_cursor?(value)
+      _ -> false
+    end)
+  end
+
+  defp cursor_in_do_block?(_), do: false
+
+  defp modules_from_ast(list, env) when is_list(list),
+    do: Enum.flat_map(list, &modules_from_ast(&1, env))
+
+  defp modules_from_ast({:__block__, _, [value]}, env), do: modules_from_ast(value, env)
+
+  defp modules_from_ast(ast, env) do
+    case expand_module(ast, env) do
+      {:ok, module} -> [module_name(module)]
+      :error -> []
+    end
+  end
+
+  defp expand_module({:__aliases__, _, segments}, env), do: expand_segments(segments, env)
+  defp expand_module({:__block__, _, [value]}, env), do: expand_module(value, env)
+  defp expand_module({:__MODULE__, _, _}, env), do: expand_segments([:__MODULE__], env)
+  defp expand_module(module, _env) when is_atom(module), do: {:ok, Atom.to_string(module)}
+  defp expand_module(_, _env), do: :error
+
+  defp expand_segments(segments, %Env{} = env) do
+    case Analysis.scopes_at(env.analysis, env.position) do
+      [%Scope{} = scope | _] ->
+        aliases = Scope.alias_map(scope, env.position)
+
+        case segments do
+          [:__MODULE__ | suffix] ->
+            resolve_alias(aliases, :__MODULE__, suffix)
+
+          [prefix | suffix] ->
+            if Map.has_key?(aliases, [prefix]),
+              do: resolve_alias(aliases, prefix, suffix),
+              else: {:ok, Module.concat(segments)}
+        end
+
+      _ ->
+        {:ok, Module.concat(segments)}
+    end
+  rescue
+    _ in ArgumentError -> :error
+  end
+
+  defp resolve_alias(aliases, prefix, suffix) do
+    case Map.get(aliases, [prefix]) do
+      %Alias{} = alias -> {:ok, Module.concat([Alias.to_module(alias) | suffix])}
+      _ -> :error
+    end
+  end
+
+  defp literal_snippet(%{atom: atom}) do
+    if Regex.match?(~r/^[a-z_][a-zA-Z0-9_@]*[?!]?$/, atom),
+      do: ":" <> atom,
+      else: ":" <> inspect(atom)
+  end
+
+  defp literal_snippet(value) when is_binary(value), do: inspect(value)
+  defp literal_snippet(value) when is_boolean(value) or is_number(value), do: to_string(value)
+  defp literal_snippet(_), do: nil
+
+  defp fetch(project, kind, module) do
+    subject = Entry.integration_subject("spark", kind, module)
+
+    case ManagerApi.search_store_exact(project, subject,
+           type: :metadata,
+           subtype: :integration
+         ) do
+      {:ok, [%Entry{metadata: %{payload: payload}} | _]} -> {:ok, payload}
+      _ -> :error
+    end
+  end
+
+  defp fetch_extensions(project) do
+    case ManagerApi.search_store_prefix(
+           project,
+           Entry.integration_subject_prefix("spark", :extension),
+           type: :metadata,
+           subtype: :integration
+         ) do
+      {:ok, entries} ->
+        Map.new(entries, fn %Entry{metadata: %{owner_module: module, payload: payload}} ->
+          {module, payload}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp hint(%Env{} = env) do
+    case Code.Fragment.cursor_context(env.prefix) do
+      {:alias, chars} -> to_string(chars)
+      {:alias, _base, chars} -> to_string(chars)
+      {:local_or_var, chars} -> to_string(chars)
+      {:local_call, chars} -> to_string(chars)
+      {:module_attribute, chars} -> to_string(chars)
+      {:unquoted_atom, chars} -> to_string(chars)
+      _ -> ""
+    end
+  end
+
+  defp matches?(_name, ""), do: true
+
+  defp matches?(name, hint) do
+    name = String.downcase(name)
+    hint = String.downcase(hint)
+
+    name =
+      if String.starts_with?(name, ":") and not String.starts_with?(hint, ":"),
+        do: String.trim_leading(name, ":"),
+        else: name
+
+    String.starts_with?(name, hint)
+  end
+
+  defp module_name(module) when is_atom(module), do: Atom.to_string(module)
+  defp module_name(module) when is_binary(module), do: module
+end

--- a/apps/engine/lib/engine/integrations/spark/completion.ex
+++ b/apps/engine/lib/engine/integrations/spark/completion.ex
@@ -1,33 +1,31 @@
 defmodule Engine.Integrations.Spark.Completion do
+  @behaviour Engine.Integrations
+
+  alias Engine.Integrations.Spark.Common
   alias Engine.Integrations.Spark.Values
-  alias Engine.ManagerApi
   alias Forge.Ast
-  alias Forge.Ast.Analysis
-  alias Forge.Ast.Analysis.Alias
-  alias Forge.Ast.Analysis.Scope
-  alias Forge.Ast.Analysis.Use
   alias Forge.Ast.Env
   alias Forge.Completion.Candidate
-  alias Forge.Search.Indexer.Entry
 
+  @impl Engine.Integrations
   def complete(%Env{} = env) do
     if Env.in_context?(env, :comment) or Env.in_context?(env, :string) do
       :ignore
     else
       cursor_path = Ast.cursor_path(env.analysis, env.position)
 
-      case use_context(cursor_path, env) do
+      case Common.use_context(cursor_path, env) do
         {:ok, module, argument} ->
-          case fetch(env.project, :dsl, module) do
+          case Common.fetch(env.project, :dsl, module) do
             {:ok, dsl} -> completion_result(schema_items(dsl.options, argument, env), :override)
             :error -> :ignore
           end
 
         :error ->
           with {:ok, module, name, arity, argument_index, argument} <-
-                 function_context(cursor_path, env),
+                 Common.function_context(cursor_path, env),
                key = "#{Forge.Formats.mfa(module, name, arity)}/#{argument_index}",
-               {:ok, options} <- fetch(env.project, :function, key) do
+               {:ok, options} <- Common.fetch(env.project, :function, key) do
             completion_result(schema_items(options, argument, env), :override)
           else
             _ -> complete_dsl(env.project, env, cursor_path)
@@ -46,9 +44,9 @@ defmodule Engine.Integrations.Spark.Completion do
     if remote_call_context?(cursor_path, env) do
       :ignore
     else
-      case dsl_context(project, env) do
+      case Common.dsl_context(project, env) do
         {:ok, dsl, use} ->
-          extensions = active_extensions(fetch_extensions(project), dsl, use, env)
+          extensions = Common.active_extensions(project, dsl, use, env)
 
           case dsl_items(extensions, cursor_path, env) do
             {:ok, items, mode} -> completion_result(items, mode)
@@ -63,22 +61,7 @@ defmodule Engine.Integrations.Spark.Completion do
 
   defp remote_call_context?(cursor_path, env) do
     match?({:dot, _, _}, Code.Fragment.cursor_context(env.prefix)) or
-      Enum.any?(cursor_path, fn
-        {{:., _, _}, _, arguments} when is_list(arguments) -> true
-        _ -> false
-      end)
-  end
-
-  defp use_context(cursor_path, env) do
-    Enum.find_value(cursor_path, :error, fn
-      {:use, _, [module_ast | arguments]} ->
-        with {:ok, module} <- expand_module(module_ast, env) do
-          {:ok, module, List.last(arguments)}
-        end
-
-      _ ->
-        nil
-    end)
+      Ast.remote_call?(cursor_path)
   end
 
   defp schema_items(options, argument, env) do
@@ -97,141 +80,15 @@ defmodule Engine.Integrations.Spark.Completion do
     end
   end
 
-  defp dsl_context(project, %Env{} = env) do
-    env.analysis
-    |> Analysis.scopes_at(env.position)
-    |> List.first()
-    |> case do
-      %Scope{} = scope ->
-        scope.uses
-        |> Enum.filter(&before_cursor?(&1, env))
-        |> Enum.find_value(:error, fn %Use{} = use ->
-          dsl_for_use(project, use, env)
-        end)
-
-      _ ->
-        :error
-    end
-  end
-
-  defp dsl_for_use(project, %Use{} = use, %Env{} = env) do
-    env = %Env{env | position: use.range.start}
-
-    case expand_segments(use.module, env) do
-      {:ok, module} ->
-        case fetch(project, :dsl, module) do
-          {:ok, dsl} -> {:ok, dsl, use}
-          :error -> nil
-        end
-
-      _ ->
-        nil
-    end
-  end
-
-  defp before_cursor?(%Use{range: range}, %Env{} = env) do
-    range.end.line < env.position.line or
-      (range.end.line == env.position.line and range.end.character <= env.position.character)
-  end
-
-  defp active_extensions(extensions, dsl, %Use{} = use, env) do
-    configured = configured_extensions(use, dsl, env)
-
-    defaults =
-      Enum.reduce(dsl.single_extension_kinds, dsl.default_extensions, fn kind, defaults ->
-        if Map.get(configured, kind, []) == [] do
-          defaults
-        else
-          defaults -- Map.get(dsl.default_extension_kinds, kind, [])
-        end
-      end)
-
-    (defaults ++ Enum.flat_map(configured, fn {_kind, extensions} -> extensions end))
-    |> Enum.uniq()
-    |> expand_extensions(extensions, %{})
-    |> apply_patches()
-  end
-
-  defp configured_extensions(%Use{opts: opts} = use, dsl, %Env{} = env) do
-    env = %Env{env | position: use.range.start}
-    extension_keys = ["extensions" | dsl.extension_kinds]
-
-    Enum.reduce(List.flatten(opts), %{}, fn
-      {key_ast, value}, acc ->
-        case option_key(key_ast) do
-          key when is_atom(key) and not is_nil(key) ->
-            key = to_string(key)
-
-            if key in extension_keys do
-              extensions = modules_from_ast(value, env)
-              Map.update(acc, key, extensions, &(&1 ++ extensions))
-            else
-              acc
-            end
-
-          nil ->
-            acc
-        end
-
-      _, acc ->
-        acc
-    end)
-  end
-
-  defp option_key(key) when is_atom(key), do: key
-  defp option_key({:__block__, _, [key]}) when is_atom(key), do: key
-  defp option_key(_), do: nil
-
-  defp expand_extensions([], _extensions, _seen), do: []
-
-  defp expand_extensions([module | rest], extensions, seen) do
-    if Map.has_key?(seen, module) do
-      expand_extensions(rest, extensions, seen)
-    else
-      seen = Map.put(seen, module, true)
-
-      case Map.fetch(extensions, module) do
-        {:ok, extension} ->
-          [extension | expand_extensions(extension.added_extensions ++ rest, extensions, seen)]
-
-        :error ->
-          expand_extensions(rest, extensions, seen)
-      end
-    end
-  end
-
-  defp apply_patches(extensions) do
-    patches = Enum.flat_map(extensions, & &1.patches)
-
-    Enum.map(extensions, fn extension ->
-      %{extension | sections: patch_sections(extension.sections, patches, [])}
-    end)
-  end
-
-  defp patch_sections(sections, patches, path) do
-    Enum.map(sections, fn section ->
-      section_path = path ++ [section.name]
-
-      patched_entities =
-        for %{section_path: ^section_path, entity: entity} <- patches, do: entity
-
-      %{
-        section
-        | entities: section.entities ++ patched_entities,
-          sections: patch_sections(section.sections, patches, section_path)
-      }
-    end)
-  end
-
   defp dsl_items(extensions, cursor_path, env) do
     sections = Enum.flat_map(extensions, & &1.sections)
-    names = enclosing_call_names(cursor_path)
-    call_context = local_call_context(cursor_path)
+    names = Ast.enclosing_local_call_names(cursor_path)
+    call_context = Ast.local_call_at_cursor(cursor_path)
     names = drop_current_partial_call(names, call_context, hint(env))
 
     current_call_name = if match?({:ok, _, _, _, _}, call_context), do: elem(call_context, 1)
 
-    with {:ok, node} <- find_node(sections, names, current_call_name) do
+    with {:ok, node} <- Common.find_node(sections, names, current_call_name) do
       {candidates, mode} =
         case call_context do
           {:ok, name, index, argument, arguments} ->
@@ -348,50 +205,11 @@ defmodule Engine.Integrations.Spark.Completion do
     end
   end
 
-  defp enclosing_call_names(cursor_path) do
-    cursor_path
-    |> Enum.flat_map(fn
-      {name, _, args}
-      when is_atom(name) and is_list(args) and
-             name not in [:__cursor__, :__block__, :defmodule, :use] ->
-        [to_string(name)]
-
-      _ ->
-        []
-    end)
-    |> Enum.reverse()
-  end
-
-  defp find_node(sections, names, current_call_name) do
-    root = %{options: [], entities: [], sections: sections}
-    last_name = List.last(names)
-
-    Enum.reduce_while(names, {:ok, root}, fn name, {:ok, node} ->
-      case child(node, name) do
-        nil when name == last_name and name == current_call_name -> {:halt, {:ok, node}}
-        nil -> {:halt, :error}
-        child -> {:cont, {:ok, child}}
-      end
-    end)
-  end
-
-  defp child(node, name) do
-    Enum.find(Map.get(node, :sections, []), &(&1.name == name)) ||
-      Enum.find(Map.get(node, :entities, []), &(&1.name == name)) ||
-      Enum.find(top_level_children(node), &(&1.name == name))
-  end
-
   defp candidates_for_node(node) do
     Map.get(node, :options, []) ++
       Map.get(node, :entities, []) ++
-      Enum.reject(Map.get(node, :sections, []), & &1.top_level?) ++ top_level_children(node)
-  end
-
-  defp top_level_children(node) do
-    node
-    |> Map.get(:sections, [])
-    |> Enum.filter(& &1.top_level?)
-    |> Enum.flat_map(fn section -> section.options ++ section.entities ++ section.sections end)
+      Enum.reject(Map.get(node, :sections, []), & &1.top_level?) ++
+      Common.top_level_children(node)
   end
 
   defp candidate_item(%{arguments: _} = entity, _env) do
@@ -451,9 +269,9 @@ defmodule Engine.Integrations.Spark.Completion do
            Enum.find(node.options, &(&1.name == "type")),
          index when is_integer(index) <- Enum.find_index(node.arguments, &(&1.name == "type")),
          type_ast when not is_nil(type_ast) <- Enum.at(arguments, index),
-         {:ok, module} <- selected_type_module(type_ast, aliases, env),
+         {:ok, module} <- Common.selected_type_module(type_ast, aliases, env),
          {:ok, %{constraints: options}} <-
-           fetch(env.project, :behaviour, "#{behaviour}/#{module}") do
+           Common.fetch(env.project, :behaviour, "#{behaviour}/#{module}") do
       schema_value_items(options, value_ast, env)
     else
       _ -> value_items_for_ast(fallback, value_ast, env)
@@ -462,16 +280,6 @@ defmodule Engine.Integrations.Spark.Completion do
 
   defp option_value_items(option, _node, _arguments, value_ast, env),
     do: value_items_for_ast(option.type, value_ast, env)
-
-  defp selected_type_module({:__block__, _, [value]}, aliases, env),
-    do: selected_type_module(value, aliases, env)
-
-  defp selected_type_module(value, aliases, _env) when is_atom(value),
-    do: Map.fetch(aliases, to_string(value))
-
-  defp selected_type_module(value, _aliases, env) do
-    with {:ok, module} <- expand_module(value, env), do: {:ok, module_name(module)}
-  end
 
   defp value_items_for_ast(%{kind: :list, item: item}, value_ast, env) do
     if list_literal?(value_ast) do
@@ -646,51 +454,6 @@ defmodule Engine.Integrations.Spark.Completion do
 
   defp default_snippet(_type, _default), do: "$0"
 
-  defp local_call_context(cursor_path) do
-    Enum.find_value(cursor_path, :error, fn
-      {name, _, arguments}
-      when is_atom(name) and is_list(arguments) and
-             name not in [:__cursor__, :__block__, :defmodule, :use, :|>] ->
-        case cursor_argument(arguments) do
-          {:ok, index, argument} -> {:ok, to_string(name), index, argument, arguments}
-          :error -> nil
-        end
-
-      _ ->
-        nil
-    end)
-  end
-
-  defp function_context(cursor_path, env) do
-    Enum.find_value(cursor_path, fn
-      {:|>, _, [_left, call]} ->
-        remote_function_context(call, env, 1)
-
-      _ ->
-        nil
-    end) || Enum.find_value(cursor_path, :error, &remote_function_context(&1, env, 0))
-  end
-
-  defp remote_function_context({{:., _, [module_ast, name]}, _, arguments}, env, offset)
-       when is_atom(name) and is_list(arguments) do
-    with {:ok, module} <- expand_module(module_ast, env),
-         {:ok, index, argument} <- cursor_argument(arguments) do
-      {:ok, module, name, length(arguments) + offset, index + offset, argument}
-    else
-      _ -> nil
-    end
-  end
-
-  defp remote_function_context(_ast, _env, _offset), do: nil
-
-  defp cursor_argument(arguments) do
-    arguments
-    |> Enum.with_index()
-    |> Enum.find_value(:error, fn {argument, index} ->
-      if contains_cursor?(argument), do: {:ok, index, argument}
-    end)
-  end
-
   defp option_cursor({:__cursor__, _, _}), do: {:key, []}
   defp option_cursor({:__block__, _, [value]}), do: option_cursor(value)
 
@@ -698,19 +461,24 @@ defmodule Engine.Integrations.Spark.Completion do
     without_cursor = Enum.reject(options, &match?({:__cursor__, _, _}, &1))
 
     if Enum.all?(without_cursor, fn
-         {key, _value} -> not is_nil(option_key(key))
+         {key, _value} -> not is_nil(Common.option_key(key))
          _ -> false
        end) do
       existing =
         without_cursor
-        |> Enum.map(fn {key, _value} -> option_key(key) end)
+        |> Enum.map(fn {key, _value} -> Common.option_key(key) end)
         |> Enum.reject(&is_nil/1)
         |> Enum.map(&to_string/1)
 
       Enum.find_value(options, {:key, existing}, fn
-        {:__cursor__, _, _} -> {:key, existing}
-        {key, value} -> if contains_cursor?(value), do: {:value, option_key(key), value}
-        _ -> nil
+        {:__cursor__, _, _} ->
+          {:key, existing}
+
+        {key, value} ->
+          if Ast.contains_cursor?(value), do: {:value, Common.option_key(key), value}
+
+        _ ->
+          nil
       end)
     else
       :invalid
@@ -719,71 +487,14 @@ defmodule Engine.Integrations.Spark.Completion do
 
   defp option_cursor(_), do: :invalid
 
-  defp contains_cursor?(ast) do
-    {_ast, found?} =
-      Macro.prewalk(ast, false, fn
-        {:__cursor__, _, _} = node, _ -> {node, true}
-        node, found? -> {node, found?}
-      end)
-
-    found?
-  end
-
   defp cursor_in_do_block?(arguments) when is_list(arguments) do
     Enum.any?(arguments, fn
-      {key, value} -> option_key(key) == :do and contains_cursor?(value)
+      {key, value} -> Common.option_key(key) == :do and Ast.contains_cursor?(value)
       _ -> false
     end)
   end
 
   defp cursor_in_do_block?(_), do: false
-
-  defp modules_from_ast(list, env) when is_list(list),
-    do: Enum.flat_map(list, &modules_from_ast(&1, env))
-
-  defp modules_from_ast({:__block__, _, [value]}, env), do: modules_from_ast(value, env)
-
-  defp modules_from_ast(ast, env) do
-    case expand_module(ast, env) do
-      {:ok, module} -> [module_name(module)]
-      :error -> []
-    end
-  end
-
-  defp expand_module({:__aliases__, _, segments}, env), do: expand_segments(segments, env)
-  defp expand_module({:__block__, _, [value]}, env), do: expand_module(value, env)
-  defp expand_module({:__MODULE__, _, _}, env), do: expand_segments([:__MODULE__], env)
-  defp expand_module(module, _env) when is_atom(module), do: {:ok, Atom.to_string(module)}
-  defp expand_module(_, _env), do: :error
-
-  defp expand_segments(segments, %Env{} = env) do
-    case Analysis.scopes_at(env.analysis, env.position) do
-      [%Scope{} = scope | _] ->
-        aliases = Scope.alias_map(scope, env.position)
-
-        case segments do
-          [:__MODULE__ | suffix] ->
-            resolve_alias(aliases, :__MODULE__, suffix)
-
-          [prefix | suffix] ->
-            if Map.has_key?(aliases, [prefix]),
-              do: resolve_alias(aliases, prefix, suffix),
-              else: {:ok, Module.concat(segments)}
-        end
-
-      _ ->
-        {:ok, Module.concat(segments)}
-    end
-  rescue
-    _ in ArgumentError -> :error
-  end
-
-  defp resolve_alias(aliases, prefix, suffix) do
-    case Map.get(aliases, [prefix]) do
-      %Alias{} = alias -> {:ok, Module.concat([Alias.to_module(alias) | suffix])}
-      _ -> :error
-    end
-  end
 
   defp literal_snippet(%{atom: atom}) do
     if Regex.match?(~r/^[a-z_][a-zA-Z0-9_@]*[?!]?$/, atom),
@@ -794,35 +505,6 @@ defmodule Engine.Integrations.Spark.Completion do
   defp literal_snippet(value) when is_binary(value), do: inspect(value)
   defp literal_snippet(value) when is_boolean(value) or is_number(value), do: to_string(value)
   defp literal_snippet(_), do: nil
-
-  defp fetch(project, kind, module) do
-    subject = Entry.integration_subject("spark", kind, module)
-
-    case ManagerApi.search_store_exact(project, subject,
-           type: :metadata,
-           subtype: :integration
-         ) do
-      {:ok, [%Entry{metadata: %{payload: payload}} | _]} -> {:ok, payload}
-      _ -> :error
-    end
-  end
-
-  defp fetch_extensions(project) do
-    case ManagerApi.search_store_prefix(
-           project,
-           Entry.integration_subject_prefix("spark", :extension),
-           type: :metadata,
-           subtype: :integration
-         ) do
-      {:ok, entries} ->
-        Map.new(entries, fn %Entry{metadata: %{owner_module: module, payload: payload}} ->
-          {module, payload}
-        end)
-
-      _ ->
-        %{}
-    end
-  end
 
   defp hint(%Env{} = env) do
     case Code.Fragment.cursor_context(env.prefix) do
@@ -849,7 +531,4 @@ defmodule Engine.Integrations.Spark.Completion do
 
     String.starts_with?(name, hint)
   end
-
-  defp module_name(module) when is_atom(module), do: Atom.to_string(module)
-  defp module_name(module) when is_binary(module), do: module
 end

--- a/apps/engine/lib/engine/integrations/spark/hover.ex
+++ b/apps/engine/lib/engine/integrations/spark/hover.ex
@@ -1,0 +1,148 @@
+defmodule Engine.Integrations.Spark.Hover do
+  @behaviour Engine.Integrations
+
+  alias Engine.CodeIntelligence.Entity
+  alias Engine.Integrations.Spark.Common
+  alias Forge.Ast
+  alias Forge.Ast.Env
+  alias Forge.Document.Position
+
+  @impl Engine.Integrations
+  def hover(%Env{} = env) do
+    with false <- Env.in_context?(env, :comment) or Env.in_context?(env, :string),
+         {:ok, %{begin: begin_pos, context: context, end: end_pos}} <-
+           Ast.surround_context(env.analysis, env.position),
+         name when is_binary(name) <- hover_name(context),
+         env = move_to_token_end(env, end_pos),
+         cursor_path = Ast.cursor_path(env.analysis, env.position),
+         {:ok, documentation} <- documentation(cursor_path, name, env) do
+      [{documentation, Entity.to_range(env.document, begin_pos, end_pos)}]
+    else
+      _ -> []
+    end
+  end
+
+  defp documentation(cursor_path, name, env) do
+    case Common.use_context(cursor_path, env) do
+      {:ok, module, _argument} ->
+        with {:ok, dsl} <- Common.fetch(env.project, :dsl, module),
+             do: find_documentation(dsl.options, name)
+
+      :error ->
+        case Common.function_context(cursor_path, env) do
+          {:ok, module, function, arity, argument_index, _argument} ->
+            key = "#{Forge.Formats.mfa(module, function, arity)}/#{argument_index}"
+
+            with {:ok, options} <- Common.fetch(env.project, :function, key),
+                 do: find_documentation(options, name)
+
+          :error ->
+            dsl_documentation(cursor_path, name, env)
+        end
+    end
+  end
+
+  defp dsl_documentation(cursor_path, name, env) do
+    if Ast.inside_definition?(cursor_path) and not Ast.remote_call?(cursor_path) do
+      :error
+    else
+      with {:ok, dsl, use} <- Common.dsl_context(env.project, env) do
+        extensions = Common.active_extensions(env.project, dsl, use, env)
+        sections = Enum.flat_map(extensions, & &1.sections)
+        names = Ast.enclosing_local_call_names(cursor_path)
+        call_context = Ast.local_call_at_cursor(cursor_path)
+        node_documentation(sections, names, call_context, name, env)
+      end
+    end
+  end
+
+  defp node_documentation(sections, names, call_context, name, env) do
+    parent_names = if List.last(names) == name, do: Enum.drop(names, -1), else: names
+
+    with :error <- documentation_in_node(sections, parent_names, name),
+         :error <- documentation_in_node(sections, names, name),
+         do: constraint_documentation(sections, names, call_context, name, env)
+  end
+
+  defp documentation_in_node(sections, names, name) do
+    with {:ok, node} <- Common.find_node(sections, names),
+         child when not is_nil(child) <- Common.child(node, name),
+         documentation when is_binary(documentation) and documentation != "" <-
+           Map.get(child, :documentation) do
+      {:ok, documentation}
+    else
+      _ ->
+        with {:ok, node} <- Common.find_node(sections, names),
+             do: find_documentation(Map.get(node, :options, []), name)
+    end
+  end
+
+  defp constraint_documentation(
+         sections,
+         names,
+         {:ok, call_name, _index, _argument, arguments},
+         name,
+         env
+       ) do
+    case Common.find_node(sections, names) do
+      {:ok, %{name: ^call_name} = node} ->
+        with %{type: %{kind: :spark_type, behaviour: behaviour, aliases: aliases}} <-
+               Enum.find(node.options, &(&1.name == "type")),
+             index when is_integer(index) <-
+               Enum.find_index(node.arguments, &(&1.name == "type")),
+             type_ast when not is_nil(type_ast) <- Enum.at(arguments, index),
+             argument_ast when not is_nil(argument_ast) <-
+               Enum.find(arguments, &Ast.contains_cursor?/1),
+             {:ok, keyword_path} <- Ast.keyword_path_at_cursor(argument_ast),
+             {:ok, module} <- Common.selected_type_module(type_ast, aliases, env),
+             {:ok, %{constraints: options}} <-
+               Common.fetch(env.project, :behaviour, "#{behaviour}/#{module}") do
+          find_documentation(options, Enum.drop(keyword_path, 1), name)
+        else
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp constraint_documentation(_sections, _names, _call_context, _name, _env), do: :error
+
+  defp find_documentation(options, name) do
+    find_documentation(options, [], name)
+  end
+
+  defp find_documentation(options, [], name) do
+    case Enum.find(options, &(&1.name == name)) do
+      %{documentation: documentation} when is_binary(documentation) and documentation != "" ->
+        {:ok, documentation}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp find_documentation(options, [key | path], name) do
+    case Enum.find(options, &(&1.name == key)) do
+      %{type: %{options: nested}} -> find_documentation(nested, path, name)
+      _ -> :error
+    end
+  end
+
+  defp move_to_token_end(%Env{} = env, {line, column}) do
+    %Env{
+      env
+      | position: Position.new(env.document, line, column),
+        prefix: String.slice(env.line, 0, column - 1),
+        suffix: String.slice(env.line, (column - 1)..-1//1),
+        zero_based_character: column - 1
+    }
+  end
+
+  defp hover_name({context, chars})
+       when context in [:keyword, :local_call, :local_or_var, :unquoted_atom],
+       do: to_string(chars)
+
+  defp hover_name(_context), do: nil
+end

--- a/apps/engine/lib/engine/integrations/spark/indexer.ex
+++ b/apps/engine/lib/engine/integrations/spark/indexer.ex
@@ -1,0 +1,549 @@
+defmodule Engine.Integrations.Spark.Indexer do
+  @behaviour Engine.Integrations
+
+  alias Engine.Modules
+  alias Forge.Search.Indexer.Entry
+
+  @callback_timeout 2_000
+  @spark_extension Spark.Dsl.Extension
+
+  def recognizes?(metadata) do
+    attributes = Map.get(metadata, :attributes, [])
+    behaviours = attribute_modules(attributes, :behaviour)
+
+    true in attribute_values(attributes, :spark_dsl) or
+      behaviours != [] or attribute_modules(attributes, :spark_is) != []
+  end
+
+  @impl Engine.Integrations
+  def index(binary, metadata, source_path) do
+    function_entries = function_option_entries(binary, metadata, source_path)
+
+    if recognizes?(metadata) do
+      index_module(binary, metadata, source_path) ++ function_entries
+    else
+      function_entries
+    end
+  end
+
+  defp index_module(binary, metadata, source_path) do
+    module = Map.fetch!(metadata, :module)
+    attributes = Map.get(metadata, :attributes, [])
+    dsl? = true in attribute_values(attributes, :spark_dsl)
+    behaviours = attribute_modules(attributes, :behaviour)
+    extension? = @spark_extension in behaviours
+    skip_callback? = exports?(binary, :skip_in_spark_autocomplete, 0)
+    constraints_callback? = exports?(binary, :constraints, 0)
+
+    {skip?, dynamic_entries} =
+      dynamic_entries(attributes, binary, module, source_path, dsl?, extension?, skip_callback?)
+
+    constraints = constraints(binary, module, constraints_callback?)
+
+    relation_entries(source_path, module, attributes, skip?, constraints) ++ dynamic_entries
+  end
+
+  defp dynamic_entries(_attributes, _binary, _module, _source_path, false, false, false),
+    do: {false, []}
+
+  defp dynamic_entries(attributes, binary, module, source_path, dsl?, extension?, skip_callback?) do
+    run_with_timeout(
+      fn ->
+        loaded? = loaded_module_matches?(module, binary)
+        skip? = skip_callback? and skip_in_spark_autocomplete?(module, loaded?)
+
+        {skip?, index_entries(attributes, module, source_path, dsl?, extension?, loaded?)}
+      end,
+      {skip_callback?, []}
+    )
+  end
+
+  defp index_entries(attributes, module, source_path, dsl?, extension?, loaded?) do
+    []
+    |> maybe_add(dsl?, fn -> dsl_entry(source_path, module, attributes, loaded?) end)
+    |> maybe_add(extension?, fn -> extension_entry(source_path, module, loaded?) end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp relation_entries(path, module, attributes, skip?, constraints) do
+    payload =
+      if constraints == [], do: %{skip?: skip?}, else: %{skip?: skip?, constraints: constraints}
+
+    behaviour_entries =
+      attributes
+      |> attribute_modules(:behaviour)
+      |> Enum.uniq()
+      |> Enum.map(&relation_entry(path, :behaviour, &1, module, payload))
+
+    type_entries =
+      attributes
+      |> attribute_modules(:spark_is)
+      |> Enum.uniq()
+      |> Enum.map(&relation_entry(path, :type, &1, module, %{}))
+
+    behaviour_entries ++ type_entries
+  end
+
+  defp constraints(_binary, _module, false), do: []
+
+  defp constraints(binary, module, true) do
+    run_with_timeout(
+      fn ->
+        if loaded_module_matches?(module, binary),
+          do: normalize_schema(module.constraints()),
+          else: []
+      end,
+      []
+    )
+  end
+
+  defp relation_entry(path, kind, target, module, payload) do
+    target = module_name(target)
+    module = module_name(module)
+
+    entry = Entry.integration(path, "spark", kind, module, Map.put(payload, :module, module))
+    %Entry{entry | subject: Entry.integration_subject("spark", kind, "#{target}/#{module}")}
+  end
+
+  defp dsl_entry(path, module, attributes, loaded?) do
+    with {:ok, default_extension_kinds} <-
+           callback_result(module, :default_extension_kinds, loaded?),
+         {:ok, single_extension_kinds} <-
+           callback_result(module, :single_extension_kinds, loaded?),
+         {:ok, options} <- callback_result(module, :opt_schema, loaded?) do
+      metadata = %{
+        default_extensions:
+          module
+          |> callback_or_attribute(
+            :default_extensions,
+            attribute_modules(attributes, :spark_default_extensions),
+            loaded?
+          )
+          |> normalize_modules(),
+        default_extension_kinds: normalize_extension_kinds(default_extension_kinds),
+        single_extension_kinds: normalize_names(single_extension_kinds),
+        extension_kinds:
+          attributes
+          |> attribute_values(:spark_extension_kinds)
+          |> List.flatten()
+          |> normalize_names(),
+        options: normalize_schema(options)
+      }
+
+      entry(path, :dsl, module, metadata)
+    else
+      _ -> nil
+    end
+  end
+
+  defp extension_entry(path, module, loaded?) do
+    with {:ok, added_extensions} <- callback_result(module, :add_extensions, loaded?),
+         {:ok, sections} <- callback_result(module, :sections, loaded?),
+         {:ok, patches} <- callback_result(module, :dsl_patches, loaded?) do
+      metadata = %{
+        added_extensions: normalize_modules(added_extensions),
+        sections: normalize_sections(sections),
+        patches: normalize_patches(patches)
+      }
+
+      entry(path, :extension, module, metadata)
+    else
+      _ -> nil
+    end
+  end
+
+  defp entry(path, kind, key, metadata) do
+    Entry.integration(path, "spark", kind, key, metadata)
+  end
+
+  defp function_option_entries(binary, metadata, source_path) do
+    module = Map.fetch!(metadata, :module)
+
+    case Modules.fetch_docs(binary) do
+      {:ok, {:docs_v1, _, _, _, _, _, entries}} ->
+        for {{kind, name, arity}, _, _, _, metadata} <- entries,
+            kind in [:function, :macro],
+            {argument_index, schema} <- Map.get(metadata, :spark_opts, []),
+            is_integer(argument_index) and argument_index >= 0,
+            callable_arity <- (arity - Map.get(metadata, :defaults, 0))..arity,
+            argument_index < callable_arity do
+          key = "#{Forge.Formats.mfa(module, name, callable_arity)}/#{argument_index}"
+          entry(source_path, :function, key, normalize_schema(schema))
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp attribute_values(attributes, name) do
+    attributes
+    |> Keyword.get_values(name)
+    |> List.flatten()
+  end
+
+  defp attribute_modules(attributes, name) do
+    attributes
+    |> attribute_values(name)
+    |> Enum.filter(&is_atom/1)
+  end
+
+  defp loaded_module_matches?(module, binary) do
+    with {:ok, {^module, md5}} <- :beam_lib.md5(binary),
+         {:module, ^module} <- Code.ensure_loaded(module) do
+      module.module_info(:md5) == md5 or reload_matching_module?(module, binary, md5)
+    else
+      _ -> false
+    end
+  end
+
+  defp reload_matching_module?(module, binary, md5) do
+    with path when is_list(path) <- :code.which(module),
+         {:ok, ^binary} <- File.read(List.to_string(path)),
+         true <- :code.soft_purge(module),
+         {:module, ^module} <- :code.load_binary(module, path, binary) do
+      module.module_info(:md5) == md5
+    else
+      _ -> false
+    end
+  end
+
+  defp callback_or_attribute(module, function, fallback, loaded?) do
+    case callback(module, function, loaded?) do
+      :error -> fallback
+      value -> value
+    end
+  end
+
+  defp callback_result(module, function, loaded?) do
+    case callback(module, function, loaded?) do
+      :error -> :error
+      value -> {:ok, value}
+    end
+  end
+
+  defp callback(_module, _function, false), do: :error
+
+  defp callback(module, function, true) do
+    if function_exported?(module, function, 0) do
+      apply(module, function, [])
+    else
+      :error
+    end
+  end
+
+  defp exports?(binary, name, arity) do
+    case :beam_lib.chunks(binary, [:exports]) do
+      {:ok, {_module, [exports: exports]}} -> {name, arity} in exports
+      _ -> false
+    end
+  end
+
+  defp skip_in_spark_autocomplete?(_module, false), do: true
+
+  defp skip_in_spark_autocomplete?(module, true) do
+    function_exported?(module, :skip_in_spark_autocomplete, 0) and
+      module.skip_in_spark_autocomplete() == true
+  end
+
+  defp run_with_timeout(fun, fallback) do
+    task =
+      Task.async(fn ->
+        try do
+          fun.()
+        rescue
+          _exception -> fallback
+        catch
+          _kind, _reason -> fallback
+        end
+      end)
+
+    case Task.yield(task, @callback_timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} -> result
+      _ -> fallback
+    end
+  end
+
+  defp normalize_extension_kinds(value) when is_list(value) do
+    Map.new(value, fn {kind, modules} -> {to_string(kind), normalize_modules(modules)} end)
+  end
+
+  defp normalize_extension_kinds(_), do: %{}
+
+  defp normalize_names(:error), do: []
+
+  defp normalize_names(value),
+    do: value |> List.wrap() |> List.flatten() |> Enum.map(&to_string/1)
+
+  defp normalize_modules(:error), do: []
+
+  defp normalize_modules(value) do
+    value
+    |> List.wrap()
+    |> List.flatten()
+    |> Enum.filter(&is_atom/1)
+    |> Enum.map(&module_name/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_sections(:error), do: []
+
+  defp normalize_sections(sections) when is_list(sections) do
+    Enum.flat_map(sections, fn
+      section when is_map(section) -> [normalize_section(section)]
+      _ -> []
+    end)
+  end
+
+  defp normalize_sections(_sections), do: []
+
+  defp normalize_section(section) when is_map(section) do
+    %{
+      name: section |> Map.get(:name) |> to_string_or_empty(),
+      documentation:
+        section
+        |> Map.get(:docs)
+        |> present_or(Map.get(section, :describe))
+        |> normalize_documentation(),
+      snippet: normalize_snippet(Map.get(section, :snippet)),
+      top_level?: Map.get(section, :top_level?, false),
+      options: normalize_schema(Map.get(section, :schema, [])),
+      entities: section |> Map.get(:entities, []) |> normalize_entities(),
+      sections: normalize_sections(Map.get(section, :sections, []))
+    }
+  end
+
+  defp normalize_entity(entity) when is_map(entity) do
+    %{
+      name: entity |> Map.get(:name) |> to_string_or_empty(),
+      documentation:
+        entity
+        |> Map.get(:docs)
+        |> present_or(Map.get(entity, :describe))
+        |> normalize_documentation(),
+      snippet: normalize_snippet(Map.get(entity, :snippet)),
+      arguments: entity |> Map.get(:args, []) |> List.wrap() |> Enum.map(&normalize_argument/1),
+      options: normalize_schema(Map.get(entity, :schema, [])),
+      entities:
+        entity
+        |> Map.get(:entities, [])
+        |> List.wrap()
+        |> Enum.flat_map(fn
+          {_group, entities} ->
+            normalize_entities(entities)
+
+          _ ->
+            []
+        end)
+    }
+  end
+
+  defp normalize_entities(entities) when is_list(entities) do
+    Enum.flat_map(entities, fn
+      entity when is_map(entity) -> [normalize_entity(entity)]
+      _ -> []
+    end)
+  end
+
+  defp normalize_entities(_entities), do: []
+
+  defp normalize_argument({:optional, name}), do: %{name: to_string(name), optional?: true}
+
+  defp normalize_argument({:optional, name, default}) do
+    %{name: to_string(name), optional?: true, default: normalize_literal(default)}
+  end
+
+  defp normalize_argument(name), do: %{name: to_string(name), optional?: false}
+
+  defp normalize_patches(patches) do
+    Enum.flat_map(List.wrap(patches), fn
+      %{section_path: path, entity: entity} ->
+        [
+          %{
+            section_path: Enum.map(List.wrap(path), &to_string/1),
+            entity: normalize_entity(entity)
+          }
+        ]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp normalize_schema(:error), do: []
+
+  defp normalize_schema(schema) when is_list(schema) do
+    Enum.flat_map(schema, fn
+      {name, config} when is_atom(name) and is_list(config) ->
+        [
+          %{
+            name: to_string(name),
+            documentation: normalize_documentation(Keyword.get(config, :doc)),
+            snippet: normalize_snippet(Keyword.get(config, :snippet)),
+            default: normalize_literal(Keyword.get(config, :default)),
+            type:
+              config
+              |> Keyword.get(:type)
+              |> normalize_type()
+              |> with_keys(Keyword.get(config, :keys))
+          }
+        ]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp normalize_schema(_), do: []
+
+  defp normalize_type(:boolean), do: %{kind: :boolean}
+  defp normalize_type(:string), do: %{kind: :string}
+  defp normalize_type(:atom), do: %{kind: :atom}
+  defp normalize_type(:map), do: %{kind: :map}
+  defp normalize_type(:keyword_list), do: %{kind: :keyword_list}
+  defp normalize_type(:non_empty_keyword_list), do: %{kind: :keyword_list}
+  defp normalize_type(:module), do: %{kind: :module}
+  defp normalize_type(:mfa), do: %{kind: :mfa}
+
+  defp normalize_type(:fun), do: %{kind: :function, arity: nil}
+
+  defp normalize_type({:behaviour, module}) when is_atom(module),
+    do: %{kind: :behaviour, behaviour: module_name(module)}
+
+  defp normalize_type({:spark, module}) when is_atom(module),
+    do: %{kind: :spark, type: module_name(module)}
+
+  defp normalize_type({:spark_type, module, function}),
+    do: normalize_type({:spark_type, module, function, []})
+
+  defp normalize_type({:spark_type, module, function, _templates})
+       when is_atom(module) and is_atom(function) do
+    %{
+      kind: :spark_type,
+      behaviour: module_name(module),
+      aliases: spark_type_aliases(module, function)
+    }
+  end
+
+  defp normalize_type({:spark_behaviour, behaviour}),
+    do: normalize_type({:spark_behaviour, behaviour, nil})
+
+  defp normalize_type({:spark_behaviour, behaviour, builtins})
+       when is_atom(behaviour) and (is_atom(builtins) or is_nil(builtins)) do
+    %{
+      kind: :spark_behaviour,
+      behaviour: module_name(behaviour),
+      builtins: source_module_name(builtins)
+    }
+  end
+
+  defp normalize_type({:spark_function_behaviour, behaviour, function}),
+    do: normalize_type({:spark_function_behaviour, behaviour, nil, function})
+
+  defp normalize_type({:spark_function_behaviour, behaviour, builtins, {module, arity}})
+       when is_atom(behaviour) and is_atom(module) and is_integer(arity) and arity >= 0 do
+    %{
+      kind: :spark_function_behaviour,
+      behaviour: module_name(behaviour),
+      builtins: source_module_name(builtins),
+      function: %{module: module_name(module), arity: arity}
+    }
+  end
+
+  defp normalize_type({:fun, arity}) when is_integer(arity) and arity >= 0,
+    do: %{kind: :function, arity: arity}
+
+  defp normalize_type({:fun, args}) when is_list(args),
+    do: %{kind: :function, arity: length(args)}
+
+  defp normalize_type({:fun, args, _return}) when is_list(args),
+    do: %{kind: :function, arity: length(args)}
+
+  defp normalize_type({kind, values}) when kind in [:one_of, :in] do
+    %{kind: :choices, values: Enum.map(Enum.to_list(values), &choice/1)}
+  end
+
+  defp normalize_type({:literal, value}), do: %{kind: :choices, values: [choice(value)]}
+
+  defp normalize_type({kind, type}) when kind in [:list, :wrap_list] do
+    %{kind: kind, item: normalize_type(type)}
+  end
+
+  defp normalize_type({kind, schema}) when kind in [:keyword_list, :non_empty_keyword_list] do
+    %{kind: :keyword_list, options: normalize_schema(schema)}
+  end
+
+  defp normalize_type({:or, types}), do: %{kind: :or, types: Enum.map(types, &normalize_type/1)}
+
+  defp normalize_type(type), do: %{kind: :unknown, value: inspect(type)}
+
+  defp with_keys(type, keys) do
+    case normalize_schema(keys) do
+      [] -> type
+      options -> Map.put(type, :options, options)
+    end
+  end
+
+  defp spark_type_aliases(module, function) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         callback when not is_nil(callback) <- spark_type_callback(module, function),
+         aliases when is_list(aliases) <- apply(module, callback, []) do
+      for {name, implementation} <- aliases,
+          is_atom(name) and is_atom(implementation),
+          into: %{} do
+        {to_string(name), module_name(implementation)}
+      end
+    else
+      _ -> %{}
+    end
+  end
+
+  defp spark_type_callback(module, function) do
+    cond do
+      function_exported?(module, function, 0) -> function
+      function == :builtins and function_exported?(module, :short_names, 0) -> :short_names
+      true -> nil
+    end
+  end
+
+  defp choice(value), do: %{label: inspect(value), insert_text: inspect(value)}
+
+  defp normalize_literal(value)
+       when is_nil(value) or is_boolean(value) or is_number(value) or is_binary(value),
+       do: value
+
+  defp normalize_literal(value) when is_atom(value), do: %{atom: Atom.to_string(value)}
+  defp normalize_literal(value) when is_list(value), do: Enum.map(value, &normalize_literal/1)
+
+  defp normalize_literal(value) when is_tuple(value) do
+    %{tuple: value |> Tuple.to_list() |> Enum.map(&normalize_literal/1)}
+  end
+
+  defp normalize_literal(value) when is_map(value) and not is_struct(value) do
+    Map.new(value, fn {key, item} -> {to_string(key), normalize_literal(item)} end)
+  end
+
+  defp normalize_literal(value), do: inspect(value)
+
+  defp normalize_documentation(value) when is_binary(value), do: value
+  defp normalize_documentation(_value), do: ""
+
+  defp normalize_snippet(value)
+       when is_binary(value) and byte_size(value) > 0 and byte_size(value) <= 64_000,
+       do: value
+
+  defp normalize_snippet(_value), do: nil
+
+  defp present_or(value, fallback) when value in [nil, ""], do: fallback
+  defp present_or(value, _fallback), do: value
+
+  defp maybe_add(entries, true, fun), do: [fun.() | entries]
+  defp maybe_add(entries, false, _fun), do: entries
+
+  defp to_string_or_empty(nil), do: ""
+  defp to_string_or_empty(value), do: to_string(value)
+
+  defp module_name(module) when is_atom(module), do: Atom.to_string(module)
+  defp source_module_name(nil), do: nil
+  defp source_module_name(module), do: Forge.Formats.module(module)
+end

--- a/apps/engine/lib/engine/integrations/spark/values.ex
+++ b/apps/engine/lib/engine/integrations/spark/values.ex
@@ -1,0 +1,185 @@
+defmodule Engine.Integrations.Spark.Values do
+  @moduledoc false
+
+  alias Engine.ManagerApi
+  alias Forge.Ast.Analysis
+  alias Forge.Ast.Analysis.Alias
+  alias Forge.Ast.Analysis.Scope
+  alias Forge.Ast.Env
+  alias Forge.Completion.Candidate
+  alias Forge.Search.Indexer.Entry
+
+  @callables [{:function, :public}, {:function, :delegate}, {:macro, :public}]
+
+  def candidates(%Env{} = env, type), do: modules(env, type) ++ builtins(env, type)
+
+  defp modules(env, %{kind: :behaviour, behaviour: target}) do
+    env
+    |> relation_entries(:behaviour, target)
+    |> Enum.reject(& &1.metadata.payload.skip?)
+    |> to_modules(env)
+  end
+
+  defp modules(env, %{kind: kind, behaviour: target})
+       when kind in [:spark_behaviour, :spark_function_behaviour] do
+    env
+    |> relation_entries(:behaviour, target)
+    |> Enum.reject(&(root(&1.metadata.payload.module) == root(target)))
+    |> to_modules(env)
+  end
+
+  defp modules(env, %{kind: :spark, type: target}),
+    do: env |> relation_entries(:type, target) |> to_modules(env)
+
+  defp modules(_env, _type), do: []
+
+  defp relation_entries(%Env{} = env, kind, target) do
+    prefix = Entry.integration_subject_prefix("spark", kind, target)
+
+    case ManagerApi.search_store_prefix(env.project, prefix,
+           type: :metadata,
+           subtype: :integration
+         ) do
+      {:ok, entries} -> entries
+      _ -> []
+    end
+  end
+
+  defp to_modules(entries, env) do
+    entries
+    |> Enum.flat_map(fn
+      %Entry{metadata: %{payload: %{module: module}}} -> module_candidate(module, env)
+      _ -> []
+    end)
+    |> Enum.uniq_by(&{&1.name, &1.full_name})
+  end
+
+  defp module_candidate(module, env) when is_binary(module) do
+    hint = hint(env)
+    full_name = source_module(module)
+
+    [full_name | aliases(module, env)]
+    |> Enum.uniq()
+    |> Enum.filter(&matches?(&1, hint))
+    |> Enum.min_by(&String.length/1, fn -> nil end)
+    |> case do
+      nil ->
+        []
+
+      name ->
+        [%Candidate.Module{name: insertion_name(name, hint), full_name: full_name, metadata: %{}}]
+    end
+  end
+
+  defp module_candidate(_module, _env), do: []
+
+  defp aliases("Elixir." <> module, %Env{} = env) do
+    parts = String.split(module, ".")
+
+    case Analysis.scopes_at(env.analysis, env.position) do
+      [%Scope{} = scope | _] ->
+        scope
+        |> Scope.alias_map(env.position)
+        |> Enum.flat_map(fn
+          {_key, %Alias{module: target, as: as}} -> alias_name(parts, target, as)
+          _ -> []
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp aliases(_module, _env), do: []
+
+  defp alias_name(parts, target, as) do
+    target = Enum.map(target, &Atom.to_string/1)
+
+    if Enum.take(parts, length(target)) == target,
+      do: [Enum.join(Enum.map(as, &Atom.to_string/1) ++ Enum.drop(parts, length(target)), ".")],
+      else: []
+  end
+
+  defp builtins(%Env{} = env, %{builtins: module}) when is_binary(module) do
+    hint = hint(env)
+    module = String.trim_leading(module, "Elixir.")
+
+    if String.contains?(hint, ".") or not lowercase?(hint) do
+      []
+    else
+      case ManagerApi.search_store_prefix(env.project, "#{module}.#{hint}", subtype: :definition) do
+        {:ok, entries} ->
+          entries
+          |> Enum.flat_map(&callable(&1, module))
+          |> Enum.uniq_by(&{&1.__struct__, &1.name, &1.arity})
+
+        _ ->
+          []
+      end
+    end
+  end
+
+  defp builtins(_env, _type), do: []
+
+  defp callable(%Entry{type: type, subject: subject}, module)
+       when type in @callables and is_binary(subject) do
+    with rest when rest != subject <- String.replace_prefix(subject, module <> ".", ""),
+         false <- String.contains?(rest, "."),
+         [name, arity] <- String.split(rest, "/", parts: 2),
+         false <- name in ["__info__", "module_info"],
+         {arity, ""} <- Integer.parse(arity) do
+      candidate = if type == {:macro, :public}, do: Candidate.Macro, else: Candidate.Function
+
+      [
+        struct(candidate,
+          name: name,
+          arity: arity,
+          argument_names: if(arity == 0, do: [], else: Enum.map(1..arity, &"arg#{&1}")),
+          origin: module,
+          type: if(candidate == Candidate.Macro, do: :macro, else: :function),
+          visibility: :public,
+          metadata: %{}
+        )
+      ]
+    else
+      _ -> []
+    end
+  end
+
+  defp callable(_entry, _module), do: []
+
+  defp root(module),
+    do: module |> String.trim_leading("Elixir.") |> String.split(".", parts: 2) |> hd()
+
+  defp source_module("Elixir." <> module), do: module
+  defp source_module(":" <> _ = module), do: module
+  defp source_module(module), do: ":" <> module
+
+  defp matches?(_module, ""), do: true
+
+  defp matches?(module, hint) do
+    module = String.downcase(module)
+    hint = String.downcase(hint)
+
+    String.starts_with?(module, hint) or
+      String.starts_with?(List.last(String.split(module, ".")), hint)
+  end
+
+  defp insertion_name(module, hint) do
+    module
+    |> String.split(".")
+    |> Enum.drop(hint |> String.graphemes() |> Enum.count(&(&1 == ".")))
+    |> Enum.join(".")
+  end
+
+  defp lowercase?(""), do: true
+  defp lowercase?(hint), do: String.first(hint) == String.downcase(String.first(hint))
+
+  defp hint(%Env{} = env) do
+    case Code.Fragment.cursor_context(env.prefix) do
+      {kind, chars} when kind in [:alias, :local_or_var, :local_call] -> to_string(chars)
+      {:alias, _base, chars} -> to_string(chars)
+      _ -> ""
+    end
+  end
+end

--- a/apps/engine/lib/engine/search/indexer.ex
+++ b/apps/engine/lib/engine/search/indexer.ex
@@ -22,11 +22,20 @@ defmodule Engine.Search.Indexer do
     ManifestStore.commit(project, manifest)
   end
 
+  def record_integrations(%Project{} = project) do
+    ManifestStore.record_integrations(project)
+  end
+
   def update_index(%Project{} = project, path_to_ids) when is_map(path_to_ids) do
     with_indexer_context(fn ->
       case ManifestStore.load(project) do
-        {:ok, %Manifest{} = manifest} -> refresh_index(project, manifest, path_to_ids)
-        :missing -> replace_index(project, path_to_ids)
+        {:ok, %Manifest{} = manifest} ->
+          if ManifestStore.integrations_changed?(project, manifest),
+            do: replace_index(project, path_to_ids),
+            else: refresh_index(project, manifest, path_to_ids)
+
+        :missing ->
+          replace_index(project, path_to_ids)
       end
     end)
   end

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -2,6 +2,7 @@ defmodule Engine.Search.Indexer.Beams do
   import Forge.Document.Line
 
   alias Engine.ApplicationCache
+  alias Engine.Integrations
   alias Engine.Progress
   alias Engine.Search.Indexer.Manifest
   alias Engine.Search.Subject
@@ -26,14 +27,16 @@ defmodule Engine.Search.Indexer.Beams do
     with {:ok, metadata} <- debug_metadata_from_binary(beam) do
       metadata = Map.put(metadata, :file, Forge.Path.native(source_path))
 
-      entries =
+      definitions =
         metadata
         |> entries_from_metadata(
           source_lines(source_path, [metadata |> metadata_position() |> elem(0)])
         )
         |> Enum.filter(&definition?/1)
 
-      {:ok, entries}
+      integrations = Integrations.index_beam(beam, metadata, Forge.Path.native(source_path))
+
+      {:ok, definitions ++ integrations}
     end
   end
 
@@ -105,12 +108,16 @@ defmodule Engine.Search.Indexer.Beams do
     {entries, manifest_entries}
   end
 
-  defp indexed_result?({:indexed, _source_path, _metadata, _manifest_entry}), do: true
+  defp indexed_result?(
+         {:indexed, _source_path, _metadata, _integration_entries, _manifest_entry}
+       ),
+       do: true
+
   defp indexed_result?(_result), do: false
 
   defp manifest_entries_from_results(results) do
     Enum.map(results, fn
-      {:indexed, _source_path, _metadata, manifest_entry} -> manifest_entry
+      {:indexed, _source_path, _metadata, _integration_entries, manifest_entry} -> manifest_entry
       {:skipped, manifest_entry} -> manifest_entry
     end)
   end
@@ -121,7 +128,9 @@ defmodule Engine.Search.Indexer.Beams do
     source_lines_by_path = source_lines_by_path(results)
 
     results
-    |> Enum.group_by(fn {:indexed, source_path, _metadata, _manifest_entry} -> source_path end)
+    |> Enum.group_by(fn {:indexed, source_path, _metadata, _integration_entries, _manifest_entry} ->
+      source_path
+    end)
     |> Enum.flat_map(fn {source_path, results} ->
       entries_from_group(source_path, results, source_lines_by_path)
     end)
@@ -129,8 +138,10 @@ defmodule Engine.Search.Indexer.Beams do
 
   defp entries_from_group(source_path, results, source_lines_by_path) do
     entries =
-      Enum.flat_map(results, fn {:indexed, _source_path, metadata, _manifest_entry} ->
-        entries_from_metadata(metadata, Map.get(source_lines_by_path, source_path, %{}))
+      Enum.flat_map(results, fn {:indexed, _source_path, metadata, integration_entries,
+                                 _manifest_entry} ->
+        entries_from_metadata(metadata, Map.get(source_lines_by_path, source_path, %{})) ++
+          integration_entries
       end)
 
     [Entry.block_structure(source_path, %{root: %{}}) | entries]
@@ -138,12 +149,12 @@ defmodule Engine.Search.Indexer.Beams do
 
   defp metadata_from_beam({beam_path, beam_stat}) do
     case debug_metadata(beam_path) do
-      {:ok, metadata} -> metadata_result_from_beam(beam_path, beam_stat, metadata)
+      {:ok, metadata, binary} -> metadata_result_from_beam(beam_path, beam_stat, metadata, binary)
       :error -> skipped_result_from_beam(beam_path, beam_stat, nil, nil)
     end
   end
 
-  defp metadata_result_from_beam(beam_path, beam_stat, metadata) do
+  defp metadata_result_from_beam(beam_path, beam_stat, metadata, binary) do
     source_path = Map.get(metadata, :file)
     source_stat_result = stat_source(source_path)
 
@@ -151,7 +162,10 @@ defmodule Engine.Search.Indexer.Beams do
       {:ok, manifest_entry} =
         Manifest.Entry.beam(beam_path, source_path, beam_stat, source_stat_result)
 
-      [{:indexed, source_path, metadata, manifest_entry}]
+      integration_entries =
+        Integrations.index_beam(binary, metadata, Forge.Path.native(source_path))
+
+      [{:indexed, source_path, metadata, integration_entries, manifest_entry}]
     else
       skipped_result_from_beam(beam_path, beam_stat, source_path, source_stat_result)
     end
@@ -187,15 +201,12 @@ defmodule Engine.Search.Indexer.Beams do
   # The debug-info chunk data is backend-owned and opaque. The public contract is
   # to ask the backend to decode it into the Elixir debug-info format we consume.
   defp debug_metadata(beam_path) do
-    with {:ok, {module, [debug_info: {:debug_info_v1, backend, data}]}} <-
-           :beam_lib.chunks(String.to_charlist(beam_path), [:debug_info]),
-         {:ok, metadata} when is_map(metadata) <- backend.debug_info(:elixir_v1, module, data, []) do
-      {:ok, metadata}
+    with {:ok, binary} <- File.read(beam_path),
+         {:ok, metadata} <- debug_metadata_from_binary(binary) do
+      {:ok, metadata, binary}
     else
       _ -> :error
     end
-  catch
-    _kind, _reason -> :error
   end
 
   defp debug_metadata_from_binary(beam) do
@@ -660,8 +671,10 @@ defmodule Engine.Search.Indexer.Beams do
   defp source_lines_by_path(results) do
     results
     |> Enum.group_by(
-      fn {:indexed, source_path, _metadata, _manifest_entry} -> source_path end,
-      fn {:indexed, _source_path, metadata, _manifest_entry} ->
+      fn {:indexed, source_path, _metadata, _integration_entries, _manifest_entry} ->
+        source_path
+      end,
+      fn {:indexed, _source_path, metadata, _integration_entries, _manifest_entry} ->
         metadata |> metadata_position() |> elem(0)
       end
     )

--- a/apps/engine/lib/engine/search/indexer/manifest_store.ex
+++ b/apps/engine/lib/engine/search/indexer/manifest_store.ex
@@ -3,11 +3,13 @@ defmodule Engine.Search.Indexer.ManifestStore do
   Persists the indexer's incremental input registry.
   """
 
+  alias Engine.Integrations
   alias Engine.Search.Indexer.Manifest
   alias Engine.Search.Indexer.Manifest.Entry
   alias Forge.Project
 
   @file_name "index_manifest.etf"
+  @integrations_file_name "integrations.etf"
 
   @doc false
   def load(%Project{} = project) do
@@ -33,8 +35,33 @@ defmodule Engine.Search.Indexer.ManifestStore do
     end
   end
 
+  def integrations_changed?(%Project{} = project) do
+    case load(project) do
+      {:ok, %Manifest{} = manifest} -> integrations_changed?(project, manifest)
+      :missing -> true
+    end
+  end
+
+  def integrations_changed?(%Project{} = project, %Manifest{}) do
+    with {:ok, binary} <- File.read(integrations_path(project)),
+         {:ok, indexers} when is_list(indexers) <- safe_binary_to_term(binary) do
+      indexers != Integrations.indexer_module_names()
+    else
+      _ -> true
+    end
+  end
+
+  def record_integrations(%Project{} = project) do
+    path = integrations_path(project)
+
+    with :ok <- File.mkdir_p(Path.dirname(path)) do
+      write_file(path, :erlang.term_to_binary(Integrations.indexer_module_names()))
+    end
+  end
+
   def invalidate(%Project{} = project) do
     File.rm(manifest_path(project))
+    File.rm(integrations_path(project))
     :ok
   end
 
@@ -132,6 +159,9 @@ defmodule Engine.Search.Indexer.ManifestStore do
   end
 
   defp manifest_path(%Project{} = project), do: Path.join(root_path(project), @file_name)
+
+  defp integrations_path(%Project{} = project),
+    do: Path.join(root_path(project), @integrations_file_name)
 
   defp root_path(%Project{} = project) do
     Project.workspace_path(project, ["indexes", "manifest"])

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -5,8 +5,11 @@ defmodule Engine.Build.StateTest do
   import Forge.Test.Fixtures
 
   alias Engine.Build
+  alias Engine.Build.Isolation
   alias Engine.Build.State
   alias Engine.Plugin
+  alias Engine.Progress
+  alias Engine.Search.Indexer.ManifestStore
   alias Forge.Document
   alias Forge.Project
 
@@ -187,6 +190,18 @@ defmodule Engine.Build.StateTest do
     end
   end
 
+  describe "project compilation with indexer changes" do
+    setup [:with_metadata_project]
+
+    test "forces compilation when integrations changed", %{state: state} do
+      assert "--force" in project_compile_options(state.project, true)
+    end
+
+    test "does not force compilation when integrations are unchanged", %{state: state} do
+      refute "--force" in project_compile_options(state.project, false)
+    end
+  end
+
   describe "project compilation with exception" do
     setup [:with_metadata_project]
 
@@ -230,5 +245,27 @@ defmodule Engine.Build.StateTest do
 
       assert State.last_deps_fetch_result(state) == {:error, "deps failed"}
     end
+  end
+
+  defp project_compile_options(project, integrations_changed?) do
+    test_pid = self()
+
+    patch(ManifestStore, :integrations_changed?, fn ^project -> integrations_changed? end)
+    patch(Engine.Mix, :in_project, fn compile -> compile.(nil) end)
+    patch(Engine.Mix, :ensure_hex_and_rebar, :ok)
+    patch(Progress, :with_progress, fn _title, work -> elem(work.(nil), 1) end)
+    patch(Isolation, :invoke, fn compile -> {:ok, compile.()} end)
+    patch(Build.Project, :maybe_load_modules, :ok)
+
+    patch(Mix.Tasks.Compile, :run, fn options ->
+      send(test_pid, {:project_compile_options, options})
+      {:ok, []}
+    end)
+
+    patch(Mix.Tasks.Loadpaths, :run, fn [] -> :ok end)
+
+    Build.Project.compile(project, false)
+    assert_receive {:project_compile_options, options}
+    options
   end
 end

--- a/apps/engine/test/engine/integrations/spark/completion_test.exs
+++ b/apps/engine/test/engine/integrations/spark/completion_test.exs
@@ -1,0 +1,416 @@
+defmodule Engine.Integrations.Spark.CompletionTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.CursorSupport
+  import Forge.Test.Fixtures
+
+  alias Forge.Ast
+  alias Forge.Ast.Env
+  alias Forge.Completion.Candidate
+  alias Forge.Search.Indexer.Entry
+
+  setup do
+    project = project()
+    entries = spark_entries()
+
+    patch(Engine.ManagerApi, :search_store_exact, fn ^project, subject, constraints ->
+      {:ok, query(entries, subject, constraints, :exact)}
+    end)
+
+    patch(Engine.ManagerApi, :search_store_prefix, fn ^project, subject, constraints ->
+      {:ok, query(entries, subject, constraints, :prefix)}
+    end)
+
+    patch(Engine.ManagerApi, :search_store_all, fn _project, _constraints ->
+      flunk("Spark completion must not read the full index")
+    end)
+
+    {:ok, project: project}
+  end
+
+  test "completes indexed use options and values", %{project: project} do
+    assert {:override, [%Candidate.Snippet{label: "otp_app", snippet: "otp_app: :$0"}], []} =
+             complete(project, "use Ash.Resource, otp_|")
+
+    assert {:override, [%Candidate.Snippet{label: "enabled?", snippet: "enabled?: true"}], []} =
+             complete(project, "use Ash.Resource, ena|")
+
+    assert {:override, [%Candidate.Snippet{label: "true", snippet: "true"}], []} =
+             complete(project, "use Ash.Resource, enabled?: t|")
+  end
+
+  test "completes sections, entities, patches, and documentation", %{project: project} do
+    assert {:augment, [%Candidate.Snippet{label: "actions", documentation: "Actions"}], []} =
+             complete(project, resource("act|"))
+
+    assert {:augment,
+            [%Candidate.Snippet{label: "read", documentation: "A read action", snippet: snippet}],
+            []} = complete(project, resource("actions do\n  rea|\nend"))
+
+    assert snippet =~ "read ${1:name}"
+
+    assert {:override, [%Candidate.Snippet{label: "description"}], []} =
+             complete(project, resource("actions do\n  read :all do\n    desc|\n  end\nend"))
+
+    assert {:augment, candidates, []} =
+             complete(project, resource("actions do\n  cre|\nend", ", extensions: [My.Patch]"))
+
+    assert Enum.any?(candidates, &match?(%Candidate.Snippet{label: "create"}, &1))
+  end
+
+  test "resolves the DSL alias at the use position", %{project: project} do
+    assert {:augment, [%Candidate.Snippet{label: "actions"}], []} =
+             complete(
+               project,
+               """
+               defmodule My.Resource do
+                 alias Ash.Resource, as: ResourceDsl
+                 use ResourceDsl
+                 alias Other.Resource, as: ResourceDsl
+
+                 act|
+               end
+               """
+             )
+  end
+
+  test "replaces default single-kind extensions when configured", %{project: project} do
+    assert {:augment, [%Candidate.Snippet{label: "default_section"}], []} =
+             complete(project, resource("def|"))
+
+    assert {:augment, [%Candidate.Snippet{label: "custom_section"}], []} =
+             complete(project, resource("cus|", ", data_layer: My.CustomDataLayer"))
+  end
+
+  test "completes constrained modules, builtins, and functions", %{project: project} do
+    assert {:override, [%Candidate.Module{full_name: "App.MyChange"}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, change: App|\nend")
+             )
+
+    assert {:override,
+            [
+              %Candidate.Function{
+                name: "set_attribute",
+                arity: 2,
+                argument_names: ["arg1", "arg2"]
+              }
+            ], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, smart_change: set|\nend")
+             )
+
+    assert {:override, [%Candidate.Macro{name: "matches", argument_names: ["arg1"]}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, smart_change: mat|\nend")
+             )
+
+    assert {:override, [%Candidate.Function{name: "delegated", argument_names: ["arg1"]}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, smart_change: del|\nend")
+             )
+
+    assert {:override, [%Candidate.Module{full_name: "App.TypedChange"}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, typed_change: App|\nend")
+             )
+
+    assert {:override, [%Candidate.Snippet{label: "callback", snippet: snippet}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, call|\nend")
+             )
+
+    assert snippet =~ "fn ${1:arg1}, ${2:arg2} ->"
+  end
+
+  test "completes constraints for the selected Spark type", %{project: project} do
+    assert {:override, [%Candidate.Snippet{label: "max_length"}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :foo, :string, constraints: [max|\nend")
+             )
+
+    assert {:override, [%Candidate.Snippet{label: "max"}], []} =
+             complete(
+               project,
+               resource(
+                 "attributes do\n  attribute :foo, :string, constraints: [range: [max|\nend"
+               )
+             )
+
+    assert {:override, [%Candidate.Snippet{label: "max_length"}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :foo, My.CustomType, constraints: [max|\nend")
+             )
+  end
+
+  test "completes indexed function options", %{project: project} do
+    assert {:override, [%Candidate.Snippet{label: "upsert?", snippet: "upsert?: true"}], []} =
+             complete(project, "Ash.create(changeset, :up|)")
+
+    assert {:override, [%Candidate.Snippet{label: "upsert?", snippet: "upsert?: true"}], []} =
+             complete(project, "changeset |> Ash.create(:up|)")
+  end
+
+  test "wraps strict list candidates only when outside a list", %{project: project} do
+    assert {:override, [{%Candidate.Snippet{label: ":read"}, []}], true, []} =
+             complete_raw(project, resource("actions do\n  configure modes: [:r|]\nend"))
+
+    assert {:override, [{%Candidate.Snippet{label: ":read"}, [:wrap_list]}], true, []} =
+             complete_raw(project, resource("actions do\n  configure modes: :r|\nend"))
+
+    assert {:override, [{%Candidate.Snippet{label: ":read"}, []}], true, []} =
+             complete_raw(project, resource("actions do\n  configure flexible: :r|\nend"))
+  end
+
+  test "augments unions containing an open type", %{project: project} do
+    assert {:augment, [%Candidate.Module{full_name: "App.MyChange"}], []} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, mixed: App|\nend")
+             )
+
+    assert {:augment, [%Candidate.Module{full_name: "App.MyChange"}], [:wrap_list]} =
+             complete(
+               project,
+               resource("attributes do\n  attribute :name, :string, mixed_list: App|\nend")
+             )
+  end
+
+  test "ignores comments, strings, unrelated uses, and ordinary code", %{project: project} do
+    assert :ignore = complete(project, resource(~S["rea|"]))
+    assert :ignore = complete(project, "use Other.Library, opt|")
+    assert :ignore = complete(project, resource("def ordinary do\n  Enum.ma|\nend"))
+  end
+
+  defp complete(project, source) do
+    case complete_raw(project, source) do
+      {mode, candidates, true, transforms} ->
+        {mode, Enum.map(candidates, &elem(&1, 0)), transforms}
+
+      :ignore ->
+        :ignore
+    end
+  end
+
+  defp complete_raw(project, source) do
+    {position, document} = pop_cursor(source, as: :document)
+    analysis = Ast.analyze(document)
+    {:ok, env} = Env.new(project, analysis, position)
+    Engine.contextual_completion(env)
+  end
+
+  defp query(entries, subject, constraints, match_type) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+
+    Enum.filter(entries, fn entry ->
+      matches?(entry.subject, subject, match_type) and constraint?(entry.type, type) and
+        constraint?(entry.subtype, subtype)
+    end)
+  end
+
+  defp matches?(subject, query, :exact), do: subject == query
+  defp matches?(subject, query, :prefix), do: String.starts_with?(subject, query)
+  defp constraint?(_value, :_), do: true
+  defp constraint?(value, value), do: true
+  defp constraint?(_value, _constraint), do: false
+
+  defp resource(body, use_options \\ "") do
+    """
+    defmodule My.Resource do
+      use Ash.Resource#{use_options}
+
+      #{body}
+    end
+    """
+  end
+
+  defp spark_entries do
+    path = "/spark.ex"
+
+    [
+      Entry.integration(path, "spark", :dsl, Ash.Resource, %{
+        default_extensions: ["Elixir.Ash.Resource.Extension", "Elixir.My.DefaultDataLayer"],
+        default_extension_kinds: %{"data_layer" => ["Elixir.My.DefaultDataLayer"]},
+        extension_kinds: ["extensions", "data_layer"],
+        single_extension_kinds: ["data_layer"],
+        options: [
+          option("otp_app", :atom, "OTP application"),
+          option("enabled?", :boolean, "Enabled", false)
+        ]
+      }),
+      Entry.integration(path, "spark", :extension, Ash.Resource.Extension, %{
+        added_extensions: ["Elixir.My.AttributeExtension"],
+        patches: [],
+        sections: [
+          section("actions", [
+            entity(
+              "read",
+              [%{name: "name", optional?: false}],
+              [option("name", :atom), option("description", :string, "Description")],
+              "A read action"
+            ),
+            entity("configure", [], [
+              list_option("modes", :list),
+              list_option("flexible", :wrap_list)
+            ])
+          ])
+        ]
+      }),
+      Entry.integration(path, "spark", :extension, My.AttributeExtension, %{
+        added_extensions: [],
+        patches: [],
+        sections: [
+          section("attributes", [
+            entity(
+              "attribute",
+              [%{name: "name", optional?: false}, %{name: "type", optional?: false}],
+              [
+                option("name", :atom),
+                option("type", %{
+                  kind: :spark_type,
+                  behaviour: "Elixir.Ash.Type",
+                  aliases: %{"string" => "Elixir.Ash.Type.String"}
+                }),
+                option("constraints", :keyword_list),
+                option("change", behaviour_type()),
+                option("smart_change", spark_behaviour_type()),
+                option("typed_change", %{kind: :spark, type: "Elixir.My.Type"}),
+                option("callback", %{kind: :function, arity: 2}),
+                option("mixed", %{kind: :or, types: [%{kind: :atom}, behaviour_type()]}),
+                option("mixed_list", %{
+                  kind: :list,
+                  item: %{kind: :or, types: [%{kind: :atom}, behaviour_type()]}
+                })
+              ]
+            )
+          ])
+        ]
+      }),
+      Entry.integration(path, "spark", :extension, My.Patch, %{
+        added_extensions: [],
+        sections: [],
+        patches: [%{section_path: ["actions"], entity: entity("create", [], [])}]
+      }),
+      extension(path, My.DefaultDataLayer, [section("default_section")]),
+      extension(path, My.CustomDataLayer, [section("custom_section")]),
+      relation(path, :behaviour, "Elixir.My.Change", "Elixir.App.MyChange"),
+      relation(path, :behaviour, "Elixir.My.Change", "Elixir.App.SkippedChange", true),
+      relation(path, :behaviour, "Elixir.Ash.Type", "Elixir.Ash.Type.String", false, %{
+        constraints: [
+          option("max_length", :non_neg_integer),
+          option("range", %{
+            kind: :keyword_list,
+            options: [option("max", :non_neg_integer)]
+          })
+        ]
+      }),
+      relation(path, :behaviour, "Elixir.Ash.Type", "Elixir.My.CustomType", false, %{
+        constraints: [option("max_length", :non_neg_integer)]
+      }),
+      relation(path, :type, "Elixir.My.Type", "Elixir.App.TypedChange"),
+      Entry.integration(path, "spark", :function, "Ash.create/2/1", [
+        option("upsert?", :boolean, "Upsert", false)
+      ]),
+      indexed_callable("My.Builtins.set_attribute/2", {:function, :public}),
+      indexed_callable("My.Builtins.matches/1", {:macro, :public}),
+      indexed_callable("My.Builtins.delegated/1", {:function, :delegate})
+    ]
+  end
+
+  defp relation(path, kind, target, module, skip? \\ false, metadata \\ %{}) do
+    entry =
+      Entry.integration(
+        path,
+        "spark",
+        kind,
+        module,
+        Map.merge(metadata, %{module: module, skip?: skip?})
+      )
+
+    %Entry{entry | subject: Entry.integration_subject("spark", kind, "#{target}/#{module}")}
+  end
+
+  defp indexed_callable(subject, type) do
+    %Entry{
+      id: System.unique_integer([:positive]),
+      path: "/builtins.ex",
+      subject: subject,
+      subtype: :definition,
+      type: type
+    }
+  end
+
+  defp extension(path, module, sections) do
+    Entry.integration(path, "spark", :extension, module, %{
+      added_extensions: [],
+      patches: [],
+      sections: sections
+    })
+  end
+
+  defp section(name, entities \\ []) do
+    %{
+      name: name,
+      documentation: String.capitalize(name),
+      snippet: nil,
+      top_level?: false,
+      options: [],
+      sections: [],
+      entities: entities
+    }
+  end
+
+  defp entity(name, arguments, options, documentation \\ "") do
+    %{
+      name: name,
+      documentation: documentation,
+      snippet: nil,
+      arguments: arguments,
+      options: options,
+      entities: []
+    }
+  end
+
+  defp option(name, type, documentation \\ "", default \\ nil) do
+    %{
+      name: name,
+      documentation: documentation,
+      snippet: nil,
+      default: default,
+      type: if(is_map(type), do: type, else: %{kind: type})
+    }
+  end
+
+  defp list_option(name, kind) do
+    option(name, %{
+      kind: kind,
+      item: %{
+        kind: :choices,
+        values: [
+          %{label: ":read", insert_text: ":read"},
+          %{label: ":write", insert_text: ":write"}
+        ]
+      }
+    })
+  end
+
+  defp behaviour_type, do: %{kind: :behaviour, behaviour: "Elixir.My.Change"}
+
+  defp spark_behaviour_type do
+    %{
+      kind: :spark_behaviour,
+      behaviour: "Elixir.My.Change",
+      builtins: "My.Builtins"
+    }
+  end
+end

--- a/apps/engine/test/engine/integrations/spark/completion_test.exs
+++ b/apps/engine/test/engine/integrations/spark/completion_test.exs
@@ -243,10 +243,7 @@ defmodule Engine.Integrations.Spark.CompletionTest do
         default_extension_kinds: %{"data_layer" => ["Elixir.My.DefaultDataLayer"]},
         extension_kinds: ["extensions", "data_layer"],
         single_extension_kinds: ["data_layer"],
-        options: [
-          option("otp_app", :atom, "OTP application"),
-          option("enabled?", :boolean, "Enabled", false)
-        ]
+        options: [option("otp_app", :atom), option("enabled?", :boolean, "", false)]
       }),
       Entry.integration(path, "spark", :extension, Ash.Resource.Extension, %{
         added_extensions: ["Elixir.My.AttributeExtension"],
@@ -256,7 +253,7 @@ defmodule Engine.Integrations.Spark.CompletionTest do
             entity(
               "read",
               [%{name: "name", optional?: false}],
-              [option("name", :atom), option("description", :string, "Description")],
+              [option("name", :atom), option("description", :string)],
               "A read action"
             ),
             entity("configure", [], [
@@ -319,7 +316,7 @@ defmodule Engine.Integrations.Spark.CompletionTest do
       }),
       relation(path, :type, "Elixir.My.Type", "Elixir.App.TypedChange"),
       Entry.integration(path, "spark", :function, "Ash.create/2/1", [
-        option("upsert?", :boolean, "Upsert", false)
+        option("upsert?", :boolean, "", false)
       ]),
       indexed_callable("My.Builtins.set_attribute/2", {:function, :public}),
       indexed_callable("My.Builtins.matches/1", {:macro, :public}),

--- a/apps/engine/test/engine/integrations/spark/hover_test.exs
+++ b/apps/engine/test/engine/integrations/spark/hover_test.exs
@@ -1,0 +1,231 @@
+defmodule Engine.Integrations.Spark.HoverTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  import Forge.Test.CursorSupport
+  import Forge.Test.Fixtures
+
+  alias Forge.Ast
+  alias Forge.Ast.Env
+  alias Forge.Search.Indexer.Entry
+
+  setup do
+    project = project()
+    entries = spark_entries()
+
+    patch(Engine.ManagerApi, :search_store_exact, fn ^project, subject, constraints ->
+      {:ok, query(entries, subject, constraints, :exact)}
+    end)
+
+    patch(Engine.ManagerApi, :search_store_prefix, fn ^project, subject, constraints ->
+      {:ok, query(entries, subject, constraints, :prefix)}
+    end)
+
+    patch(Engine.ManagerApi, :search_store_all, fn _project, _constraints ->
+      flunk("Spark hover must not read the full index")
+    end)
+
+    {:ok, project: project}
+  end
+
+  test "returns indexed Spark documentation", %{project: project} do
+    for {source, expected} <- [
+          {"use Ash.Resource, otp_|app: :my_app", "OTP application"},
+          {resource("act|ions do\nend"), "Actions"},
+          {resource("actions do\n  re|ad :all\nend"), "A read action"},
+          {resource("actions do\n  tra|ce? true\nend"), "Trace actions"},
+          {resource("actions do\n  read :all do\n    desc|ription \"All\"\n  end\nend"),
+           "Description"},
+          {resource("actions do\n  cre|ate :new\nend", ", extensions: [My.Patch]"),
+           "A create action"},
+          {resource(
+             "attributes do\n  attribute :name, :string, constraints: [max_|length: 10]\nend"
+           ), "Maximum length"},
+          {resource(
+             "attributes do\n  attribute :name, :string, constraints: [range: [ma|x: 10]]\nend"
+           ), "Maximum value"},
+          {"Ash.create(record, ups|ert?: true)", "Upsert"}
+        ] do
+      assert [{^expected, range}] = hover(project, source)
+      assert range.start.line == range.end.line
+      assert range.start.character < range.end.character
+    end
+  end
+
+  test "skips integration queries for ordinary calls inside a Spark module", %{
+    project: project
+  } do
+    patch(Engine.ManagerApi, :search_store_exact, fn _project, _subject, _constraints ->
+      flunk("ordinary hover must not query Spark metadata")
+    end)
+
+    patch(Engine.ManagerApi, :search_store_prefix, fn _project, _prefix, _constraints ->
+      flunk("ordinary hover must not scan Spark extensions")
+    end)
+
+    assert [] = hover(project, resource("def ordinary, do: lo|cal_call()"))
+  end
+
+  test "does not use documentation from an unrelated nested option", %{project: project} do
+    assert [] =
+             hover(
+               project,
+               resource("attributes do\n  attribute :name, :string, constraints: [ma|x: 10]\nend")
+             )
+  end
+
+  defp hover(project, source) do
+    {position, document} = pop_cursor(source, as: :document)
+    analysis = Ast.analyze(document)
+    {:ok, env} = Env.new(project, analysis, position)
+    Engine.contextual_hover(env)
+  end
+
+  defp query(entries, subject, constraints, match_type) do
+    type = Keyword.get(constraints, :type, :_)
+    subtype = Keyword.get(constraints, :subtype, :_)
+
+    Enum.filter(entries, fn entry ->
+      matches?(entry.subject, subject, match_type) and
+        constraint?(entry.type, type) and constraint?(entry.subtype, subtype)
+    end)
+  end
+
+  defp matches?(subject, query, :exact), do: subject == query
+  defp matches?(subject, query, :prefix), do: String.starts_with?(subject, query)
+  defp constraint?(_value, :_), do: true
+  defp constraint?(value, value), do: true
+  defp constraint?(_value, _constraint), do: false
+
+  defp resource(body, use_options \\ "") do
+    """
+    defmodule My.Resource do
+      use Ash.Resource#{use_options}
+
+      #{body}
+    end
+    """
+  end
+
+  defp spark_entries do
+    path = "/spark.ex"
+
+    [
+      Entry.integration(path, "spark", :dsl, Ash.Resource, %{
+        default_extensions: ["Elixir.Ash.Resource.Extension"],
+        default_extension_kinds: %{},
+        extension_kinds: ["extensions"],
+        single_extension_kinds: [],
+        options: [option("otp_app", "OTP application")]
+      }),
+      Entry.integration(path, "spark", :extension, Ash.Resource.Extension, %{
+        added_extensions: ["Elixir.My.AttributeExtension"],
+        patches: [],
+        sections: [
+          section(
+            "actions",
+            [
+              entity("read", [option("description", "Description")], "A read action")
+            ],
+            [option("trace?", "Trace actions")]
+          )
+        ]
+      }),
+      Entry.integration(path, "spark", :extension, My.AttributeExtension, %{
+        added_extensions: [],
+        patches: [],
+        sections: [
+          section("attributes", [
+            %{
+              entity("attribute", [
+                %{
+                  option("type")
+                  | type: %{
+                      kind: :spark_type,
+                      behaviour: "Elixir.Ash.Type",
+                      aliases: %{"string" => "Elixir.Ash.Type.String"}
+                    }
+                }
+              ])
+              | arguments: [
+                  %{name: "name", optional?: false},
+                  %{name: "type", optional?: false}
+                ]
+            }
+          ])
+        ]
+      }),
+      Entry.integration(path, "spark", :extension, My.Patch, %{
+        added_extensions: [],
+        sections: [],
+        patches: [
+          %{section_path: ["actions"], entity: entity("create", [], "A create action")}
+        ]
+      }),
+      relation(path, "Elixir.Ash.Type", "Elixir.Ash.Type.String", %{
+        constraints: [
+          option("max_length", "Maximum length"),
+          %{
+            option("range")
+            | type: %{
+                kind: :keyword_list,
+                options: [option("max", "Maximum value")]
+              }
+          }
+        ]
+      }),
+      Entry.integration(path, "spark", :function, "Ash.create/2/1", [
+        option("upsert?", "Upsert")
+      ])
+    ]
+  end
+
+  defp relation(path, target, module, metadata) do
+    entry =
+      Entry.integration(
+        path,
+        "spark",
+        :behaviour,
+        module,
+        Map.merge(metadata, %{module: module, skip?: false})
+      )
+
+    %Entry{
+      entry
+      | subject: Entry.integration_subject("spark", :behaviour, "#{target}/#{module}")
+    }
+  end
+
+  defp section(name, entities, options \\ []) do
+    %{
+      name: name,
+      documentation: String.capitalize(name),
+      snippet: nil,
+      top_level?: false,
+      options: options,
+      sections: [],
+      entities: entities
+    }
+  end
+
+  defp entity(name, options, documentation \\ "") do
+    %{
+      name: name,
+      documentation: documentation,
+      snippet: nil,
+      arguments: [],
+      options: options,
+      entities: []
+    }
+  end
+
+  defp option(name, documentation \\ "") do
+    %{
+      name: name,
+      documentation: documentation,
+      snippet: nil,
+      default: nil,
+      type: %{kind: :atom}
+    }
+  end
+end

--- a/apps/engine/test/engine/integrations/spark/indexer_test.exs
+++ b/apps/engine/test/engine/integrations/spark/indexer_test.exs
@@ -1,0 +1,499 @@
+defmodule Engine.Integrations.Spark.IndexerTest do
+  use ExUnit.Case, async: false
+
+  alias Engine.Integrations
+  alias Forge.Search.Indexer.Entry
+
+  setup_all do
+    if !Code.ensure_loaded?(Spark.Dsl.Extension) do
+      Code.compile_string("""
+      defmodule Spark.Dsl.Extension do
+        @callback sections() :: list()
+        @callback dsl_patches() :: list()
+        @callback add_extensions() :: list()
+      end
+      """)
+
+      on_exit(fn ->
+        :code.purge(Spark.Dsl.Extension)
+        :code.delete(Spark.Dsl.Extension)
+      end)
+    end
+
+    :ok
+  end
+
+  @tag :tmp_dir
+  test "indexes DSL sections, entities, options, values, and documentation", %{tmp_dir: tmp_dir} do
+    start_supervised!(Engine.ApplicationCache)
+
+    compiler_options = Code.compiler_options()
+    Code.compiler_options(debug_info: true)
+    on_exit(fn -> Code.compiler_options(compiler_options) end)
+
+    suffix = System.unique_integer([:positive])
+    dsl = Module.concat(__MODULE__, "Dsl#{suffix}")
+    extension = Module.concat(__MODULE__, "Extension#{suffix}")
+
+    [{^extension, extension_binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(extension)} do
+        @behaviour Spark.Dsl.Extension
+
+        def add_extensions, do: []
+
+        def sections do
+          [
+            %{
+              name: :attributes,
+              docs: "Attribute definitions",
+              entities: [
+                %{
+                  name: :attribute,
+                  docs: "Declares an attribute",
+                   args: [:name, :type],
+                   schema: [
+                    type: [type: {:spark_type, #{inspect(dsl)}, :builtins, []}],
+                    constraints: [
+                      type: :keyword_list,
+                      keys: [max_length: [type: :non_neg_integer]]
+                    ],
+                    private?: [type: :boolean, default: false],
+                    mode: [type: {:one_of, [:read, :write]}]
+                  ]
+                }
+              ]
+            }
+          ]
+        end
+
+        def dsl_patches do
+          [%{section_path: [:attributes], entity: %{name: :calculation, args: [], schema: []}}]
+        end
+      end
+      """)
+
+    [{^dsl, dsl_binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(dsl)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        Module.register_attribute(__MODULE__, :spark_default_extensions, persist: true)
+        Module.register_attribute(__MODULE__, :spark_extension_kinds, persist: true)
+        @spark_dsl true
+        @spark_default_extensions [#{inspect(extension)}]
+        @spark_extension_kinds [:extensions]
+
+        def default_extensions, do: [#{inspect(extension)}]
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+        def short_names, do: [string: #{inspect(extension)}]
+        def opt_schema, do: [otp_app: [type: :atom, doc: "OTP application"]]
+      end
+      """)
+
+    extension_metadata =
+      extension_binary
+      |> index(extension, Path.join(tmp_dir, "extension.ex"))
+      |> metadata(Entry.integration_subject("spark", :extension, extension))
+
+    assert [%{name: "attributes", documentation: "Attribute definitions", entities: [entity]}] =
+             extension_metadata.sections
+
+    assert entity.name == "attribute"
+    assert entity.documentation == "Declares an attribute"
+    assert Enum.map(entity.arguments, & &1.name) == ["name", "type"]
+
+    assert entity.options |> Enum.find(&(&1.name == "type")) |> Map.fetch!(:type) == %{
+             kind: :spark_type,
+             behaviour: Atom.to_string(dsl),
+             aliases: %{"string" => Atom.to_string(extension)}
+           }
+
+    assert %{
+             kind: :keyword_list,
+             options: [
+               %{name: "max_length", type: %{kind: :unknown, value: ":non_neg_integer"}}
+             ]
+           } = entity.options |> Enum.find(&(&1.name == "constraints")) |> Map.fetch!(:type)
+
+    assert Enum.find(entity.options, &(&1.name == "private?")).type == %{kind: :boolean}
+
+    assert Enum.find(entity.options, &(&1.name == "mode")).type == %{
+             kind: :choices,
+             values: [
+               %{label: ":read", insert_text: ":read"},
+               %{label: ":write", insert_text: ":write"}
+             ]
+           }
+
+    assert [%{section_path: ["attributes"], entity: %{name: "calculation"}}] =
+             extension_metadata.patches
+
+    dsl_metadata =
+      dsl_binary
+      |> index(dsl, Path.join(tmp_dir, "dsl.ex"))
+      |> metadata(Entry.integration_subject("spark", :dsl, dsl))
+
+    assert dsl_metadata.default_extensions == [Atom.to_string(extension)]
+    assert dsl_metadata.extension_kinds == ["extensions"]
+
+    assert [%{name: "otp_app", documentation: "OTP application", type: %{kind: :atom}}] =
+             dsl_metadata.options
+  end
+
+  test "does not replace a module already loaded by the engine" do
+    module = Module.concat(__MODULE__, "Loaded#{System.unique_integer([:positive])}")
+    compiler_options = Code.compiler_options()
+    Code.compiler_options(ignore_module_conflict: true)
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, original_binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+        def opt_schema, do: [source: [type: {:literal, :loaded}]]
+        def marker, do: :original
+      end
+      """)
+
+    [{^module, spark_binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+        def opt_schema, do: [source: [type: {:literal, :indexed}]]
+      end
+      """)
+
+    :code.purge(module)
+    :code.delete(module)
+    assert {:module, ^module} = :code.load_binary(module, ~c"original", original_binary)
+
+    assert [] = index(spark_binary, module, "loaded.ex")
+    assert module.marker() == :original
+  end
+
+  @tag :tmp_dir
+  test "reloads updated metadata from the same dependency BEAM", %{tmp_dir: tmp_dir} do
+    module = Module.concat(__MODULE__, "Updated#{System.unique_integer([:positive])}")
+    beam_path = Path.join(tmp_dir, Atom.to_string(module) <> ".beam")
+    code_path = String.to_charlist(tmp_dir)
+    compiler_options = Code.compiler_options()
+    Code.compiler_options(ignore_module_conflict: true)
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+      :code.purge(module)
+      :code.delete(module)
+      :code.del_path(code_path)
+    end)
+
+    [{^module, original_binary}] =
+      Code.compile_string(dsl_source(module, :original))
+
+    [{^module, updated_binary}] =
+      Code.compile_string(dsl_source(module, :updated))
+
+    File.write!(beam_path, original_binary)
+    true = :code.add_patha(code_path)
+    :code.purge(module)
+    :code.delete(module)
+    assert {:module, ^module} = Code.ensure_loaded(module)
+
+    File.write!(beam_path, updated_binary)
+
+    assert %{options: [%{type: %{values: [%{label: ":updated"}]}}]} =
+             updated_binary
+             |> index(module, "updated.ex")
+             |> metadata(Entry.integration_subject("spark", :dsl, module))
+  end
+
+  test "rejects malformed callback metadata without crashing" do
+    module = Module.concat(__MODULE__, "Malformed#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: [:invalid]
+        def single_extension_kinds, do: []
+        def opt_schema, do: []
+      end
+      """)
+
+    assert [] = index(binary, module, "malformed.ex")
+  end
+
+  @tag :tmp_dir
+  test "loads matching dependency modules to index their documentation", %{tmp_dir: tmp_dir} do
+    module = Module.concat(__MODULE__, "Unloaded#{System.unique_integer([:positive])}")
+    beam_path = Path.join(tmp_dir, Atom.to_string(module) <> ".beam")
+    code_path = String.to_charlist(tmp_dir)
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+      :code.del_path(code_path)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+        def opt_schema, do: [source: [type: :atom, doc: "Source documentation"]]
+      end
+      """)
+
+    File.write!(beam_path, binary)
+    true = :code.add_patha(code_path)
+    :code.purge(module)
+    :code.delete(module)
+
+    assert false == :code.is_loaded(module)
+
+    assert %{options: [%{name: "source", documentation: "Source documentation"}]} =
+             binary
+             |> index(module, "unloaded.ex")
+             |> metadata(Entry.integration_subject("spark", :dsl, module))
+
+    assert {:file, _path} = :code.is_loaded(module)
+  end
+
+  test "drops malformed section nodes" do
+    module = Module.concat(__MODULE__, "MalformedSections#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        @behaviour Spark.Dsl.Extension
+
+        def add_extensions, do: []
+        def sections, do: [:invalid]
+        def dsl_patches, do: []
+      end
+      """)
+
+    assert %{sections: []} =
+             binary
+             |> index(module, "malformed_sections.ex")
+             |> metadata(Entry.integration_subject("spark", :extension, module))
+  end
+
+  test "times out callbacks without exiting the caller" do
+    module = Module.concat(__MODULE__, "SlowCallback#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+        def opt_schema, do: Process.sleep(:infinity)
+      end
+      """)
+
+    assert [] = index(binary, module, "slow_callback.ex")
+  end
+
+  test "stops callback work when the indexing caller exits" do
+    suffix = System.unique_integer([:positive])
+    module = Module.concat(__MODULE__, "OwnedCallback#{suffix}")
+    receiver = String.to_atom("spark_indexer_test_#{suffix}")
+    Process.register(self(), receiver)
+
+    on_exit(fn ->
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+        @spark_dsl true
+
+        def default_extensions, do: []
+        def default_extension_kinds, do: []
+        def single_extension_kinds, do: []
+
+        def opt_schema do
+          send(Process.whereis(#{inspect(receiver)}), {:callback, self()})
+          Process.sleep(:infinity)
+        end
+      end
+      """)
+
+    caller = spawn(fn -> index(binary, module, "owned_callback.ex") end)
+    assert_receive {:callback, callback}
+    monitor = Process.monitor(callback)
+
+    Process.exit(caller, :kill)
+
+    assert_receive {:DOWN, ^monitor, :process, ^callback, _reason}
+  end
+
+  test "indexes behaviour and Spark type relations with the skip decision" do
+    suffix = System.unique_integer([:positive])
+    behaviour = Module.concat(__MODULE__, "Behaviour#{suffix}")
+    type = Module.concat(__MODULE__, "Type#{suffix}")
+    included = Module.concat(__MODULE__, "Included#{suffix}")
+    skipped = Module.concat(__MODULE__, "Skipped#{suffix}")
+
+    modules = [behaviour, included, skipped]
+
+    on_exit(fn ->
+      Enum.each(modules, fn module ->
+        :code.purge(module)
+        :code.delete(module)
+      end)
+    end)
+
+    binaries =
+      """
+      defmodule #{inspect(behaviour)} do
+        @callback run() :: term()
+      end
+
+      defmodule #{inspect(included)} do
+        @behaviour #{inspect(behaviour)}
+        Module.register_attribute(__MODULE__, :spark_is, persist: true)
+        @spark_is #{inspect(type)}
+        def run, do: :ok
+        def constraints, do: [max_length: [type: :non_neg_integer]]
+        def skip_in_spark_autocomplete, do: false
+      end
+
+      defmodule #{inspect(skipped)} do
+        @behaviour #{inspect(behaviour)}
+        def run, do: :ok
+        def skip_in_spark_autocomplete, do: true
+      end
+      """
+      |> Code.compile_string()
+      |> Map.new()
+
+    included_entries = index(Map.fetch!(binaries, included), included, "included.ex")
+    skipped_entries = index(Map.fetch!(binaries, skipped), skipped, "skipped.ex")
+
+    included_relation =
+      Entry.integration_subject(
+        "spark",
+        :behaviour,
+        "#{Atom.to_string(behaviour)}/#{Atom.to_string(included)}"
+      )
+
+    skipped_relation =
+      Entry.integration_subject(
+        "spark",
+        :behaviour,
+        "#{Atom.to_string(behaviour)}/#{Atom.to_string(skipped)}"
+      )
+
+    type_relation =
+      Entry.integration_subject(
+        "spark",
+        :type,
+        "#{Atom.to_string(type)}/#{Atom.to_string(included)}"
+      )
+
+    assert %{module: module, skip?: false, constraints: [%{name: "max_length"}]} =
+             metadata(included_entries, included_relation)
+
+    assert module == Atom.to_string(included)
+    assert %{module: module, skip?: true} = metadata(skipped_entries, skipped_relation)
+    assert module == Atom.to_string(skipped)
+    assert %{module: module} = metadata(included_entries, type_relation)
+    assert module == Atom.to_string(included)
+  end
+
+  test "indexes EEP-48 function option schemas for callable arities" do
+    module = Module.concat(__MODULE__, "Functions#{System.unique_integer([:positive])}")
+    compiler_options = Code.compiler_options()
+    Code.compiler_options(docs: true)
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+      :code.purge(module)
+      :code.delete(module)
+    end)
+
+    [{^module, binary}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        @doc "Creates a value"
+        @doc spark_opts: [{1, [upsert?: [type: :boolean, default: false]]}]
+        def create(value, params \\\\ %{}, opts \\\\ []), do: {value, params, opts}
+      end
+      """)
+
+    entries = index(binary, module, "functions.ex")
+    function = &Entry.integration_subject("spark", :function, &1)
+
+    assert [%{name: "upsert?", type: %{kind: :boolean}}] =
+             metadata(entries, function.("#{Forge.Formats.mfa(module, :create, 2)}/1"))
+  end
+
+  defp index(binary, module, source_path) do
+    {:ok, {^module, [attributes: attributes]}} = :beam_lib.chunks(binary, [:attributes])
+    Integrations.index_beam(binary, %{module: module, attributes: attributes}, source_path)
+  end
+
+  defp dsl_source(module, value) do
+    """
+    defmodule #{inspect(module)} do
+      Module.register_attribute(__MODULE__, :spark_dsl, persist: true)
+      @spark_dsl true
+
+      def default_extensions, do: []
+      def default_extension_kinds, do: []
+      def single_extension_kinds, do: []
+      def opt_schema, do: [source: [type: {:literal, #{inspect(value)}}]]
+    end
+    """
+  end
+
+  defp metadata(entries, subject) do
+    assert %Entry{metadata: %{payload: payload}} = Enum.find(entries, &(&1.subject == subject))
+    payload
+  end
+end

--- a/apps/engine/test/engine/search/indexer/beams_test.exs
+++ b/apps/engine/test/engine/search/indexer/beams_test.exs
@@ -4,6 +4,7 @@ defmodule Engine.Search.Indexer.BeamsTest do
 
   import Forge.Test.RangeSupport
 
+  alias Engine.Compilation.TraceBuffer
   alias Engine.Search.Indexer.Beams
   alias Forge.Formats
   alias Forge.Search.Indexer.Entry
@@ -129,6 +130,47 @@ defmodule Engine.Search.Indexer.BeamsTest do
       assert start_pos.valid?
       assert start_pos.document_line_count >= start_pos.line
       assert start_pos.context_line != nil
+    end
+
+    test "extracts integration entries from compiler trace binaries", %{tmp_dir: tmp_dir} do
+      start_supervised!(TraceBuffer)
+      suffix = System.unique_integer([:positive])
+      behaviour = unique_module("TraceBehaviour#{suffix}")
+      implementation = unique_module("TraceImplementation#{suffix}")
+
+      %{beam_paths_by_module: beam_paths_by_module, source_path: source_path} =
+        compile_source!(
+          tmp_dir,
+          """
+          defmodule #{inspect(behaviour)} do
+            @callback run() :: term()
+          end
+
+          defmodule #{inspect(implementation)} do
+            @behaviour #{inspect(behaviour)}
+            def run, do: :ok
+          end
+          """,
+          expected_modules: [behaviour, implementation],
+          rewrite_source?: false
+        )
+
+      binary = beam_paths_by_module |> Map.fetch!(implementation) |> File.read!()
+      assert :ok = TraceBuffer.record_module(source_path, binary)
+      native_source_path = Forge.Path.native(source_path)
+      assert {:ok, %{^native_source_path => entries}} = TraceBuffer.drain_definitions()
+
+      relation =
+        Entry.integration_subject(
+          "spark",
+          :behaviour,
+          "#{Atom.to_string(behaviour)}/#{Atom.to_string(implementation)}"
+        )
+
+      assert %Entry{subject: ^relation, metadata: %{payload: %{module: module}}} =
+               Enum.find(entries, &(&1.subject == relation))
+
+      assert module == Atom.to_string(implementation)
     end
 
     test "synthesizes contextual ranges for macro-generated definitions from beam metadata", %{

--- a/apps/engine/test/engine/search/indexer/manifest_store_test.exs
+++ b/apps/engine/test/engine/search/indexer/manifest_store_test.exs
@@ -151,14 +151,49 @@ defmodule Engine.Search.Indexer.ManifestStoreTest do
     end
   end
 
-  describe "invalidate/1" do
-    test "removes the committed manifest", %{tmp_dir: tmp_dir} do
+  describe "integrations" do
+    test "are changed until the current module names are recorded", %{tmp_dir: tmp_dir} do
       project = project(tmp_dir)
 
+      assert ManifestStore.integrations_changed?(project)
+
       :ok = ManifestStore.commit(project, manifest(tmp_dir))
+      assert ManifestStore.integrations_changed?(project)
+
+      :ok = ManifestStore.record_integrations(project)
+      refute ManifestStore.integrations_changed?(project)
+    end
+
+    test "are changed when the recorded module names differ", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      :ok = ManifestStore.commit(project, manifest(tmp_dir))
+      :ok = ManifestStore.record_integrations(project)
+
+      integrations_path =
+        Path.join(
+          Project.workspace_path(project, ["indexes", "manifest"]),
+          "integrations.etf"
+        )
+
+      File.write!(integrations_path, :erlang.term_to_binary(["Engine.Integrations.Removed"]))
+
+      assert ManifestStore.integrations_changed?(project)
+    end
+  end
+
+  describe "invalidate/1" do
+    test "removes the committed manifest and recorded integrations", %{tmp_dir: tmp_dir} do
+      project = project(tmp_dir)
+      manifest = manifest(tmp_dir)
+
+      :ok = ManifestStore.commit(project, manifest)
+      :ok = ManifestStore.record_integrations(project)
       :ok = ManifestStore.invalidate(project)
 
       assert ManifestStore.load(project) == :missing
+
+      :ok = ManifestStore.commit(project, manifest)
+      assert ManifestStore.integrations_changed?(project)
     end
   end
 

--- a/apps/engine/test/engine/search/indexer_test.exs
+++ b/apps/engine/test/engine/search/indexer_test.exs
@@ -57,6 +57,7 @@ defmodule Engine.Search.IndexerTest do
   defp create_index(project) do
     assert {:ok, entries, manifest} = Indexer.create_index(project)
     assert :ok = Indexer.commit_manifest(project, manifest)
+    assert :ok = ManifestStore.record_integrations(project)
     entries
   end
 
@@ -65,6 +66,7 @@ defmodule Engine.Search.IndexerTest do
              Indexer.update_index(project, path_to_ids)
 
     assert :ok = Indexer.commit_manifest(project, manifest)
+    assert :ok = ManifestStore.record_integrations(project)
     {entries, paths_to_clear}
   end
 
@@ -526,6 +528,25 @@ defmodule Engine.Search.IndexerTest do
 
       assert {:error, :commit_failed} = Indexer.commit_manifest(project, manifest)
       assert {:ok, ^old_manifest} = ManifestStore.load(project)
+    end
+  end
+
+  describe "update_index/2 indexer changes" do
+    @tag :tmp_dir
+    test "replaces an unchanged index when recorded integrations are missing", %{tmp_dir: tmp_dir} do
+      source_file = native_join([tmp_dir, "lib", "source_file.ex"])
+      write_file!(source_file, "defmodule IntegrationStampSource do end")
+      project = tmp_dir |> Forge.Document.Path.to_uri() |> Project.bare()
+
+      assert {:ok, initial_entries, manifest} = Indexer.create_index(project)
+      assert :ok = Indexer.commit_manifest(project, manifest)
+
+      path_to_ids = Map.new(initial_entries, &{&1.path, 1})
+
+      assert {:ok, replacement_entries, _paths_to_clear, _manifest} =
+               Indexer.update_index(project, path_to_ids)
+
+      assert Enum.any?(replacement_entries, &(&1.subject == IntegrationStampSource))
     end
   end
 

--- a/apps/expert/lib/expert/code_intelligence/completion.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion.ex
@@ -8,6 +8,8 @@ defmodule Expert.CodeIntelligence.Completion do
   alias Forge.Ast.Analysis
   alias Forge.Ast.Env
   alias Forge.Completion.Candidate
+  alias Forge.Document.Changes
+  alias Forge.Document.Edit
   alias Forge.Document.Position
   alias Forge.Project
   alias GenLSP.Enumerations.CompletionTriggerKind
@@ -42,11 +44,11 @@ defmodule Expert.CodeIntelligence.Completion do
           end
 
         hex_items = hex_items_for_context(hex_context, project, env)
-        regular_items = completions(project, env, context)
+        {regular_items, contextual_incomplete?} = completions(project, env, context)
         all = hex_items ++ regular_items
         log_candidates(all)
 
-        if hex_context do
+        if not is_nil(hex_context) or contextual_incomplete? do
           %CompletionList{items: all, is_incomplete: true}
         else
           maybe_to_completion_list(all)
@@ -80,6 +82,49 @@ defmodule Expert.CodeIntelligence.Completion do
   end
 
   defp completions(%Project{} = project, %Env{} = env, %CompletionContext{} = context) do
+    case EngineApi.contextual_completion(project, env) do
+      {:override, candidates, incomplete?, _transforms} ->
+        {translate_contextual_candidates(candidates, env), incomplete?}
+
+      {:augment, candidates, incomplete?, transforms} ->
+        contextual_items = translate_contextual_candidates(candidates, env)
+        ordinary_items = project |> ordinary_completions(env, context) |> transform(transforms)
+        augment(contextual_items, ordinary_items, incomplete?)
+
+      :ignore ->
+        {ordinary_completions(project, env, context), false}
+    end
+  end
+
+  defp translate_contextual_candidates(candidates, env) do
+    Enum.flat_map(candidates, fn {candidate, transforms} ->
+      case Translatable.translate(candidate, Builder, env) do
+        :skip -> []
+        items -> items |> List.wrap() |> transform(transforms)
+      end
+    end)
+  end
+
+  defp transform(items, transforms) do
+    Enum.reduce(transforms, items, fn
+      :wrap_list, items -> Enum.map(items, &wrap_list_item/1)
+    end)
+  end
+
+  defp wrap_list_item(
+         %CompletionItem{text_edit: %Changes{edits: %Edit{text: text} = edit} = changes} = item
+       ) do
+    %CompletionItem{item | text_edit: %Changes{changes | edits: %Edit{edit | text: "[#{text}]"}}}
+  end
+
+  defp wrap_list_item(item), do: item
+
+  defp augment(items, ordinary_items, incomplete?) do
+    items = Enum.map(items, &Builder.set_sort_scope(&1, "000"))
+    {Enum.uniq_by(items ++ ordinary_items, &{&1.label, &1.kind}), incomplete?}
+  end
+
+  defp ordinary_completions(project, env, context) do
     prefix_tokens = Env.prefix_tokens(env, 1)
 
     cond do

--- a/apps/expert/lib/expert/code_intelligence/completion/translations/snippet.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion/translations/snippet.ex
@@ -1,0 +1,25 @@
+defmodule Expert.CodeIntelligence.Completion.Translations.Snippet do
+  alias Expert.CodeIntelligence.Completion.Translatable
+  alias Forge.Ast.Env
+  alias Forge.Completion.Candidate
+  alias GenLSP.Enumerations.CompletionItemKind
+
+  defimpl Translatable, for: Candidate.Snippet do
+    def translate(%{priority: :contextual} = snippet, builder, %Env{} = env) do
+      builder.snippet(env, snippet.snippet,
+        detail: snippet.detail,
+        documentation: snippet.documentation,
+        filter_text: snippet.filter_text,
+        kind: kind(snippet.kind),
+        label: snippet.label
+      )
+    end
+
+    def translate(_snippet, _builder, _env), do: :skip
+
+    defp kind(:function), do: CompletionItemKind.function()
+    defp kind(:field), do: CompletionItemKind.field()
+    defp kind(:enum_member), do: CompletionItemKind.enum_member()
+    defp kind(_kind), do: CompletionItemKind.snippet()
+  end
+end

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -90,6 +90,10 @@ defmodule Expert.EngineApi do
     call(project, Engine, :contextual_completion, [env])
   end
 
+  def contextual_hover(%Project{} = project, %Env{} = env) do
+    call(project, Engine, :contextual_hover, [env])
+  end
+
   def complete_struct_fields(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
     call(project, Engine, :complete_struct_fields, [
       analysis,

--- a/apps/expert/lib/expert/engine_api.ex
+++ b/apps/expert/lib/expert/engine_api.ex
@@ -86,6 +86,10 @@ defmodule Expert.EngineApi do
     call(project, Engine, :complete, [env])
   end
 
+  def contextual_completion(%Project{} = project, %Env{} = env) do
+    call(project, Engine, :contextual_completion, [env])
+  end
+
   def complete_struct_fields(%Project{} = project, %Analysis{} = analysis, %Position{} = position) do
     call(project, Engine, :complete_struct_fields, [
       analysis,

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -184,19 +184,12 @@ defmodule Expert.Project.Indexer do
   end
 
   defp missing_trace_entries(current_entries, trace_batch) do
-    current_keys =
-      current_entries
-      |> Enum.filter(&definition?/1)
-      |> MapSet.new(&definition_identity/1)
-
-    trace_entries =
-      trace_batch
-      |> Enum.flat_map(fn {_path, entries} -> entries end)
-      |> Enum.filter(&definition?/1)
+    current_keys = MapSet.new(current_entries, &entry_identity/1)
+    trace_entries = Enum.flat_map(trace_batch, fn {_path, entries} -> entries end)
 
     {_keys, missing_entries} =
       Enum.reduce(trace_entries, {current_keys, []}, fn entry, {keys, entries} ->
-        key = definition_identity(entry)
+        key = entry_identity(entry)
 
         if MapSet.member?(keys, key),
           do: {keys, entries},
@@ -206,11 +199,8 @@ defmodule Expert.Project.Indexer do
     Enum.reverse(missing_entries)
   end
 
-  defp definition?(%{subtype: :definition}), do: true
-  defp definition?(_entry), do: false
-
-  defp definition_identity(%{path: path, subject: subject, subtype: :definition, type: type}) do
-    {path, subject, :definition, type}
+  defp entry_identity(%{path: path, subject: subject, subtype: subtype, type: type}) do
+    {path, subject, subtype, type}
   end
 
   defp persist_index(%Project{} = project, :empty, create_index, _update_index) do

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -94,7 +94,7 @@ defmodule Expert.Project.Indexer do
   @impl GenServer
   def handle_info(project_compiled(status: status), %State{} = state)
       when status in [:success, :successful, :error] do
-    trace_batch = if status == :error, do: %{}, else: drain_trace_definitions(state)
+    trace_batch = if status != :error, do: drain_trace_definitions(state)
     state = %State{state | trace_batch: trace_batch}
     {:noreply, start_or_queue_index(state)}
   end
@@ -134,12 +134,15 @@ defmodule Expert.Project.Indexer do
   defp complete_index(%State{} = state, :ok) do
     state = %State{state | task: nil}
 
-    case apply_trace_definitions(state.project, state.trace_batch) do
+    state.project
+    |> apply_trace_definitions(state.trace_batch)
+    |> record_integrations(state)
+    |> case do
       :ok ->
         broadcast_index_ready(state)
 
       {:error, reason} ->
-        Logger.warning("Could not apply compiler trace index supplement: #{inspect(reason)}")
+        Logger.warning("Could not finalize search index: #{inspect(reason)}")
         broadcast_index_ready(state)
     end
   end
@@ -159,6 +162,13 @@ defmodule Expert.Project.Indexer do
     %State{state | trace_batch: nil}
   end
 
+  defp record_integrations(:ok, %State{trace_batch: trace_batch} = state)
+       when is_map(trace_batch),
+       do: Search.Indexer.record_integrations(state.project)
+
+  defp record_integrations(:ok, %State{}), do: :ok
+  defp record_integrations(error, %State{}), do: error
+
   defp drain_trace_definitions(%State{project: project}) do
     case EngineApi.call(project, Engine.Compilation.TraceBuffer, :drain_definitions, []) do
       {:ok, entries_by_path} when is_map(entries_by_path) ->
@@ -166,10 +176,11 @@ defmodule Expert.Project.Indexer do
 
       {:error, reason} ->
         Logger.warning("Could not drain compiler trace index supplement: #{inspect(reason)}")
-        %{}
+        nil
     end
   end
 
+  defp apply_trace_definitions(_project, nil), do: :ok
   defp apply_trace_definitions(_project, trace_batch) when map_size(trace_batch) == 0, do: :ok
 
   defp apply_trace_definitions(%Project{} = project, trace_batch) when is_map(trace_batch) do

--- a/apps/expert/lib/expert/provider/handlers/hover.ex
+++ b/apps/expert/lib/expert/provider/handlers/hover.ex
@@ -8,6 +8,7 @@ defmodule Expert.Provider.Handlers.Hover do
   alias Expert.Search.Store
   alias Forge.Ast
   alias Forge.Ast.Analysis
+  alias Forge.Ast.Env
   alias Forge.CodeIntelligence.Docs
   alias Forge.Document
   alias Forge.Document.Position
@@ -26,27 +27,63 @@ defmodule Expert.Provider.Handlers.Hover do
     maybe_hover =
       with {:ok, _document, %Ast.Analysis{} = analysis} <-
              Document.Store.fetch(document.uri, :analysis),
-           nil <- hex_hover(document, analysis, params.position, project),
-           {:ok, entity, range} <- resolve_entity(project, analysis, params.position),
-           {:ok, markdown} <- hover_content(entity, project) do
-        content = Markdown.to_content(markdown)
-        %Structures.Hover{contents: content, range: range}
+           nil <- hex_hover(document, analysis, params.position, project) do
+        integration_hovers = integration_hovers(project, analysis, params.position)
+        generic_hover = generic_hover(project, document, analysis, params.position)
+        combine_hovers(integration_hovers, generic_hover)
       else
         %Structures.Hover{} = hover ->
           hover
 
-        {:error, reason} when reason in [:no_code, :no_doc, :no_type] ->
-          nil
-
-        :error ->
-          nil
-
         _ ->
-          try_elixir_sense(project, document, params.position)
+          combine_hovers([], elixir_sense_hover(project, document, params.position))
       end
 
     {:ok, maybe_hover}
   end
+
+  defp integration_hovers(project, analysis, position) do
+    case Env.new(project, analysis, position) do
+      {:ok, env} -> EngineApi.contextual_hover(project, env)
+      _ -> []
+    end
+  end
+
+  defp generic_hover(project, document, analysis, position) do
+    with {:ok, entity, range} <- resolve_entity(project, analysis, position),
+         {:ok, markdown} <- hover_content(entity, project) do
+      {:ok, markdown, range}
+    else
+      {:error, reason} when reason in [:no_code, :no_doc, :no_type] -> nil
+      :error -> nil
+      _ -> elixir_sense_hover(project, document, position)
+    end
+  end
+
+  defp combine_hovers(integration_hovers, generic_hover) do
+    hovers =
+      integration_hovers
+      |> prepend_hover(generic_hover)
+      |> Enum.uniq_by(&elem(&1, 0))
+
+    case hovers do
+      [] ->
+        nil
+
+      [{markdown, range}] ->
+        %Structures.Hover{contents: Markdown.to_content(markdown), range: range}
+
+      hovers ->
+        markdown =
+          hovers |> Enum.map(&elem(&1, 0)) |> Markdown.join_sections(Markdown.separator())
+
+        range = hovers |> List.first() |> elem(1)
+        %Structures.Hover{contents: Markdown.to_content(markdown), range: range}
+    end
+  end
+
+  defp prepend_hover(hovers, {:ok, markdown, range}), do: [{markdown, range} | hovers]
+  defp prepend_hover(hovers, nil), do: hovers
 
   defp hex_hover(%Document{} = document, analysis, %Position{} = position, project) do
     with true <- Hex.project_file?(project, document),
@@ -61,14 +98,10 @@ defmodule Expert.Provider.Handlers.Hover do
     EngineApi.resolve_entity(project, analysis, position)
   end
 
-  defp try_elixir_sense(project, document, position) do
+  defp elixir_sense_hover(project, document, position) do
     case EngineApi.hover(project, document, position) do
-      {:ok, markdown, range} ->
-        content = Markdown.to_content(markdown)
-        %Structures.Hover{contents: content, range: range}
-
-      {:error, _} ->
-        nil
+      {:ok, markdown, range} -> {:ok, markdown, range}
+      {:error, _} -> nil
     end
   end
 

--- a/apps/expert/lib/expert/search/indexer.ex
+++ b/apps/expert/lib/expert/search/indexer.ex
@@ -18,6 +18,15 @@ defmodule Expert.Search.Indexer do
     end
   end
 
+  def record_integrations(%Project{} = project) do
+    EngineApi.call(
+      project,
+      Engine.Search.Indexer,
+      :record_integrations,
+      [project]
+    )
+  end
+
   defp commit_manifest(%Project{} = project, manifest) do
     EngineApi.call(project, Engine.Search.Indexer, :commit_manifest, [project, manifest])
   end

--- a/apps/expert/lib/expert/search/store/backends/sqlite.ex
+++ b/apps/expert/lib/expert/search/store/backends/sqlite.ex
@@ -11,7 +11,7 @@ defmodule Expert.Search.Store.Backends.Sqlite do
   require Entry
   require Logger
 
-  @schema_version 3
+  @schema_version 4
   @database_file "source.index.sqlite3"
   @slow_query_threshold_ms 500
   # NOTE(doorgan): SQLite has a variable limit of 32766. Entry batches use 7 params

--- a/apps/expert/test/expert/code_intelligence/completion/contextual_test.exs
+++ b/apps/expert/test/expert/code_intelligence/completion/contextual_test.exs
@@ -1,0 +1,106 @@
+defmodule Expert.CodeIntelligence.Completion.ContextualTest do
+  use Expert.Test.Expert.CompletionCase
+  use Patch
+
+  alias Expert.EngineApi
+  alias Forge.Completion.Candidate
+  alias GenLSP.Structures.CompletionList
+
+  test "contextual completions override ordinary completion", %{project: project} do
+    patch(EngineApi, :contextual_completion, {
+      :override,
+      [{snippet("context", "contextual"), []}],
+      true,
+      []
+    })
+
+    patch(EngineApi, :complete, fn _project, _env -> flunk("ordinary completion ran") end)
+
+    assert [%{label: "context"} = item] = complete(project, "con|")
+    assert apply_completion(item) == "contextual"
+  end
+
+  test "contextual completions augment ordinary completion", %{project: project} do
+    patch(EngineApi, :contextual_completion, {
+      :augment,
+      [{snippet("context", "contextual"), []}],
+      true,
+      [:wrap_list]
+    })
+
+    patch(EngineApi, :complete, [
+      %Candidate.Module{name: "OrdinaryModule", full_name: "OrdinaryModule", metadata: %{}}
+    ])
+
+    assert [%{label: "context"}, %{label: "OrdinaryModule"} = ordinary] =
+             complete(project, "con|")
+
+    assert apply_completion(ordinary) == "[OrdinaryModule]"
+  end
+
+  test "candidate transforms apply before an override is translated", %{project: project} do
+    patch(EngineApi, :contextual_completion, {
+      :override,
+      [{snippet(":read", ":read"), [:wrap_list]}],
+      true,
+      []
+    })
+
+    assert [%{label: ":read"} = item] = complete(project, ":r|")
+    assert apply_completion(item) == "[:read]"
+  end
+
+  test "indexed callable placeholders survive contextual translation", %{project: project} do
+    patch(EngineApi, :contextual_completion, {
+      :override,
+      [
+        {%Candidate.Function{
+           name: "set_attribute",
+           arity: 2,
+           argument_names: ["arg1", "arg2"],
+           origin: "My.Builtins",
+           type: :function,
+           visibility: :public,
+           metadata: %{}
+         }, []}
+      ],
+      true,
+      []
+    })
+
+    assert [%{label: "set_attribute(arg1, arg2)"} = item] = complete(project, "set|")
+    assert apply_completion(item) == "set_attribute(${1:arg1}, ${2:arg2})"
+  end
+
+  test "ignored contextual completion uses ordinary completion", %{project: project} do
+    patch(EngineApi, :contextual_completion, :ignore)
+
+    patch(EngineApi, :complete, [
+      %Candidate.Module{name: "OrdinaryModule", full_name: "OrdinaryModule", metadata: %{}}
+    ])
+
+    assert [%{label: "OrdinaryModule"}] = complete(project, "Ord|")
+  end
+
+  test "contextual results remain incomplete", %{project: project} do
+    patch(EngineApi, :contextual_completion, {
+      :override,
+      [{snippet("context", "contextual"), []}],
+      true,
+      []
+    })
+
+    assert %CompletionList{is_incomplete: true, items: [%{label: "context"}]} =
+             complete(project, "con|", as_list: false)
+  end
+
+  defp snippet(label, text) do
+    %Candidate.Snippet{
+      label: label,
+      snippet: text,
+      detail: "Contextual",
+      priority: :contextual,
+      kind: :field
+    }
+  end
+end

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -156,17 +156,21 @@ defmodule Expert.Project.IndexerTest do
     assert {:ok, [^new_entry]} = Store.exact(project, ProjectIndexer.Fresh, [])
   end
 
-  test "applies compiler trace definitions after the normal index write", %{
+  test "applies compiler trace entries after the normal index write", %{
     project: project,
     task_supervisor: task_supervisor
   } do
     test_pid = self()
-    structure_entry = Entry.block_structure("/generated.ex", %{root: %{}})
-    source_entry = definition(id: 1, subject: ProjectIndexer.Source, path: "/generated.ex")
-    trace_entry = definition(id: 2, subject: ProjectIndexer.Generated, path: "/generated.ex")
+    path = "/generated.ex"
+    structure_entry = Entry.block_structure(path, %{root: %{}})
+    source_entry = definition(id: 1, subject: ProjectIndexer.Source, path: path)
+    trace_entry = definition(id: 2, subject: ProjectIndexer.Generated, path: path)
+
+    integration_entry =
+      Entry.integration(path, "test", :metadata, ProjectIndexer.Generated, %{})
 
     patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
-      {:ok, %{trace_entry.path => [trace_entry]}}
+      {:ok, %{path => [trace_entry, integration_entry]}}
     end)
 
     start_supervised!(
@@ -197,6 +201,12 @@ defmodule Expert.Project.IndexerTest do
              Store.exact(project, ProjectIndexer.Generated, [])
 
     assert {:ok, [^source_entry]} = Store.exact(project, ProjectIndexer.Source, [])
+
+    assert {:ok, [^integration_entry]} =
+             Store.exact(project, integration_entry.subject,
+               type: :metadata,
+               subtype: :integration
+             )
   end
 
   test "uses the latest trace batch when successful compiles overlap indexing", %{

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -9,6 +9,7 @@ defmodule Expert.Project.IndexerTest do
 
   alias Expert.EngineApi
   alias Expert.Project.Indexer
+  alias Expert.Search.Indexer, as: SearchIndexer
   alias Expert.Search.Store
   alias Expert.Search.Store.Backends.Sqlite
   alias Expert.Test.DispatchFake
@@ -18,6 +19,7 @@ defmodule Expert.Project.IndexerTest do
   setup do
     project = project()
     DispatchFake.start()
+    patch(SearchIndexer, :record_integrations, fn _project -> :ok end)
     Sqlite.destroy_all(project)
 
     start_supervised!({Sqlite, [project, runtime_versions: runtime_versions()]})
@@ -39,6 +41,11 @@ defmodule Expert.Project.IndexerTest do
   } do
     test_pid = self()
     entry = definition(id: 1, subject: ProjectIndexer.Initial, path: "/initial.ex")
+
+    patch(SearchIndexer, :record_integrations, fn ^project ->
+      send(test_pid, :record_integrations)
+      :ok
+    end)
 
     patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
       {:ok, %{}}
@@ -70,6 +77,7 @@ defmodule Expert.Project.IndexerTest do
     refute_receive :update_index
 
     assert_receive {:after_apply, {:ok, [^entry]}}
+    assert_receive :record_integrations
     assert_receive project_index_ready(project: ^project)
     assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.Initial, [])
   end
@@ -80,6 +88,11 @@ defmodule Expert.Project.IndexerTest do
   } do
     test_pid = self()
     entry = definition(id: 1, subject: ProjectIndexer.OnError, path: "/on_error.ex")
+
+    patch(SearchIndexer, :record_integrations, fn ^project ->
+      send(test_pid, :record_integrations)
+      :ok
+    end)
 
     start_supervised!(
       {Indexer,
@@ -106,8 +119,40 @@ defmodule Expert.Project.IndexerTest do
 
     assert_receive :create_index
     assert_receive {:after_apply, {:ok, [^entry]}}
+    refute_receive :record_integrations
     assert_receive project_index_ready(project: ^project)
     assert_eventually {:ok, [^entry]} = Store.exact(project, ProjectIndexer.OnError, [])
+  end
+
+  test "does not record integrations when compiler traces cannot be drained", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    test_pid = self()
+
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:error, :unavailable}
+    end)
+
+    patch(SearchIndexer, :record_integrations, fn ^project ->
+      send(test_pid, :record_integrations)
+      :ok
+    end)
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project -> {:ok, [], fn -> :ok end} end,
+         update_index: fn ^project, _path_to_ids -> {:ok, [], [], fn -> :ok end} end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+
+    assert_receive project_index_ready(project: ^project)
+    refute_receive :record_integrations
   end
 
   test "updates an existing index after later successful project compiles", %{
@@ -173,6 +218,19 @@ defmodule Expert.Project.IndexerTest do
       {:ok, %{path => [trace_entry, integration_entry]}}
     end)
 
+    patch(SearchIndexer, :record_integrations, fn ^project ->
+      send(
+        test_pid,
+        {:commit_after_trace,
+         Store.exact(project, integration_entry.subject,
+           type: :metadata,
+           subtype: :integration
+         )}
+      )
+
+      :ok
+    end)
+
     start_supervised!(
       {Indexer,
        [
@@ -195,6 +253,7 @@ defmodule Expert.Project.IndexerTest do
 
     send(index_task, :finish_index)
 
+    assert_receive {:commit_after_trace, {:ok, [^integration_entry]}}
     assert_receive project_index_ready(project: ^project)
 
     assert {:ok, [%Entry{subject: ProjectIndexer.Generated}]} =

--- a/apps/expert/test/expert/provider/handlers/hover_test.exs
+++ b/apps/expert/test/expert/provider/handlers/hover_test.exs
@@ -1,5 +1,6 @@
 defmodule Expert.Provider.Handlers.HoverTest do
   use ExUnit.Case, async: false
+  use Patch
 
   import Forge.Test.CodeSigil
   import Forge.Test.CursorSupport
@@ -52,6 +53,48 @@ defmodule Expert.Provider.Handlers.HoverTest do
     start_supervised!(Engine.ApplicationCache)
     :persistent_term.erase(Expert.Configuration)
     :ok
+  end
+
+  test "combines integration and generic hover documentation", %{project: project} do
+    patch(EngineApi, :contextual_hover, fn _project, env ->
+      [{"Integration documentation", hover_range(env.document, 1, 2, 1, 6)}]
+    end)
+
+    patch(EngineApi, :resolve_entity, {:error, :not_found})
+
+    patch(EngineApi, :hover, fn _project, document, _position ->
+      {:ok, "Generic documentation", hover_range(document, 1, 1, 1, 7)}
+    end)
+
+    assert {:ok, %Structures.Hover{contents: contents, range: range}} = hover(project, "|option")
+    assert contents.kind == "markdown"
+    assert contents.value =~ "Generic documentation"
+    assert contents.value =~ "Integration documentation"
+    assert contents.value =~ "---"
+    assert range.start.character == 1
+    assert range.end.character == 7
+  end
+
+  test "deduplicates identical integration and generic hover documentation", %{project: project} do
+    patch(EngineApi, :contextual_hover, fn _project, env ->
+      [{"Same documentation", hover_range(env.document, 1, 1, 1, 7)}]
+    end)
+
+    patch(EngineApi, :resolve_entity, {:error, :not_found})
+
+    patch(EngineApi, :hover, fn _project, document, _position ->
+      {:ok, "Same documentation", hover_range(document, 1, 1, 1, 7)}
+    end)
+
+    assert {:ok, %Structures.Hover{contents: %{value: "Same documentation"}}} =
+             hover(project, "|option")
+  end
+
+  defp hover_range(document, start_line, start_character, end_line, end_character) do
+    Forge.Document.Range.new(
+      Position.new(document, start_line, start_character),
+      Position.new(document, end_line, end_character)
+    )
   end
 
   # compiles and writes beam files in the given project

--- a/apps/expert/test/expert/search/indexer_test.exs
+++ b/apps/expert/test/expert/search/indexer_test.exs
@@ -52,4 +52,14 @@ defmodule Expert.Search.IndexerTest do
     assert :ok = after_apply.()
     assert_receive :commit_manifest
   end
+
+  test "record_integrations/1 uses the engine indexer boundary", %{project: project} do
+    patch(EngineApi, :call, fn
+      ^project, Engine.Search.Indexer, :record_integrations, [^project] -> :ok
+    end)
+
+    assert :ok = Indexer.record_integrations(project)
+
+    assert_called(EngineApi.call(project, Engine.Search.Indexer, :record_integrations, [project]))
+  end
 end

--- a/apps/forge/lib/forge/ast.ex
+++ b/apps/forge/lib/forge/ast.ex
@@ -345,6 +345,154 @@ defmodule Forge.Ast do
   end
 
   @doc """
+  Returns the index and value of the first argument containing a cursor node.
+  """
+  @spec cursor_argument([Macro.t()]) :: {:ok, non_neg_integer(), Macro.t()} | :error
+  def cursor_argument(arguments) when is_list(arguments) do
+    arguments
+    |> Enum.with_index()
+    |> Enum.find_value(:error, fn {argument, index} ->
+      if contains_cursor?(argument), do: {:ok, index, argument}
+    end)
+  end
+
+  @doc """
+  Returns the enclosing local call whose arguments contain the cursor.
+
+  The result includes the call name, cursor argument index, cursor argument,
+  and all call arguments.
+  """
+  @spec local_call_at_cursor([Macro.t()]) ::
+          {:ok, String.t(), non_neg_integer(), Macro.t(), [Macro.t()]} | :error
+  def local_call_at_cursor(cursor_path) when is_list(cursor_path) do
+    Enum.find_value(cursor_path, :error, fn
+      {name, _, arguments}
+      when is_atom(name) and is_list(arguments) and
+             name not in [:__cursor__, :__block__, :defmodule, :use, :|>] ->
+        case cursor_argument(arguments) do
+          {:ok, index, argument} -> {:ok, to_string(name), index, argument, arguments}
+          :error -> nil
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  @doc """
+  Returns the enclosing remote call whose arguments contain the cursor.
+
+  The result includes the module AST, function name, arity, cursor argument
+  index, and cursor argument. For piped calls, the arity and argument index
+  include the implicit first argument.
+  """
+  @spec remote_call_at_cursor([Macro.t()]) ::
+          {:ok, Macro.t(), atom(), non_neg_integer(), non_neg_integer(), Macro.t()} | :error
+  def remote_call_at_cursor(cursor_path) when is_list(cursor_path) do
+    Enum.find_value(cursor_path, fn
+      {:|>, _, [_left, call]} -> remote_call_at_cursor(call, 1)
+      _ -> nil
+    end) || Enum.find_value(cursor_path, :error, &remote_call_at_cursor(&1, 0))
+  end
+
+  @doc """
+  Returns enclosing local call names from outermost to innermost.
+  """
+  @spec enclosing_local_call_names([Macro.t()]) :: [String.t()]
+  def enclosing_local_call_names(cursor_path) when is_list(cursor_path) do
+    cursor_path
+    |> Enum.flat_map(fn
+      {name, _, arguments}
+      when is_atom(name) and is_list(arguments) and
+             name not in [:__cursor__, :__block__, :defmodule, :use] ->
+        [to_string(name)]
+
+      _ ->
+        []
+    end)
+    |> Enum.reverse()
+  end
+
+  @doc """
+  Returns whether the given AST contains a cursor node.
+  """
+  @spec contains_cursor?(Macro.t()) :: boolean()
+  def contains_cursor?(ast) do
+    {_ast, found?} =
+      Macro.prewalk(ast, false, fn
+        {:__cursor__, _, _} = node, _ -> {node, true}
+        node, found? -> {node, found?}
+      end)
+
+    found?
+  end
+
+  @doc """
+  Returns the nested keyword keys leading to the cursor.
+
+  Keys are ordered from outermost to innermost.
+  """
+  @spec keyword_path_at_cursor(Macro.t()) :: {:ok, [String.t() | nil]} | :error
+  def keyword_path_at_cursor(ast), do: keyword_path_at_cursor(ast, [])
+
+  defp keyword_path_at_cursor({:__block__, _, [value]}, path),
+    do: keyword_path_at_cursor(value, path)
+
+  defp keyword_path_at_cursor(options, path) when is_list(options) do
+    Enum.find_value(options, :error, fn
+      {key, value} ->
+        if contains_cursor?(value) do
+          keyword_path_at_cursor(value, path ++ [keyword_key(key)])
+        end
+
+      {:__cursor__, _, _} ->
+        {:ok, path}
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp keyword_path_at_cursor({:__cursor__, _, _}, path), do: {:ok, path}
+  defp keyword_path_at_cursor(_ast, _path), do: :error
+
+  defp keyword_key(key) when is_atom(key), do: to_string(key)
+  defp keyword_key({:__block__, _, [key]}) when is_atom(key), do: to_string(key)
+  defp keyword_key(_key), do: nil
+
+  @doc """
+  Returns whether the cursor path is inside a function or macro definition.
+  """
+  @spec inside_definition?([Macro.t()]) :: boolean()
+  def inside_definition?(cursor_path) when is_list(cursor_path) do
+    Enum.any?(cursor_path, &match?({kind, _, _} when kind in [:def, :defp, :defmacro], &1))
+  end
+
+  @doc """
+  Returns whether the cursor path contains a remote call.
+  """
+  @spec remote_call?([Macro.t()]) :: boolean()
+  def remote_call?(cursor_path) when is_list(cursor_path) do
+    Enum.any?(cursor_path, fn
+      {{:., _, _}, _, arguments} when is_list(arguments) -> true
+      _ -> false
+    end)
+  end
+
+  defp remote_call_at_cursor({{:., _, [module_ast, name]}, _, arguments}, offset)
+       when is_atom(name) and is_list(arguments) do
+    case cursor_argument(arguments) do
+      {:ok, index, argument} ->
+        {:ok, module_ast, name, length(arguments) + offset, index + offset, argument}
+
+      :error ->
+        nil
+    end
+  end
+
+  defp remote_call_at_cursor(_ast, _offset), do: nil
+
+  @doc """
   Returns a zipper for the document AST focused at the given position.
   """
   @spec zipper_at(Document.t(), Position.t()) :: {:ok, Zipper.t()} | {:error, parse_error()}

--- a/apps/forge/lib/forge/search/indexer/entry.ex
+++ b/apps/forge/lib/forge/search/indexer/entry.ex
@@ -10,6 +10,7 @@ defmodule Forge.Search.Indexer.Entry do
   @type entry_type ::
           :ex_unit_describe
           | :ex_unit_test
+          | :metadata
           | :module
           | :module_attribute
           | :struct
@@ -18,7 +19,7 @@ defmodule Forge.Search.Indexer.Entry do
           | {:function, function_type()}
 
   @type subject :: String.t()
-  @type entry_subtype :: :reference | :definition
+  @type entry_subtype :: :reference | :definition | :integration
   @type version :: String.t()
   @type entry_id :: pos_integer() | nil
   @type block_id :: pos_integer() | :root
@@ -78,6 +79,45 @@ defmodule Forge.Search.Indexer.Entry do
       type: :metadata,
       subtype: :block_structure
     }
+  end
+
+  @doc """
+  Creates portable metadata owned by an integration.
+
+  The payload must not contain dependency structs.
+  """
+  def integration(path, provider, kind, owner_module, payload) when is_binary(path) do
+    %__MODULE__{
+      block_id: :root,
+      id: Identifier.next_global!(),
+      metadata: %{
+        owner_module: module_name(owner_module),
+        payload: payload
+      },
+      path: path,
+      subject: integration_subject(provider, kind, owner_module),
+      subtype: :integration,
+      type: :metadata
+    }
+  end
+
+  def integration_subject(provider, kind, owner_module) do
+    integration_subject_prefix(provider, kind) <> module_name(owner_module)
+  end
+
+  @doc """
+  Returns the search subject prefix for integration metadata.
+
+  An owner can be provided to match metadata nested below that owner.
+  """
+  @spec integration_subject_prefix(String.t(), atom()) :: String.t()
+  @spec integration_subject_prefix(String.t(), atom(), module() | String.t()) :: String.t()
+  def integration_subject_prefix(provider, kind) do
+    "$integration/#{provider}/#{kind}/"
+  end
+
+  def integration_subject_prefix(provider, kind, owner_module) do
+    integration_subject(provider, kind, owner_module) <> "/"
   end
 
   def reference(path, %Block{} = block, subject, type, range, application) do
@@ -151,4 +191,7 @@ defmodule Forge.Search.Indexer.Entry do
   def put_metadata(%__MODULE__{} = entry, metadata) do
     %__MODULE__{entry | metadata: metadata}
   end
+
+  defp module_name(module) when is_atom(module), do: Atom.to_string(module)
+  defp module_name(module) when is_binary(module), do: module
 end

--- a/apps/forge/test/forge/ast_test.exs
+++ b/apps/forge/test/forge/ast_test.exs
@@ -59,6 +59,51 @@ defmodule Forge.AstTest do
     end
   end
 
+  describe "calls at cursor" do
+    test "returns local call arguments" do
+      path = cursor_path("configure modes: [:r|]")
+
+      assert {:ok, "configure", 0, argument, [argument]} = Ast.local_call_at_cursor(path)
+      assert Ast.contains_cursor?(argument)
+      assert ["configure"] = Ast.enclosing_local_call_names(path)
+    end
+
+    test "returns remote call arguments" do
+      path = cursor_path("Ash.create(changeset, ups|ert?: true)")
+
+      assert {:ok, {:__aliases__, _, [:Ash]}, :create, 2, 1, argument} =
+               Ast.remote_call_at_cursor(path)
+
+      assert Ast.contains_cursor?(argument)
+    end
+
+    test "accounts for a piped first argument" do
+      path = cursor_path("changeset |> Ash.create(ups|ert?: true)")
+
+      assert {:ok, {:__aliases__, _, [:Ash]}, :create, 2, 1, _argument} =
+               Ast.remote_call_at_cursor(path)
+    end
+
+    test "reports definition and remote-call ancestry" do
+      local_path = cursor_path("def run, do: lo|cal()")
+      remote_path = cursor_path("def run, do: Ash.create(record, ups|ert?: true)")
+
+      assert Ast.inside_definition?(local_path)
+      refute Ast.remote_call?(local_path)
+      assert Ast.inside_definition?(remote_path)
+      assert Ast.remote_call?(remote_path)
+    end
+
+    test "returns the keyword branch containing the cursor" do
+      assert {:ok, ["constraints", "range"]} =
+               "attribute :name, :string, constraints: [range: [max: 1, ma|]]"
+               |> cursor_path()
+               |> Ast.local_call_at_cursor()
+               |> elem(3)
+               |> Ast.keyword_path_at_cursor()
+    end
+  end
+
   describe "path_at/2" do
     defp path_at(text) do
       {position, document} = pop_cursor(text, as: :document)

--- a/apps/forge/test/forge/search/indexer/entry_test.exs
+++ b/apps/forge/test/forge/search/indexer/entry_test.exs
@@ -1,0 +1,16 @@
+defmodule Forge.Search.Indexer.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Forge.Search.Indexer.Entry
+
+  test "builds integration subjects and prefixes" do
+    assert Entry.integration_subject("spark", :extension, My.Extension) ==
+             "$integration/spark/extension/Elixir.My.Extension"
+
+    assert Entry.integration_subject_prefix("spark", :extension) ==
+             "$integration/spark/extension/"
+
+    assert Entry.integration_subject_prefix("spark", :behaviour, My.Behaviour) ==
+             "$integration/spark/behaviour/Elixir.My.Behaviour/"
+  end
+end


### PR DESCRIPTION
This is an experiment I started over the weekend, and I think it's very viable

It implements support for Spark with the skeleton for an integrations system. Rather than a plugin system, it's just some file organization and integration points to make it easier for contributors to figure out how to add other integrations. The main assumption I am making is that user integrations will always be managed by the Engine. I do not know what a proper extensible plugin system will look like, but I do foresee it running in the engine and be contained within the engine.

RIght now there's two integration points: beam indexing, and completions, which is what the Spark integration needs.

During indexing, the beam data is passed to the enabled integrations, which produce indexer entries specific to them via the new `:integration` subtype and `:metadata` field for arbitrary information.

When requesting completions, integrations also run against the completion request and can either replace, augment or leave untouched the list of completions provided by core expert. Integration completions are returned at the top of the list as they are more likely(in my opinion) to be what the user expects, and we treat the core expert completions are generic completions for that context.

As for the Spark integration itself, it takes advantage of Spark compiling all its DSL as data within the compiled module, so the indexer basically extracts all the DSL metadata from the beam and converts it to integration entires. The completion side of it figures out the cursor context and provides the appropriate completions and docs from the DSL.

For example, for the Ash framework, if the module you are editing has `use Ash.Resource`, the Spark integration will:

- provide completions for `actions`, `attributes`, etc:
<img width="1261" height="1303" alt="Screenshot 2026-08-04 at 5 25 34 AM" src="https://github.com/user-attachments/assets/19f383ab-6e05-4a2b-8bcc-b9c34aafd599" />

- provide completions for things inside a DSL block:
<img width="1257" height="1295" alt="Screenshot 2026-08-04 at 5 26 11 AM" src="https://github.com/user-attachments/assets/7583aac3-8355-42eb-96d3-66e8590b5ca3" />
<img width="1261" height="99" alt="Screenshot 2026-08-04 at 5 26 40 AM" src="https://github.com/user-attachments/assets/c1ebd81c-ba50-4752-a373-df26e797716f" />
<img width="955" height="158" alt="Screenshot 2026-08-04 at 5 27 08 AM" src="https://github.com/user-attachments/assets/6df41e78-9785-478c-a8c9-d827b252ec36" />

- Ash.create completions
<img width="1250" height="89" alt="Screenshot 2026-08-04 at 6 36 41 AM" src="https://github.com/user-attachments/assets/bafdd2e7-100e-4e47-92cb-c710ce3c460f" />
