### PR TITLE
fix: don't discard multiple diagnostics from file and project compilation

### DIFF
--- a/apps/engine/lib/engine/build/error/location.ex
+++ b/apps/engine/lib/engine/build/error/location.ex
@@ -66,21 +66,21 @@ defmodule Engine.Build.Error.Location do
   def uniq(diagnostics) do
     exacts = Enum.filter(diagnostics, fn diagnostic -> match?(%Range{}, diagnostic.position) end)
 
-    extract_line = fn
-      %Result{position: {line, _column}} -> line
-      %Result{position: line} -> line
+    extract_uri_and_line = fn
+      %Result{uri: uri, position: {line, _column}} -> {uri, line}
+      %Result{uri: uri, position: line} -> {uri, line}
     end
 
     # Note: Sometimes error and warning appear on one line at the same time
-    # So we need to uniq by line and severity,
+    # So we need to uniq by URI, line, and severity,
     # and :error is always more important than :warning
-    extract_line_and_severity = &{extract_line.(&1), &1.severity}
+    extract_uri_line_and_severity = &{extract_uri_and_line.(&1), &1.severity}
 
     filtered =
       diagnostics
       |> Enum.filter(fn diagnostic -> not match?(%Range{}, diagnostic.position) end)
-      |> Enum.sort_by(extract_line_and_severity)
-      |> Enum.uniq_by(extract_line)
+      |> Enum.sort_by(extract_uri_line_and_severity)
+      |> Enum.uniq_by(extract_uri_and_line)
       |> reject_zeroth_line()
 
     exacts ++ filtered

--- a/apps/engine/test/engine/build/error_test.exs
+++ b/apps/engine/test/engine/build/error_test.exs
@@ -56,6 +56,28 @@ defmodule Engine.Build.ErrorTest do
       assert String.starts_with?(normalized.uri, "file://")
       assert String.ends_with?(normalized.uri, "lib/dummy.ex")
     end
+
+    test "keeps same-line diagnostics from different files" do
+      diagnostics = [
+        %Mix.Task.Compiler.Diagnostic{
+          file: "lib/first.ex",
+          severity: :warning,
+          message: "first",
+          position: 2,
+          compiler_name: "Boundary"
+        },
+        %Mix.Task.Compiler.Diagnostic{
+          file: "lib/second.ex",
+          severity: :warning,
+          message: "second",
+          position: 2,
+          compiler_name: "Boundary"
+        }
+      ]
+
+      assert [%{uri: first_uri}, %{uri: second_uri}] = Build.Error.refine_diagnostics(diagnostics)
+      assert first_uri != second_uri
+    end
   end
 
   describe "diagnostic/3" do

--- a/apps/expert/lib/expert/project/diagnostics.ex
+++ b/apps/expert/lib/expert/project/diagnostics.ex
@@ -71,7 +71,7 @@ defmodule Expert.Project.Diagnostics do
 
         diagnostics ->
           Enum.reduce(diagnostics, state, fn diagnostic, state ->
-            State.add(state, build_number, diagnostic)
+            State.add_file(state, build_number, diagnostic)
           end)
       end
 
@@ -94,9 +94,8 @@ defmodule Expert.Project.Diagnostics do
   # Private
 
   defp publish_diagnostics(%State{} = state) do
-    Enum.each(state.entries_by_uri, fn {uri, %State.Entry{} = entry} ->
-      with {:ok, diagnostics} <-
-             entry |> State.Entry.diagnostics() |> Expert.Protocol.Convert.to_lsp() do
+    Enum.each(State.diagnostics_by_uri(state), fn {uri, diagnostics} ->
+      with {:ok, diagnostics} <- Expert.Protocol.Convert.to_lsp(diagnostics) do
         GenLSP.notify(Expert.get_lsp(), %TextDocumentPublishDiagnostics{
           params: %Structures.PublishDiagnosticsParams{uri: uri, diagnostics: diagnostics}
         })

--- a/apps/expert/lib/expert/project/diagnostics/state.ex
+++ b/apps/expert/lib/expert/project/diagnostics/state.ex
@@ -34,21 +34,40 @@ defmodule Expert.Project.Diagnostics.State do
     end
   end
 
-  defstruct project: nil, entries_by_uri: %{}
+  defstruct project: nil, entries_by_uri: %{}, file_entries_by_uri: %{}
 
   def new(%Project{} = project) do
     %__MODULE__{project: project}
   end
 
   def get(%__MODULE__{} = state, source_uri) do
-    entry = Map.get(state.entries_by_uri, source_uri, Entry.new(0))
-    Entry.diagnostics(entry)
+    project_diagnostics =
+      state.entries_by_uri
+      |> Map.get(source_uri, Entry.new(0))
+      |> Entry.diagnostics()
+
+    file_diagnostics =
+      state.file_entries_by_uri
+      |> Map.get(source_uri, Entry.new(0))
+      |> Entry.diagnostics()
+
+    project_diagnostics ++ file_diagnostics
+  end
+
+  def diagnostics_by_uri(%__MODULE__{} = state) do
+    uris =
+      state.entries_by_uri
+      |> Map.keys()
+      |> MapSet.new()
+      |> MapSet.union(MapSet.new(Map.keys(state.file_entries_by_uri)))
+
+    Map.new(uris, &{&1, get(state, &1)})
   end
 
   def clear(%__MODULE__{} = state, source_uri) do
-    new_entries = Map.put(state.entries_by_uri, source_uri, Entry.new(0))
+    file_entries = Map.put(state.file_entries_by_uri, source_uri, Entry.new(0))
 
-    %__MODULE__{state | entries_by_uri: new_entries}
+    %__MODULE__{state | file_entries_by_uri: file_entries}
   end
 
   @doc """
@@ -57,31 +76,14 @@ defmodule Expert.Project.Diagnostics.State do
   that exists on the disk is actually an older copy of the file in memory.
   """
   def clear_all_flushed(%__MODULE__{} = state) do
-    cleared =
-      Map.new(state.entries_by_uri, fn {uri, %Entry{} = entry} ->
-        with true <- Document.Store.open?(uri),
-             {:ok, %Document{} = document} <- Document.Store.fetch(uri),
-             true <- keep_diagnostics?(document) do
-          {uri, entry}
-        else
-          _ ->
-            {uri, Entry.new(0)}
-        end
-      end)
+    entries_by_uri = clear_flushed(state.entries_by_uri)
+    file_entries_by_uri = clear_flushed(state.file_entries_by_uri)
 
-    %__MODULE__{state | entries_by_uri: cleared}
+    %__MODULE__{state | entries_by_uri: entries_by_uri, file_entries_by_uri: file_entries_by_uri}
   end
 
   def add(%__MODULE__{} = state, build_number, %Diagnostic.Result{} = diagnostic) do
-    entries_by_uri =
-      Map.update(
-        state.entries_by_uri,
-        diagnostic.uri,
-        Entry.new(build_number, diagnostic),
-        fn entry ->
-          Entry.add(entry, build_number, diagnostic)
-        end
-      )
+    entries_by_uri = add_to_entries(state.entries_by_uri, build_number, diagnostic)
 
     %__MODULE__{state | entries_by_uri: entries_by_uri}
   end
@@ -89,6 +91,36 @@ defmodule Expert.Project.Diagnostics.State do
   def add(%__MODULE__{} = state, _build_number, other) do
     Logger.error("Invalid diagnostic: #{inspect(other)}")
     state
+  end
+
+  def add_file(%__MODULE__{} = state, build_number, %Diagnostic.Result{} = diagnostic) do
+    file_entries_by_uri = add_to_entries(state.file_entries_by_uri, build_number, diagnostic)
+
+    %__MODULE__{state | file_entries_by_uri: file_entries_by_uri}
+  end
+
+  defp add_to_entries(entries_by_uri, build_number, diagnostic) do
+    Map.update(
+      entries_by_uri,
+      diagnostic.uri,
+      Entry.new(build_number, diagnostic),
+      fn entry ->
+        Entry.add(entry, build_number, diagnostic)
+      end
+    )
+  end
+
+  defp clear_flushed(entries_by_uri) do
+    Map.new(entries_by_uri, fn {uri, %Entry{} = entry} ->
+      with true <- Document.Store.open?(uri),
+           {:ok, %Document{} = document} <- Document.Store.fetch(uri),
+           true <- keep_diagnostics?(document) do
+        {uri, entry}
+      else
+        _ ->
+          {uri, Entry.new(0)}
+      end
+    end)
   end
 
   defp keep_diagnostics?(%Document{} = document) do

--- a/apps/expert/test/expert/project/diagnostics_test.exs
+++ b/apps/expert/test/expert/project/diagnostics_test.exs
@@ -132,5 +132,28 @@ defmodule Expert.Project.DiagnosticsTest do
                start: %Structures.Position{character: 0, line: 3}
              }
     end
+
+    test "it keeps project diagnostics when a file has no diagnostics", %{project: project} do
+      document = open_file(project, "defmodule Dummy")
+
+      EngineApi.broadcast(
+        project,
+        project_diagnostics(
+          build_number: 1,
+          diagnostics: [diagnostic(document.uri, message: "boundary warning")]
+        )
+      )
+
+      assert_receive {:transport, %TextDocumentPublishDiagnostics{}}
+
+      EngineApi.broadcast(project, file_diagnostics(build_number: 2, uri: document.uri))
+
+      assert_receive {:transport,
+                      %TextDocumentPublishDiagnostics{
+                        params: %PublishDiagnosticsParams{
+                          diagnostics: [%Structures.Diagnostic{message: "boundary warning"}]
+                        }
+                      }}
+    end
   end
 end


### PR DESCRIPTION
Fix #801 

We were discarding diagnostics if they reported the same line at different files, and diagnostics from file compilation could clear diagnostics from project compilation. This became evident with Boundary in the linked issue, where only one of the Boundary warnings would show in the editor, but both show with `mix compile`