### PR TITLE
fix(expert): force unicode encoding on IO

### DIFF
--- a/apps/expert/rel/vm.args.eex
+++ b/apps/expert/rel/vm.args.eex
@@ -13,3 +13,6 @@
 
 # Alternative user_drv
 -user Elixir.XPExpert.Stdio.User
+
+# LSP messages are UTF-8 regardless of the host locale
+-kernel standard_io_encoding unicode

--- a/apps/expert/test/expert/stdio/user_test.exs
+++ b/apps/expert/test/expert/stdio/user_test.exs
@@ -93,13 +93,22 @@ defmodule Expert.Stdio.UserTest do
     refute merged =~ "STILL_RUNNING"
   end
 
+  @tag :tmp_dir
+  test "preserves multibyte characters split across stdin reads", %{tmp_dir: tmp_dir} do
+    # A 4-byte character offset by one ASCII byte straddles the driver's 1024-byte reads.
+    payload = "a" <> String.duplicate("😀", 1_250)
+
+    round_tripped = round_trip(payload, tmp_dir)
+
+    assert byte_size(round_tripped) == byte_size(payload)
+    assert round_tripped == payload
+  end
+
   # `-user` names the module as a string that nothing compiles or type checks, and the release
   # runs it under the `XP` namespace. A rename would silently leave the release booting
   # `user_drv` and sharing stdout again, so pin the two together here.
   test "the release boot flag names the namespaced module" do
-    vm_args = __DIR__ |> Path.join("../../../rel/vm.args.eex") |> File.read!()
-
-    assert vm_args =~ "-user Elixir.XP#{inspect(Expert.Stdio.User)}"
+    assert release_vm_args() =~ "-user Elixir.XP#{inspect(Expert.Stdio.User)}"
   end
 
   # Debugging a `--port` server or a console needs Erlang's shell, which only exists if
@@ -116,18 +125,29 @@ defmodule Expert.Stdio.UserTest do
     File.write!(path, script)
     on_exit(fn -> File.rm(path) end)
 
-    erl_flags =
+    code_paths =
       [Mix.Project.build_path(), "lib", "*", "ebin"]
       |> Path.join()
       |> Path.wildcard()
       |> Enum.map_join(" ", &"-pa #{&1}")
-      |> Kernel.<>(" -user #{Atom.to_string(Expert.Stdio.User)}")
+
+    erl_flags =
+      [
+        code_paths,
+        release_standard_io_flags(),
+        "-user #{Atom.to_string(Expert.Stdio.User)}"
+      ]
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.join(" ")
 
     # `start/0` only reserves stdout when the stdio transport was asked for, so pass it
     # through the same way the release does.
     args = ["--erl", erl_flags, path] ++ if(opts[:stdio] == false, do: [], else: ["--stdio"])
 
     port_opts = [:binary, :exit_status]
+
+    port_opts =
+      if env = opts[:env], do: [{:env, env} | port_opts], else: port_opts
 
     port_opts =
       if opts[:stderr] == :merge, do: [:stderr_to_stdout | port_opts], else: port_opts
@@ -149,6 +169,18 @@ defmodule Expert.Stdio.UserTest do
 
   defp elixir, do: System.find_executable("elixir")
 
+  defp release_standard_io_flags do
+    release_vm_args()
+    |> String.split("\n")
+    |> Stream.map(&String.trim/1)
+    |> Stream.filter(&Regex.match?(~r/^-kernel[ \t]+standard_io_encoding(?:[ \t]+|$)/, &1))
+    |> Enum.join(" ")
+  end
+
+  defp release_vm_args do
+    __DIR__ |> Path.join("../../../rel/vm.args.eex") |> File.read!()
+  end
+
   defp collect(port, acc) do
     receive do
       {^port, {:data, data}} -> collect(port, acc <> data)
@@ -157,5 +189,35 @@ defmodule Expert.Stdio.UserTest do
     after
       30_000 -> flunk("child timed out, output so far:\n#{acc}")
     end
+  end
+
+  defp round_trip(bytes, tmp_dir) do
+    received_path = Path.join(tmp_dir, "stdio_roundtrip.bin")
+
+    run(
+      """
+      :ok = Expert.Stdio.User.subscribe()
+
+      expected = #{byte_size(bytes)}
+
+      gather = fn gather, acc ->
+        if byte_size(acc) >= expected do
+          acc
+        else
+          receive do
+            {:lsp_stdin, bytes} -> gather.(gather, acc <> bytes)
+          after
+            5_000 -> acc
+          end
+        end
+      end
+
+      File.write!(#{inspect(received_path)}, gather.(gather, ""))
+      """,
+      stdin: bytes,
+      env: [{~c"LANG", ~c"C"}, {~c"LC_ALL", ~c"C"}, {~c"LC_CTYPE", ~c"C"}]
+    )
+
+    File.read!(received_path)
   end
 end


### PR DESCRIPTION
After coming back from vacations and updating Expert, it greeted me with a persistent error crashing it on start:

```
11:43:38.078 instance_id=1A0144148B1 [error] GenServer XPExpert.Buffer terminating
** (XPJason.DecodeError) unexpected end of input at position 136839
    (xp_jason 1.4.5) lib/jason.ex:92: XPJason.decode!/2
    (xp_gen_lsp 0.11.3) lib/gen_lsp/buffer.ex:87: anonymous fn/3 in XPGenLSP.Buffer.handle_cast/2
    (xp_telemetry 1.4.2) src/telemetry.erl:359: :xp_telemetry.span/3
    (xp_gen_lsp 0.11.3) lib/gen_lsp/buffer.ex:85: XPGenLSP.Buffer.handle_cast/2
    (stdlib 7.3.0.1) gen_server.erl:2460: :gen_server.try_handle_cast/3
    (stdlib 7.3.0.1) gen_server.erl:2418: :gen_server.handle_msg/3
    (stdlib 7.3.0.1) proc_lib.erl:333: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:incoming, "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/didOpen\",\"params\":{\"textDocument\":{\"uri\":\"file:///Users/pawel.sw/jump/Jump/api/lib/jump_web/live/meetings_live.ex\",\"languageId\":\"elixir\",\"version\":1,\"text\":\"[truncated]]" <> ...}}
State: %{awaiting_response: %{1 => {#PID<0.197.0>, #Reference<0.3052531354.1266941954.132065>}}, comm_data: %{}, comm: XPExpert.Stdio.Adapter, lsp: #PID<0.197.0>}
```

This was probably because of some unicode after the changes made in #824. Not without some difficulties I forced Claude Code and Codex to get me a reproduction test which failed with:

```
1) test preserves multibyte characters split across stdin reads (Expert.Stdio.UserTest)
     test/expert/stdio/user_test.exs:97
     Assertion with == failed
     code:  assert byte_size(round_tripped) == byte_size(payload)
     left:  10001
     right: 5001
     stacktrace:
       test/expert/stdio/user_test.exs:103: (test)
```

Then it's a matter of changing default encoding in the VM args of the release. After these changes Expert starts correctly.