### PR TITLE
fix: don't use token_metadata option when compiling

### DIFF
--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -269,7 +269,7 @@ defmodule Engine.Build.State do
   end
 
   defp parser_options do
-    [columns: true, token_metadata: true]
+    [columns: true]
   end
 
   defp increment_build_number(%__MODULE__{} = state) do

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -85,6 +85,17 @@ defmodule Engine.Build.StateTest do
     :ok
   end
 
+  describe "compiler options" do
+    test "does not attach token metadata during project compilation" do
+      compiler_options = Code.compiler_options()
+      on_exit(fn -> Code.compiler_options(compiler_options) end)
+
+      State.set_compiler_options()
+
+      assert Code.get_compiler_option(:parser_options) == [columns: true]
+    end
+  end
+
   describe "throttled document compilation" do
     setup [:with_metadata_project, :with_a_valid_document, :with_patched_compilation]
 

--- a/apps/expert/test/engine/build_test.exs
+++ b/apps/expert/test/engine/build_test.exs
@@ -130,6 +130,16 @@ defmodule Engine.BuildTest do
     end
   end
 
+  describe "compiling transformed block AST" do
+    test "does not add token metadata that breaks generated AST formatting" do
+      {:ok, project} = with_project(:token_metadata_compilation)
+      EngineApi.schedule_compile(project, true)
+
+      assert_receive project_compiled(status: :success), @project_compile_timeout
+      assert_receive project_diagnostics(diagnostics: [])
+    end
+  end
+
   describe "compilng a project with parse errors" do
     setup :with_parse_errors_project
 

--- a/apps/forge/test/fixtures/token_metadata_compilation/lib/token_metadata_compilation.ex
+++ b/apps/forge/test/fixtures/token_metadata_compilation/lib/token_metadata_compilation.ex
@@ -1,0 +1,18 @@
+defmodule TokenMetadataCompilation.Stringifier do
+  defmacro stringify_case({:case, metadata, [expression, _clauses]}) do
+    Macro.to_string({:case, metadata, [expression, expression]})
+    expression
+  end
+end
+
+defmodule TokenMetadataCompilation do
+  require TokenMetadataCompilation.Stringifier
+
+  def compile(target) do
+    TokenMetadataCompilation.Stringifier.stringify_case(
+      case target do
+        _ -> target
+      end
+    )
+  end
+end

--- a/apps/forge/test/fixtures/token_metadata_compilation/mix.exs
+++ b/apps/forge/test/fixtures/token_metadata_compilation/mix.exs
@@ -1,0 +1,12 @@
+defmodule TokenMetadataCompilation.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :token_metadata_compilation,
+      version: "0.1.0",
+      elixir: "~> 1.15",
+      deps: []
+    ]
+  end
+end


### PR DESCRIPTION
There is a bug in the core elixir `Code.Normalizer` that makes it choke with Scholar because it messes around with the AST metadata. The culprit is the metadata included by the `:token_metadata` option, which is required when parsing source code, but not really required when *compiling* it, which is what triggers the crash.

To reproduce:
1. On a build from `main`, and a project that has `:scholar` as a dependency and uses elixir 1.20, open `mix.exs` and wait for the project to compile.
2. Check the `.expert/project.log` file and you'll see this error:
```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Tuple

Got value:

    {:target_x, [version: 2, counter: 2, generated: true, line: 246, column: 12],
     nil}

    (elixir 1.20.0) lib/enum.ex:5: Enumerable.impl_for!/1
    (elixir 1.20.0) lib/enum.ex:184: Enumerable.reduce/3
    (elixir 1.20.0) lib/enum.ex:4667: Enum.map/2
    (elixir 1.20.0) lib/code/normalizer.ex:472: Code.Normalizer.normalize_kw_blocks/4
    (elixir 1.20.0) lib/code.ex:1562: Code.quoted_to_algebra/2
    (elixir 1.20.0) lib/macro.ex:1271: Macro.to_string/1
    (elixir 1.20.0) lib/module/types/helpers.ex:273: Module.Types.Helpers.expr_to_string/2
    (elixir 1.20.0) lib/module/types/helpers.ex:193: anonymous fn/1 in Module.Types.Helpers.collect_var_traces/2
```

With a build from this PR, no such error shows.