### PR TITLE
fix: properly calculate callback completion line range

### DIFF
--- a/apps/expert/lib/expert/code_intelligence/completion/translations/callback.ex
+++ b/apps/expert/lib/expert/code_intelligence/completion/translations/callback.ex
@@ -66,7 +66,7 @@ defmodule Expert.CodeIntelligence.Completion.Translations.Callback do
       start_char =
         case String.split(line, "def", parts: 2) do
           [i, _] -> String.length(i) + 1
-          [_] -> 0
+          [_] -> Forge.Text.count_leading_spaces(line) + 1
         end
 
       end_char = String.length(line) + 1

--- a/apps/expert/test/expert/code_intelligence/completion/translations/callback_test.exs
+++ b/apps/expert/test/expert/code_intelligence/completion/translations/callback_test.exs
@@ -1,6 +1,7 @@
 defmodule Expert.CodeIntelligence.Completion.Translations.CallbackTest do
   use Expert.Test.Expert.CompletionCase
 
+  alias Forge.Protocol.Convertible
   alias GenLSP.Enumerations.CompletionItemKind
 
   describe "callback completions" do
@@ -19,6 +20,35 @@ defmodule Expert.CodeIntelligence.Completion.Translations.CallbackTest do
 
       assert apply_completion(completion) =~
                "@impl true\ndef handle_info(${1:msg}, ${2:state}) do"
+    end
+
+    test "suggest callbacks without def", %{project: project} do
+      source = ~q[
+        defmodule MyServer do
+          use GenServer
+          child_sp|
+        end
+      ]
+
+      {:ok, completion} =
+        project
+        |> complete(source)
+        |> fetch_completion(
+          kind: CompletionItemKind.interface(),
+          label: "child_spec(init_arg)"
+        )
+
+      assert {:ok, lsp_edits} = Convertible.to_lsp(completion.text_edit)
+      assert [%{range: %{start: %{character: 2}, end: %{character: 10}}}] = List.wrap(lsp_edits)
+
+      assert apply_completion(completion) == """
+             defmodule MyServer do
+               use GenServer
+               def child_spec(${1:init_arg}) do
+               $0
+             end
+             end
+             """
     end
 
     test "do not add parens if they're already present", %{project: project} do


### PR DESCRIPTION
Zed was rejecting our completions because we were miscalculating the line range for callback completions

Fix #785 