### PR TITLE
fix: index macro-generated definitions from compiler traces

### DIFF
--- a/apps/engine/lib/engine/build/project.ex
+++ b/apps/engine/lib/engine/build/project.ex
@@ -66,7 +66,7 @@ defmodule Engine.Build.Project do
     compile_fun = fn ->
       Mix.Task.clear()
       Progress.report(token, message: "Compiling #{Project.display_name(project)}")
-      result = compile_in_isolation()
+      result = compile_in_isolation(initial?)
       maybe_load_modules()
       Engine.Mix.ensure_hex_and_rebar()
       Mix.Task.run(:loadpaths)
@@ -105,10 +105,10 @@ defmodule Engine.Build.Project do
     end
   end
 
-  defp compile_in_isolation do
+  defp compile_in_isolation(initial?) do
     compile_fun = fn ->
       Engine.Mix.ensure_hex_and_rebar()
-      Mix.Task.run(:compile, mix_compile_opts())
+      Mix.Task.run(:compile, Build.State.mix_compile_opts(initial?))
     end
 
     case Isolation.invoke(compile_fun) do
@@ -149,21 +149,5 @@ defmodule Engine.Build.Project do
       Progress.report(token, message: "mix deps.compile")
       Mix.Task.run("deps.safe_compile", ~w(--skip-umbrella-children))
     end
-  end
-
-  defp mix_compile_opts do
-    # --no-prune-code-paths keeps mix from deleting the engine's own code
-    # paths during the project compile. It only applies to the top-level
-    # compile; dependencies each compile in their own project frame with
-    # pruning enabled, which is what isolates them from undeclared siblings.
-    ~w(
-        --return-errors
-        --ignore-module-conflict
-        --all-warnings
-        --docs
-        --debug-info
-        --no-protocol-consolidation
-        --no-prune-code-paths
-    )
   end
 end

--- a/apps/engine/lib/engine/build/state.ex
+++ b/apps/engine/lib/engine/build/state.ex
@@ -252,10 +252,11 @@ defmodule Engine.Build.State do
         --docs
         --debug-info
         --no-protocol-consolidation
+        --no-prune-code-paths
     )
 
     if initial? do
-      ["--force " | opts]
+      ["--force" | opts]
     else
       opts
     end

--- a/apps/engine/lib/engine/code_intelligence/definition.ex
+++ b/apps/engine/lib/engine/code_intelligence/definition.ex
@@ -253,6 +253,9 @@ defmodule Engine.CodeIntelligence.Definition do
     entries
     |> Stream.flat_map(fn entry ->
       case entry do
+        %Entry{metadata: %{via: :use, original_mfa: mfa}} ->
+          query_search_index(mfa, subtype: :definition)
+
         %Entry{
           type: {:function, :delegate},
           metadata: %{original_mfa: mfa}

--- a/apps/engine/lib/engine/compilation/trace_buffer.ex
+++ b/apps/engine/lib/engine/compilation/trace_buffer.ex
@@ -22,6 +22,19 @@ defmodule Engine.Compilation.TraceBuffer do
 
   def record_module(_path, _binary), do: :ok
 
+  def record_module(path, binary, module, definitions)
+      when is_binary(path) and is_binary(binary) and is_atom(module) and is_list(definitions) do
+    true =
+      :ets.insert(
+        @table,
+        {Forge.Path.native(path), binary, module, definitions}
+      )
+
+    :ok
+  end
+
+  def record_module(_path, _binary, _module, _definitions), do: :ok
+
   @impl GenServer
   def init(%__MODULE__{} = state) do
     _ = :ets.new(@table, [:named_table, :public, :duplicate_bag, write_concurrency: true])
@@ -59,6 +72,13 @@ defmodule Engine.Compilation.TraceBuffer do
 
   defp definitions_from_event({path, binary}) do
     case Beams.extract_definitions_from_binary(binary, path) do
+      {:ok, entries} -> entries
+      :error -> []
+    end
+  end
+
+  defp definitions_from_event({path, binary, module, definitions}) do
+    case Beams.extract_definitions_from_binary(binary, path, module, definitions) do
       {:ok, entries} -> entries
       :error -> []
     end

--- a/apps/engine/lib/engine/compilation/tracer.ex
+++ b/apps/engine/lib/engine/compilation/tracer.ex
@@ -7,7 +7,7 @@ defmodule Engine.Compilation.Tracer do
   alias Engine.Progress
 
   def trace({:on_module, module_binary, _filename}, %Macro.Env{} = env) do
-    maybe_record_module(env.file, module_binary)
+    maybe_record_module(env.file, module_binary, env.module)
     message = extract_module_updated(env.module, module_binary, env.file)
     maybe_report_progress(env.file)
     Engine.broadcast(message)
@@ -51,12 +51,22 @@ defmodule Engine.Compilation.Tracer do
     end
   end
 
-  defp maybe_record_module(file, module_binary)
-       when is_binary(file) and is_binary(module_binary) do
-    TraceBuffer.record_module(file, module_binary)
+  defp maybe_record_module(file, module_binary, module)
+       when is_binary(file) and is_binary(module_binary) and is_atom(module) do
+    definitions =
+      module
+      |> Module.definitions_in()
+      |> Enum.flat_map(fn definition ->
+        case Module.get_definition(module, definition, skip_clauses: true) do
+          {:v1, kind, metadata, []} -> [{definition, kind, metadata}]
+          _ -> []
+        end
+      end)
+
+    TraceBuffer.record_module(file, module_binary, module, definitions)
   end
 
-  defp maybe_record_module(_file, _module_binary), do: :ok
+  defp maybe_record_module(_file, _module_binary, _module), do: :ok
 
   defp progress_message(file) do
     relative_path_elements =

--- a/apps/engine/lib/engine/search/indexer/beams.ex
+++ b/apps/engine/lib/engine/search/indexer/beams.ex
@@ -37,6 +37,23 @@ defmodule Engine.Search.Indexer.Beams do
     end
   end
 
+  def extract_definitions_from_binary(beam, source_path, module, compiler_definitions)
+      when is_binary(beam) and is_binary(source_path) and is_atom(module) and
+             is_list(compiler_definitions) do
+    compiler_entries =
+      remote_context_definition_entries(
+        Forge.Path.native(source_path),
+        module,
+        compiler_definitions
+      )
+
+    case extract_definitions_from_binary(beam, source_path) do
+      {:ok, entries} -> {:ok, entries ++ compiler_entries}
+      :error when compiler_entries != [] -> {:ok, compiler_entries}
+      :error -> :error
+    end
+  end
+
   defp stat_beams(paths) do
     Enum.reduce(paths, {[], 0}, fn path, {beams, total_bytes} ->
       case File.stat(path) do
@@ -275,6 +292,7 @@ defmodule Engine.Search.Indexer.Beams do
   defp public_definition_entries(metadata, context) do
     definitions = Map.get(metadata, :definitions, [])
     protocol_callbacks = protocol_callbacks(metadata)
+    protocol_definition? = module_type(metadata) == {:protocol, :definition}
     delegate_specs = delegate_specs_from_metadata(metadata)
     default_wrappers = default_wrapper_identities(definitions)
 
@@ -284,6 +302,7 @@ defmodule Engine.Search.Indexer.Beams do
         &1,
         context,
         protocol_callbacks,
+        protocol_definition?,
         delegate_specs,
         default_wrappers
       )
@@ -294,6 +313,7 @@ defmodule Engine.Search.Indexer.Beams do
          {{name, arity}, definition, metadata, clauses},
          context,
          protocol_callbacks,
+         protocol_definition?,
          delegate_specs,
          default_wrappers
        )
@@ -311,11 +331,20 @@ defmodule Engine.Search.Indexer.Beams do
           arity,
           Keyword.get(metadata, :defaults, 0),
           metadata,
-          protocol_callbacks
+          protocol_callbacks,
+          protocol_definition?
         )
-        |> Enum.flat_map(
-          &public_definition_entries(context, name, &1, definition, metadata, delegate_specs)
-        )
+        |> Enum.flat_map(fn public_arity ->
+          public_definition_entries(
+            context,
+            name,
+            public_arity,
+            definition,
+            metadata,
+            delegate_specs,
+            MapSet.member?(protocol_callbacks, {name, public_arity})
+          )
+        end)
     end
   end
 
@@ -323,6 +352,7 @@ defmodule Engine.Search.Indexer.Beams do
          _definition,
          _context,
          _protocol_callbacks,
+         _protocol_definition?,
          _delegate_specs,
          _default_wrappers
        ),
@@ -368,28 +398,113 @@ defmodule Engine.Search.Indexer.Beams do
 
   defp default_wrapper_clause?(_clause, _definition, _name), do: false
 
-  defp public_definition_entries(context, name, arity, definition, metadata, delegate_specs) do
+  defp public_definition_entries(
+         context,
+         name,
+         arity,
+         definition,
+         metadata,
+         delegate_specs,
+         protocol_callback?
+       ) do
     case Map.get(delegate_specs, {name, arity}) do
       nil ->
-        [public_definition_entry(context, name, arity, definition, metadata)]
+        [
+          public_definition_entry(
+            context,
+            name,
+            arity,
+            definition,
+            metadata,
+            protocol_callback?
+          )
+        ]
 
       delegate_spec ->
         [delegate_definition_entry(context, name, arity, delegate_spec)]
     end
   end
 
-  defp public_definition_entry(context, name, arity, definition, metadata) do
+  defp public_definition_entry(
+         context,
+         name,
+         arity,
+         definition,
+         metadata,
+         protocol_callback?
+       ) do
     type = if definition == :def, do: {:function, :public}, else: {:macro, :public}
 
-    Entry.definition(
-      context.source_path,
-      context.root_block,
-      Subject.mfa(context.module, name, arity),
-      type,
-      definition_range(metadata, name),
-      context.app
-    )
+    entry =
+      Entry.definition(
+        context.source_path,
+        context.root_block,
+        Subject.mfa(context.module, name, arity),
+        type,
+        definition_range(metadata, name),
+        context.app
+      )
+
+    case Keyword.get(metadata, :context) do
+      macro_context
+      when is_atom(macro_context) and not is_nil(macro_context) and
+             macro_context != context.module and not protocol_callback? ->
+        Entry.put_metadata(entry, %{
+          original_mfa: Subject.mfa(macro_context, name, arity),
+          via: :use
+        })
+
+      _ ->
+        entry
+    end
   end
+
+  defp remote_context_definition_entries(source_path, module, compiler_definitions) do
+    context = %{
+      app: ApplicationCache.application(module),
+      module: module,
+      root_block: Block.root(),
+      source_path: source_path
+    }
+
+    compiler_definitions
+    |> Enum.flat_map(&remote_context_definition_entry(&1, context))
+    |> Enum.uniq_by(&{&1.subject, &1.type})
+  end
+
+  defp remote_context_definition_entry(
+         {{name, arity}, definition, metadata},
+         context
+       )
+       when is_atom(name) and is_integer(arity) and definition in [:def, :defmacro] and
+              is_list(metadata) do
+    with macro_context when is_atom(macro_context) and not is_nil(macro_context) <-
+           Keyword.get(metadata, :context),
+         true <- macro_context != context.module do
+      type = if definition == :def, do: {:function, :public}, else: {:macro, :public}
+
+      entry =
+        Entry.definition(
+          context.source_path,
+          context.root_block,
+          Subject.mfa(context.module, name, arity),
+          type,
+          definition_range(metadata, name),
+          context.app
+        )
+
+      [
+        Entry.put_metadata(entry, %{
+          original_mfa: Subject.mfa(macro_context, name, arity),
+          via: :use
+        })
+      ]
+    else
+      _ -> []
+    end
+  end
+
+  defp remote_context_definition_entry(_definition, _context), do: []
 
   defp delegate_definition_entry(context, name, arity, delegate_spec) do
     context.source_path
@@ -508,10 +623,17 @@ defmodule Engine.Search.Indexer.Beams do
     end)
   end
 
-  defp public_arities(name, arity, defaults, definition_metadata, protocol_callbacks) do
+  defp public_arities(
+         name,
+         arity,
+         defaults,
+         definition_metadata,
+         protocol_callbacks,
+         protocol_definition?
+       ) do
     arities = Enum.to_list((arity - defaults)..arity)
 
-    if Keyword.has_key?(definition_metadata, :context) do
+    if protocol_definition? and Keyword.has_key?(definition_metadata, :context) do
       Enum.filter(arities, &MapSet.member?(protocol_callbacks, {name, &1}))
     else
       arities

--- a/apps/engine/test/engine/build/state_test.exs
+++ b/apps/engine/test/engine/build/state_test.exs
@@ -92,6 +92,12 @@ defmodule Engine.Build.StateTest do
 
       assert Code.get_compiler_option(:parser_options) == [columns: true]
     end
+
+    test "forces Mix to recompile during a forced project build" do
+      assert "--force" in State.mix_compile_opts(true)
+      refute "--force" in State.mix_compile_opts(false)
+      assert "--no-prune-code-paths" in State.mix_compile_opts(true)
+    end
   end
 
   describe "throttled document compilation" do

--- a/apps/engine/test/engine/compilation/tracer_test.exs
+++ b/apps/engine/test/engine/compilation/tracer_test.exs
@@ -1,0 +1,114 @@
+defmodule Engine.Compilation.TracerTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Engine.Compilation.TraceBuffer
+  alias Engine.Compilation.Tracer
+  alias Forge.Formats
+  alias Forge.Search.Indexer.Entry
+
+  @moduletag :tmp_dir
+
+  setup do
+    start_supervised!(Engine.ApplicationCache)
+    start_supervised!(TraceBuffer)
+    patch(Engine, :broadcast, fn _message -> :ok end)
+    :ok = TraceBuffer.discard()
+    compiler_options = Code.compiler_options()
+
+    on_exit(fn ->
+      Code.compiler_options(compiler_options)
+    end)
+
+    :ok
+  end
+
+  test "records compiler-resolved definitions with foreign macro contexts", %{tmp_dir: tmp_dir} do
+    suffix = System.unique_integer([:positive])
+    provider = Module.concat(__MODULE__, :"Provider#{suffix}")
+    outer = Module.concat(__MODULE__, :"Outer#{suffix}")
+    enabled = Module.concat(__MODULE__, :"Enabled#{suffix}")
+    disabled = Module.concat(__MODULE__, :"Disabled#{suffix}")
+    path = Path.join(tmp_dir, "definitions.ex")
+
+    source = """
+    defmodule #{inspect(provider)} do
+      defmacro __using__(opts) do
+        name = Keyword.fetch!(opts, :name)
+        enabled? = Keyword.fetch!(opts, :enabled?)
+
+        quote do
+          if unquote(enabled?) do
+            def unquote(name)(argument), do: argument
+          end
+        end
+      end
+    end
+
+    defmodule #{inspect(outer)} do
+      defmacro __using__(opts) do
+        quote do
+          use #{inspect(provider)}, unquote(opts)
+        end
+      end
+    end
+
+    defmodule #{inspect(enabled)} do
+      use #{inspect(outer)}, name: :generated_name, enabled?: true
+    end
+
+    defmodule #{inspect(disabled)} do
+      use #{inspect(outer)}, name: :not_generated, enabled?: false
+    end
+    """
+
+    File.write!(path, source)
+    compiler_options = Code.compiler_options()
+    tracers = Access.get(compiler_options, :tracers, [])
+
+    Code.compiler_options(debug_info: true, tracers: Enum.uniq([Tracer | tracers]))
+
+    Code.compile_file(path)
+
+    native_path = Forge.Path.native(path)
+
+    assert {:ok, %{^native_path => entries}} = TraceBuffer.drain_definitions()
+
+    assert %Entry{
+             subject: generated_subject,
+             type: {:function, :public},
+             metadata: %{via: :use, original_mfa: original_mfa},
+             range: %{start: %{line: line}}
+           } =
+             Enum.find(entries, fn
+               %Entry{subject: subject, metadata: %{via: :use}} ->
+                 subject == Formats.mfa(enabled, :generated_name, 1)
+
+               _ ->
+                 false
+             end)
+
+    assert generated_subject == Formats.mfa(enabled, :generated_name, 1)
+    assert original_mfa == Formats.mfa(provider, :generated_name, 1)
+    assert line == source_line(source, "use #{inspect(outer)}, name: :generated_name")
+
+    refute Enum.any?(entries, fn entry ->
+             entry.subject == Formats.mfa(disabled, :not_generated, 1)
+           end)
+
+    refute Enum.any?(entries, fn
+             %Entry{metadata: %{original_mfa: original_mfa, via: :use}} ->
+               original_mfa == Formats.mfa(nil, :__using__, 1)
+
+             _ ->
+               false
+           end)
+  end
+
+  defp source_line(source, text) do
+    source
+    |> String.split("\n")
+    |> Enum.find_index(&String.contains?(&1, text))
+    |> Kernel.+(1)
+  end
+end

--- a/apps/expert/lib/expert/project/indexer.ex
+++ b/apps/expert/lib/expert/project/indexer.ex
@@ -174,14 +174,21 @@ defmodule Expert.Project.Indexer do
 
   defp apply_trace_definitions(%Project{} = project, trace_batch) when is_map(trace_batch) do
     with {:ok, current_entries} <- Search.Store.all(project, paths: Map.keys(trace_batch)) do
+      current_entries = Enum.reject(current_entries, &use_definition?/1)
       trace_entries = missing_trace_entries(current_entries, trace_batch)
 
-      case trace_entries do
-        [] -> :ok
-        [_ | _] -> Search.Store.apply_index_update(project, current_entries ++ trace_entries, [])
-      end
+      Search.Store.apply_index_update(
+        project,
+        current_entries ++ trace_entries,
+        Map.keys(trace_batch)
+      )
     end
   end
+
+  defp use_definition?(%{subtype: :definition, metadata: %{via: :use}}),
+    do: true
+
+  defp use_definition?(_entry), do: false
 
   defp missing_trace_entries(current_entries, trace_batch) do
     current_keys =

--- a/apps/expert/test/engine/code_intelligence/definition_test.exs
+++ b/apps/expert/test/engine/code_intelligence/definition_test.exs
@@ -8,6 +8,7 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
   import Forge.Test.RangeSupport
 
   alias Engine.Search
+  alias Engine.Search.Indexer.Beams
   alias Expert.EngineApi
   alias Expert.EngineNode
   alias Expert.EngineSupervisor
@@ -344,6 +345,51 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
                definition(project, subject_module, referenced_uri)
 
       assert definition_line == ~S[      def «hello_func_in_using»() do]
+    end
+
+    test "find the quoted definition injected into another module", %{
+      project: project,
+      uri: referenced_uri
+    } do
+      subject_module = ~q[
+        defmodule UsesInjectedDefinition do
+          def allowed?(user) do
+            MyDefinition.Capability.allowe|d?(user, :some_capability)
+          end
+        end
+      ]
+
+      assert {:ok, ^referenced_uri, definition_line} =
+               definition(project, subject_module, referenced_uri)
+
+      assert definition_line == ~S[      def «allowed?(_user, _capability)», do: true]
+    end
+
+    test "resolves a use-injected definition after a forced project compile", %{
+      project: project,
+      uri: referenced_uri
+    } do
+      EngineApi.register_listener(project, self(), [:all])
+      EngineApi.schedule_compile(project, true)
+      assert_receive project_compiled(), @project_compile_timeout
+      assert_receive project_index_ready(project: ^project), @project_index_timeout
+
+      code = ~q[
+        defmodule UsesInjectedDefinition do
+          def allowed?(user) do
+            MyDefinition.Capability.allowe|d?(user, :some_capability)
+          end
+        end
+      ]
+
+      {position, code} = pop_cursor(code)
+      {:ok, document} = subject_module(project, code)
+
+      assert {:ok, location} = EngineApi.definition(project, document, position)
+      assert location.document.uri == referenced_uri
+
+      assert decorate(location.document, location.range) ==
+               ~S[      def «allowed?(_user, _capability)», do: true]
     end
   end
 
@@ -718,13 +764,17 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
   end
 
   defp index(project, referenced_uris) when is_list(referenced_uris) do
-    entries = Enum.flat_map(referenced_uris, &do_index/1)
+    entries =
+      Enum.flat_map(referenced_uris, fn referenced_uri ->
+        source_entries = do_index(referenced_uri)
+        source_entries ++ compiler_use_entries(project, referenced_uri, source_entries)
+      end)
+
     Store.replace(project, entries)
   end
 
   defp index(project, referenced_uri) do
-    entries = do_index(referenced_uri)
-    Store.replace(project, entries)
+    index(project, [referenced_uri])
   end
 
   defp do_index(referenced_uri) do
@@ -733,5 +783,31 @@ defmodule Expert.Engine.CodeIntelligence.DefinitionTest do
            Search.Indexer.Source.index(document.path, Document.to_string(document)) do
       entries
     end
+  end
+
+  defp compiler_use_entries(project, referenced_uri, source_entries) do
+    source_path = Document.Path.ensure_path(referenced_uri)
+
+    beam_paths_by_name =
+      project
+      |> file_path(Path.join([".expert", "build", "**", "ebin", "*.beam"]))
+      |> Path.wildcard()
+      |> Enum.group_by(&Path.basename/1)
+
+    source_entries
+    |> Enum.filter(&(&1.type == :module and is_atom(&1.subject)))
+    |> Enum.flat_map(fn entry ->
+      beam_paths_by_name
+      |> Map.get("#{entry.subject}.beam", [])
+      |> Enum.flat_map(fn beam_path ->
+        with {:ok, binary} <- File.read(beam_path),
+             {:ok, entries} <- Beams.extract_definitions_from_binary(binary, source_path) do
+          Enum.filter(entries, &match?(%{metadata: %{via: :use}}, &1))
+        else
+          _ -> []
+        end
+      end)
+    end)
+    |> Enum.uniq_by(&{&1.subject, &1.type})
   end
 end

--- a/apps/expert/test/expert/project/indexer_test.exs
+++ b/apps/expert/test/expert/project/indexer_test.exs
@@ -304,6 +304,53 @@ defmodule Expert.Project.IndexerTest do
              Store.exact(project, ProjectIndexer.TraceOnly, [])
   end
 
+  test "compiler trace definitions replace stale use definitions", %{
+    project: project,
+    task_supervisor: task_supervisor
+  } do
+    path = "/use_definition.ex"
+
+    stale_entry =
+      [id: 1, subject: ProjectIndexer.Injected, path: path]
+      |> definition()
+      |> Entry.put_metadata(%{via: :use, original_mfa: "OldProvider.injected/0"})
+
+    compiler_entry =
+      [id: 2, subject: ProjectIndexer.Injected, path: path]
+      |> definition()
+      |> Entry.put_metadata(%{via: :use, original_mfa: "ActualProvider.injected/0"})
+
+    impossible_entry =
+      [id: 3, subject: ProjectIndexer.DisabledInjection, path: path]
+      |> definition()
+      |> Entry.put_metadata(%{via: :use, original_mfa: "Provider.disabled/0"})
+
+    patch(EngineApi, :call, fn ^project, Engine.Compilation.TraceBuffer, :drain_definitions, [] ->
+      {:ok, %{path => [compiler_entry]}}
+    end)
+
+    start_supervised!(
+      {Indexer,
+       [
+         project,
+         task_supervisor: task_supervisor,
+         create_index: fn ^project ->
+           {:ok, [stale_entry, impossible_entry], fn -> :ok end}
+         end,
+         update_index: fn ^project, _path_to_ids -> {:ok, [], [], fn -> :ok end} end
+       ]}
+    )
+
+    EngineApi.broadcast(project, project_compiled(project: project, status: :success))
+
+    assert_receive project_index_ready(project: ^project)
+
+    assert {:ok, [%Entry{metadata: %{original_mfa: "ActualProvider.injected/0"}}]} =
+             Store.exact(project, ProjectIndexer.Injected, [])
+
+    assert {:ok, []} = Store.exact(project, ProjectIndexer.DisabledInjection, [])
+  end
+
   defp definition(opts) do
     opts = Keyword.validate!(opts, [:id, :subject, path: "/file.ex"])
 

--- a/apps/forge/test/fixtures/navigations/lib/my_definition.ex
+++ b/apps/forge/test/fixtures/navigations/lib/my_definition.ex
@@ -29,3 +29,15 @@ defmodule MyDefinition do
     nil
   end
 end
+
+defmodule MyDefinition.AccessBehaviour do
+  defmacro __using__(_opts) do
+    quote do
+      def allowed?(_user, _capability), do: true
+    end
+  end
+end
+
+defmodule MyDefinition.Capability do
+  use MyDefinition.AccessBehaviour
+end


### PR DESCRIPTION
This is an attempt to solve #853 on the Expert side, leveraging compiler traces. In my tests it fixes the issue described in the linked ticket, however it works for go-to-definition but not for references (probably needs adjustments for reference queries; but I think it's a material for a different PR).