### PR TITLE
fix: don't load deps before the project is compiled

### DIFF
--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -41,6 +41,7 @@ defmodule Engine.Build.Project do
 
           try do
             prepare_for_project_build(token)
+            Engine.Mix.record_deps(project)
             {:done, :ok}
           after
             Build.clear_progress_token()
@@ -57,7 +58,11 @@ defmodule Engine.Build.Project do
   defp do_compile(project, initial?, token) do
     Mix.Task.clear()
 
-    if initial?, do: prepare_for_project_build(token)
+    if initial? do
+      prepare_for_project_build(token)
+    end
+
+    Engine.Mix.record_deps(project)
 
     compile_fun = fn ->
       Mix.Task.clear()

--- a/apps/engine/lib/engine/mix.ex
+++ b/apps/engine/lib/engine/mix.ex
@@ -72,7 +72,6 @@ defmodule Engine.Mix do
   defp in_loaded_project(%Project{} = project, fun) do
     File.cd!(Project.root_path(project), fn ->
       with_pushed_project(project, fn project_module ->
-        record_deps(project)
         fun.(project_module)
       end)
     end)
@@ -92,7 +91,7 @@ defmodule Engine.Mix do
     end
   end
 
-  defp record_deps(%Project{} = project) do
+  def record_deps(%Project{} = project) do
     deps_paths = Mix.Project.deps_paths()
     put_persistent({__MODULE__, :deps_paths}, deps_paths)
     record_deps_formatter_opts(project, deps_paths)

--- a/apps/engine/test/engine/code_mod/format_test.exs
+++ b/apps/engine/test/engine/code_mod/format_test.exs
@@ -203,7 +203,7 @@ defmodule Engine.CodeMod.FormatTest do
                Mix.ProjectStack.on_clean_slate(fn ->
                  # Dependency paths are recorded while the project is loaded, as
                  # a build does.
-                 Engine.Mix.in_project(project, fn _ -> :ok end)
+                 Engine.Mix.in_project(project, fn _ -> Engine.Mix.record_deps(project) end)
                  modify("my_dsl :foo\n", file_path: file_path, project: project)
                end)
 
@@ -224,7 +224,8 @@ defmodule Engine.CodeMod.FormatTest do
       )
 
       Mix.ProjectStack.on_clean_slate(fn ->
-        assert {:ok, :ok} = Engine.Mix.in_project(project, fn _ -> :ok end)
+        assert {:ok, :ok} =
+                 Engine.Mix.in_project(project, fn _ -> Engine.Mix.record_deps(project) end)
 
         File.mkdir_p!(Path.dirname(file_path))
 
@@ -233,7 +234,8 @@ defmodule Engine.CodeMod.FormatTest do
           ~s([import_deps: [:my_dep], inputs: ["lib/**/*.{ex,exs}"]]\n)
         )
 
-        assert {:ok, :ok} = Engine.Mix.in_project(project, fn _ -> :ok end)
+        assert {:ok, :ok} =
+                 Engine.Mix.in_project(project, fn _ -> Engine.Mix.record_deps(project) end)
 
         assert {:ok, "my_dsl :foo"} =
                  modify("my_dsl :foo\n", file_path: file_path, project: project)
@@ -253,6 +255,7 @@ defmodule Engine.CodeMod.FormatTest do
         build =
           Task.async(fn ->
             Engine.Mix.in_project(project, fn _ ->
+              Engine.Mix.record_deps(project)
               send(parent, :build_project_pushed)
 
               receive do


### PR DESCRIPTION
Fix #838 

In #834 we added a line that caused project startup from accidentally trying to load dependencies that may not have yet been compiled